### PR TITLE
Automatic Content-Type for FormData uploads

### DIFF
--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -21,6 +21,10 @@ module.exports = function xhrAdapter(resolve, reject, config) {
     config.headers || {}
   );
 
+  if (utils.isFormData(data)) {
+    delete headers['Content-Type']; // Let the browser set it
+  }
+
   // Create the request
   var request = new(XMLHttpRequest || ActiveXObject)('Microsoft.XMLHTTP');
   request.open(config.method, buildUrl(config.url, config.params), true);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -23,6 +23,16 @@ function isArrayBuffer(val) {
 }
 
 /**
+ * Determine if a value is a FormData
+ *
+ * @param {Object} val The value to test
+ * @returns {boolean} True if value is an FormData, otherwise false
+ */
+function isFormData(val) {
+  return toString.call(val) === '[object FormData]';
+}
+
+/**
  * Determine if a value is a view on an ArrayBuffer
  *
  * @param {Object} val The value to test
@@ -188,6 +198,7 @@ function merge(obj1/*, obj2, obj3, ...*/) {
 module.exports = {
   isArray: isArray,
   isArrayBuffer: isArrayBuffer,
+  isFormData: isFormData,
   isArrayBufferView: isArrayBufferView,
   isString: isString,
   isNumber: isNumber,


### PR DESCRIPTION
When data passed to axios is of type FormData we have to let the browser
create the Content-Type header so that the boundaries will get right
etc.

Usage:

``` js
var data = new FormData();
data.append('field', 'some string');
data.append('file', someFile);

var opts = {
  transformRequest: function(data) { return data; }
};

axios.post('/fileupload', data, opts);

```
