### PR TITLE
Handle UTF-8 multibyte sequences in node

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -14,10 +14,6 @@ module.exports = function httpAdapter(resolve, reject, config) {
     config.transformRequest
   );
 
-  if (utils.isArrayBuffer(data)) {
-    data = new Buffer(new Uint8Array(data));
-  }
-
   // Merge headers
   var headers = utils.merge(
     defaults.headers.common,
@@ -25,8 +21,15 @@ module.exports = function httpAdapter(resolve, reject, config) {
     config.headers || {}
   );
 
-  // Add Content-Length header if data exists
   if (data) {
+    if (utils.isArrayBuffer(data)) {
+      data = new Buffer(new Uint8Array(data));
+    } else if (utils.isString(data)) {
+      data = new Buffer(data, 'utf-8');
+    } else {
+      return reject(new Error('Data after transformation must be a string or an ArrayBuffer'));
+    }
+    // Add Content-Length header if data exists
     headers['Content-Length'] = data.length;
   }
 


### PR DESCRIPTION
Content-length header was set to the length of the string, which does not take into account multibyte sequences in UTF-8 strings. Now converts first to a buffer to get the proper length.
