### PR TITLE
Fixing #385 - instance.defaults changes global object

### DIFF
--- a/lib/core/Axios.js
+++ b/lib/core/Axios.js
@@ -13,7 +13,7 @@ var combineURLs = require('./../helpers/combineURLs');
  * @param {Object} defaultConfig The default config for the instance
  */
 function Axios(defaultConfig) {
-  this.defaults = utils.merge(defaults, defaultConfig);
+  this.defaults = utils.merge(utils.cloneDeep(defaults), defaultConfig);
   this.interceptors = {
     request: new InterceptorManager(),
     response: new InterceptorManager()

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -245,8 +245,6 @@ function merge(/* obj1, obj2, obj3, ... */) {
   function assignValue(val, key) {
     if (typeof result[key] === 'object' && typeof val === 'object') {
       result[key] = merge(result[key], val);
-    } else if (key === 'headers') {
-      result[key] = JSON.parse(JSON.stringify(val));
     } else {
       result[key] = val;
     }
@@ -255,6 +253,46 @@ function merge(/* obj1, obj2, obj3, ... */) {
   for (var i = 0, l = arguments.length; i < l; i++) {
     forEach(arguments[i], assignValue);
   }
+  return result;
+}
+
+/**
+ * Creates a deep copy of the value which may contain (nested) Arrays and Objects.
+ *
+ * @param {Object} val The object or array to clone
+ * @return {Object} A new object or array
+ */
+function cloneDeep(val) {
+  /*eslint no-use-before-define:0*/
+  if (isArray(val)) {
+    return cloneDeepArray(val);
+  } else if (isObject(val)) {
+    return cloneDeepObject(val);
+  }
+  return val;
+}
+
+function cloneDeepObject(obj) {
+  var result = {};
+
+  function assignValue(val, key) {
+    result[key] = cloneDeep(val);
+  }
+
+  forEach(obj, assignValue);
+
+  return result;
+}
+
+function cloneDeepArray(arr) {
+  var result = [];
+
+  function assignValue(val) {
+    result.push(cloneDeep(val));
+  }
+
+  forEach(arr, assignValue);
+
   return result;
 }
 
@@ -295,6 +333,7 @@ module.exports = {
   isStandardBrowserEnv: isStandardBrowserEnv,
   forEach: forEach,
   merge: merge,
+  cloneDeep: cloneDeep,
   extend: extend,
   trim: trim
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var bind = require('./helpers/bind');
-
 /*global toString:true*/
 
 // utils is a library of generic helper functions non-specific to axios
@@ -246,6 +245,8 @@ function merge(/* obj1, obj2, obj3, ... */) {
   function assignValue(val, key) {
     if (typeof result[key] === 'object' && typeof val === 'object') {
       result[key] = merge(result[key], val);
+    } else if (key === 'headers') {
+      result[key] = JSON.parse(JSON.stringify(val));
     } else {
       result[key] = val;
     }

--- a/test/specs/instance.spec.js
+++ b/test/specs/instance.spec.js
@@ -68,6 +68,14 @@ describe('instance', function () {
     expect(typeof instance.defaults.headers.common, 'object');
   });
 
+  it('should not be affected by change to another instance defaults', function () {
+    var instance1 = axios.create();
+    var instance2 = axios.create();
+
+    instance1.defaults.headers.common['Authorization'] = 'askdjfaksdjf';
+    expect(instance2.defaults.headers.common['Authorization']).not.toContain('askdjfaksdjf');
+  });
+
   it('should have interceptors on the instance', function (done) {
     axios.interceptors.request.use(function (config) {
       config.foo = true;


### PR DESCRIPTION
This will fix the problem of instance's headers being overriding other instances' headers. 

According to https://github.com/mzabriskie/axios/issues/370 we want to have some kind of "whitelist" for keys we do want to deep clone. I went over `auth`, `transformRequest` etc. and did not find a similar problem.

I think that this solution is a hack, but it can temporarily fix this (urgent) issue. 

For long term I think we should reconsider this and maybe think of better approach here.

I understand If this approach (hack) is not acceptable, and I would love to discuss a solution and help fixing it!

This will fix #385 