### PR TITLE
Adding support for jsonp request

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Promise based HTTP client for the browser and node.js
 - Automatic transforms for JSON data
 - Client side support for protecting against [XSRF](http://en.wikipedia.org/wiki/Cross-site_request_forgery)
 - Specify HTTP request headers
+- JSONP support with [jsonp](https://github.com/webmodules/jsonp)
 
 ## Installing
 
@@ -43,7 +44,7 @@ axios.get('/user?ID=12345')
 	.catch(function (response) {
 		console.log(response);
 	});
-	
+
 // Optionally the request above could also be done as
 axios.get('/user', {
 		params: {
@@ -122,6 +123,7 @@ For convenience aliases have been provided for all supported request methods.
 ##### axios.get(url[, config])
 ##### axios.delete(url[, config])
 ##### axios.head(url[, config])
+##### axios.jsonp(url[, config])
 ##### axios.post(url[, data[, config]])
 ##### axios.put(url[, data[, config]])
 ##### axios.patch(url[, data[, config]])
@@ -144,53 +146,53 @@ This is the available config options for making requests. Only the `url` is requ
 {
 	// `url` is the server URL that will be used for the request
 	url: '/user',
-	
+
 	// `method` is the request method to be used when making the request
 	method: 'get', // default
-	
+
 	// `transformRequest` allows changes to the request data before it is sent to the server
 	// This is only applicable for request methods 'PUT', 'POST', and 'PATCH'
 	// The last function in the array must return a string or an ArrayBuffer
 	transformRequest: [function (data) {
 		// Do whatever you want to transform the data
-		
+
 		return data;
 	}],
-	
+
 	// `transformResponse` allows changes to the response data to be made before
 	// it is passed to the success/error handlers
 	transformResponse: [function (data) {
 		// Do whatever you want to transform the data
-		
+
 		return data;
 	}],
-	
+
 	// `headers` are custom headers to be sent
 	headers: {'X-Requested-With': 'XMLHttpRequest'},
-	
+
 	// `param` are the URL parameters to be sent with the request
 	params: {
 		ID: 12345
 	},
-	
+
 	// `data` is the data to be sent as the request body
 	// Only applicable for request methods 'PUT', 'POST', and 'PATCH'
 	// When no `transformRequest` is set, must be a string, an ArrayBuffer or a hash
 	data: {
 		firstName: 'Fred'
 	},
-	
+
 	// `withCredentials` indicates whether or not cross-site Access-Control requests
 	// should be made using credentials
 	withCredentials: false, // default
-	
+
 	// `responseType` indicates the type of data that the server will respond with
 	// options are 'arraybuffer', 'blob', 'document', 'json', 'text'
 	responseType: 'json', // default
-	
+
 	// `xsrfCookieName` is the name of the cookie to use as a value for xsrf token
 	xsrfCookieName: 'XSRF-TOKEN', // default
-	
+
 	// `xsrfHeaderName` is the name of the http header that carries the xsrf token value
 	xsrfHeaderName: 'X-XSRF-TOKEN' // default
 }
@@ -204,13 +206,13 @@ The response for a request contains the following information.
 {
 	// `data` is the response that was provided by the server
 	data: {},
-	
+
 	// `status` is the HTTP status code from the server response
 	status: 200,
-	
+
 	// `headers` the headers that the server responded with
 	headers: {},
-	
+
 	// `config` is the config that was provided to `axios` for the request
 	config: {}
 }

--- a/example/index.html
+++ b/example/index.html
@@ -54,6 +54,8 @@
   <body>
     <h1>People</h1>
     <ul id="people"></ul>
+    <h1>JSONP</h1>
+    <ul id="gravatar"></ul>
 
     <script src="../dist/axios.min.js"></script>
     <script>
@@ -77,6 +79,24 @@
         .error(function(data) {
           document.getElementById('people').innerHTML = '<li class="error">' + data + '</li>';
         });
+
+      axios.jsonp('https://secure.gravatar.com/21403b8b5f544512598fe92a6f62eb5d.json')
+        .success(function (data) {
+          var gravatar = data.entry.map(function (user) {
+            return (
+              '<li>' +
+                '<img src="' + user.thumbnailUrl + '"/>' +
+                '<strong>' + user.displayName + '</strong>' +
+                '<div>Profile: <a href="' + user.profileUrl + ' " target="_blank">' + user.profileUrl + '</a></div>' +
+              '</li>'
+            )
+          });
+
+          document.getElementById('gravatar').innerHTML = gravatar;
+        })
+        .error(function(data) {
+          document.getElementById('gravatar').innerHTML = '<li class="error">' + data + '</li>';
+        })
     </script>
   </body>
 </html>

--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -5,6 +5,7 @@ var cookies = require('./../helpers/cookies');
 var parseHeaders = require('./../helpers/parseHeaders');
 var transformData = require('./../helpers/transformData');
 var urlIsSameOrigin = require('./../helpers/urlIsSameOrigin');
+var jsonp = require('jsonp');
 
 module.exports = function xhrAdapter(resolve, reject, config) {
   // Transform request data
@@ -21,76 +22,88 @@ module.exports = function xhrAdapter(resolve, reject, config) {
     config.headers || {}
   );
 
-  // Create the request
-  var request = new(XMLHttpRequest || ActiveXObject)('Microsoft.XMLHTTP');
-  request.open(config.method, buildUrl(config.url, config.params), true);
+  if (config.method.toLowerCase() == 'jsonp') {
+    // TODO: deal with jsonp opts
+    var opts = {};
 
-  // Listen for ready state
-  request.onreadystatechange = function () {
-    if (request && request.readyState === 4) {
-      // Prepare the response
-      var headers = parseHeaders(request.getAllResponseHeaders());
-      var response = {
-        data: transformData(
-          request.responseText,
-          headers,
-          config.transformResponse
-        ),
-        status: request.status,
-        headers: headers,
-        config: config
-      };
+    jsonp(buildUrl(config.url, config.params), opts, function(err, data) {
+      if (err) return reject(err)
+      resolve(data)
+    });
 
-      // Resolve or reject the Promise based on the status
-      (request.status >= 200 && request.status < 300
-        ? resolve
-        : reject)(response);
+  } else {
+    // Create the request
+    var request = new(XMLHttpRequest || ActiveXObject)('Microsoft.XMLHTTP');
+    request.open(config.method, buildUrl(config.url, config.params), true);
 
-      // Clean up request
-      request = null;
+    // Listen for ready state
+    request.onreadystatechange = function () {
+      if (request && request.readyState === 4) {
+        // Prepare the response
+        var headers = parseHeaders(request.getAllResponseHeaders());
+        var response = {
+          data: transformData(
+            request.responseText,
+            headers,
+            config.transformResponse
+          ),
+          status: request.status,
+          headers: headers,
+          config: config
+        };
+
+        // Resolve or reject the Promise based on the status
+        (request.status >= 200 && request.status < 300
+          ? resolve
+          : reject)(response);
+
+        // Clean up request
+        request = null;
+      }
+    };
+
+    // Add xsrf header
+    var xsrfValue = urlIsSameOrigin(config.url)
+      ? cookies.read(config.xsrfCookieName || defaults.xsrfCookieName)
+      : undefined;
+    if (xsrfValue) {
+      headers[config.xsrfHeaderName || defaults.xsrfHeaderName] = xsrfValue;
     }
-  };
 
-  // Add xsrf header
-  var xsrfValue = urlIsSameOrigin(config.url)
-    ? cookies.read(config.xsrfCookieName || defaults.xsrfCookieName)
-    : undefined;
-  if (xsrfValue) {
-    headers[config.xsrfHeaderName || defaults.xsrfHeaderName] = xsrfValue;
-  }
+    // Add headers to the request
+    utils.forEach(headers, function (val, key) {
+      // Remove Content-Type if data is undefined
+      if (!data && key.toLowerCase() === 'content-type') {
+        delete headers[key];
+      }
+      // Otherwise add header to the request
+      else {
+        request.setRequestHeader(key, val);
+      }
+    });
 
-  // Add headers to the request
-  utils.forEach(headers, function (val, key) {
-    // Remove Content-Type if data is undefined
-    if (!data && key.toLowerCase() === 'content-type') {
-      delete headers[key];
+    // Add withCredentials to request if needed
+    if (config.withCredentials) {
+      request.withCredentials = true;
     }
-    // Otherwise add header to the request
-    else {
-      request.setRequestHeader(key, val);
-    }
-  });
 
-  // Add withCredentials to request if needed
-  if (config.withCredentials) {
-    request.withCredentials = true;
-  }
-
-  // Add responseType to request if needed
-  if (config.responseType) {
-    try {
-      request.responseType = config.responseType;
-    } catch (e) {
-      if (request.responseType !== 'json') {
-        throw e;
+    // Add responseType to request if needed
+    if (config.responseType) {
+      try {
+        request.responseType = config.responseType;
+      } catch (e) {
+        if (request.responseType !== 'json') {
+          throw e;
+        }
       }
     }
+
+    if (utils.isArrayBuffer(data)) {
+      data = new DataView(data);
+    }
+
+    // Send the request
+    request.send(data);
   }
 
-  if (utils.isArrayBuffer(data)) {
-    data = new DataView(data);
-  }
-
-  // Send the request
-  request.send(data);
 };

--- a/lib/axios.js
+++ b/lib/axios.js
@@ -31,6 +31,10 @@ var axios = module.exports = function axios(config) {
   // Provide alias for success
   promise.success = function success(fn) {
     promise.then(function(response) {
+
+      // jsonp only return the data object, just pass the data to callback function
+      if (!response.status) return fn(response)
+
       fn(response.data, response.status, response.headers, response.config);
     });
     return promise;
@@ -57,7 +61,7 @@ axios.all = function (promises) {
 axios.spread = require('./helpers/spread');
 
 // Provide aliases for supported request methods
-createShortMethods('delete', 'get', 'head');
+createShortMethods('delete', 'get', 'head', 'jsonp');
 createShortMethodsWithData('post', 'put', 'patch');
 
 function createShortMethods() {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   },
   "homepage": "https://github.com/mzabriskie/axios",
   "dependencies": {
-    "es6-promise": "^1.0.0"
+    "es6-promise": "^1.0.0",
+    "jsonp": "0.0.4"
   },
   "devDependencies": {
     "grunt": "^0.4.5",

--- a/test/specs/api.spec.js
+++ b/test/specs/api.spec.js
@@ -3,6 +3,7 @@ describe('api', function () {
     expect(typeof axios.get).toEqual('function');
     expect(typeof axios.head).toEqual('function');
     expect(typeof axios.delete).toEqual('function');
+    expect(typeof axios.jsonp).toEqual('function');
     expect(typeof axios.post).toEqual('function');
     expect(typeof axios.put).toEqual('function');
     expect(typeof axios.patch).toEqual('function');


### PR DESCRIPTION
Hi @mzabriskie 

I've used your module in my project, but sometimes I need support for jsonp request, and I find this module called [jsonp](https://github.com/webmodules/jsonp), it's very lightweight and does not have any dependencies, and it plays nicely in the browser, so I'm considering to add it to this module(as $http has this in angularjs).

I also checked the source code from [angularjs jsonpReq method](jsonpReq) but I think that is mixed up with angularjs stuff  so I don't want to use it.

I'm trying hard to follow your contributing guide as long as I can, and feel free to have me fix my code if you think there's any problem, thanks.
