### PR TITLE
Change http request method in Axios request method

### DIFF
--- a/lib/core/Axios.js
+++ b/lib/core/Axios.js
@@ -34,7 +34,7 @@ Axios.prototype.request = function request(config) {
     }, arguments[1]);
   }
 
-  config = utils.merge(defaults, this.defaults, { method: 'get' }, config);
+  config = utils.merge(defaults, { method: 'get' }, this.defaults, config);
 
   // Support baseURL config
   if (config.baseURL && !isAbsoluteURL(config.url)) {


### PR DESCRIPTION
Fixed a bug that used Axios' request method to use only "get" method unconditionally.