### PR TITLE
Status and headers not given to then/success

### DIFF
--- a/test/specs/axios.spec.js
+++ b/test/specs/axios.spec.js
@@ -101,6 +101,30 @@ describe('axios', function () {
       expect(request.method).toBe('get');
     });
 
+    it('should provide status', function () {
+      var status;
+      var finished = false;
+      var p = axios({
+        url: '/foo'
+      }).success(function (data, st) {
+        status = st;
+        finished = true;
+      });
+
+      var request = jasmine.Ajax.requests.mostRecent();
+      request.response({
+        status: 200,
+        responseText: '{"hello":"world"}'
+      });
+
+      waitsFor(function() {
+        return finished;
+      });
+      runs(function () {
+        expect(status).toBe(200);
+      });
+    });
+
     it('should accept headers', function () {
       axios({
         url: '/foo',


### PR DESCRIPTION
The [readme](https://github.com/mzabriskie/axios/tree/f2fd9f7dd3a644ddbd25b4bfe59c86313b24a443#response-api) mentions that promises resolve with multiple arguments giving the status code and response headers in addition to data, but most promises library do not handle multiple arguments.

I added a spec [to show it](https://travis-ci.org/mathbruyen/axios/builds/35427410), but I think it requires an API change to work, thus I did not look at solutions yet.

Any advice there?
