### PR TITLE
Pass agents to follow redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,11 +311,13 @@ These are the available config options for making requests. Only the `url` is re
   // If set to 0, no redirects will be followed.
   maxRedirects: 5, // default
 
-  // `httpAgent` and `httpsAgent` define a custom agent to be used when performing http
-  // and https requests, respectively, in node.js. This allows options to be added like
-  // `keepAlive` that are not enabled by default.
-  httpAgent: new http.Agent({ keepAlive: true }),
-  httpsAgent: new https.Agent({ keepAlive: true }),
+  // `agents` define custom agents to be used when performing http
+  // and https requests in node.js.
+  // This option allows features like keep alive requests.
+  agents: {
+    http: new http.Agent({ keepAlive: true }),
+    https: new https.Agent({ keepAlive: true })
+  },
 
   // 'proxy' defines the hostname and port of the proxy server
   // `auth` indicates that HTTP Basic auth should be used to connect to the proxy, and

--- a/index.d.ts
+++ b/index.d.ts
@@ -16,6 +16,11 @@ export interface AxiosProxyConfig {
   port: number;
 }
 
+export interface AxiosAgentsConfig {
+  http?: any,
+  https?: any
+}
+
 export interface AxiosRequestConfig {
   url?: string;
   method?: string;
@@ -38,8 +43,7 @@ export interface AxiosRequestConfig {
   maxContentLength?: number;
   validateStatus?: (status: number) => boolean;
   maxRedirects?: number;
-  httpAgent?: any;
-  httpsAgent?: any;
+  agents?: AxiosAgentsConfig,
   proxy?: AxiosProxyConfig;
   cancelToken?: CancelToken;
 }

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -71,7 +71,8 @@ module.exports = function httpAdapter(config) {
     }
 
     var isHttps = protocol === 'https:';
-    var agent = isHttps ? config.httpsAgent : config.httpAgent;
+    var protocolName = protocol.substr(0, protocol.length - 1);
+    var agent = config.agents && config.agents[protocolName];
 
     var options = {
       hostname: parsed.hostname,
@@ -79,8 +80,8 @@ module.exports = function httpAdapter(config) {
       path: buildURL(parsed.path, config.params, config.paramsSerializer).replace(/^\?/, ''),
       method: config.method,
       headers: headers,
-      agent: agent,
-      auth: auth
+      auth: auth,
+      agent: agent
     };
 
     var proxy = config.proxy;
@@ -124,6 +125,9 @@ module.exports = function httpAdapter(config) {
     } else {
       if (config.maxRedirects) {
         options.maxRedirects = config.maxRedirects;
+      }
+      if (config.agents) {
+        options.agents = config.agents;
       }
       transport = isHttps ? httpsFollow : httpFollow;
     }

--- a/test/unit/adapters/http.js
+++ b/test/unit/adapters/http.js
@@ -67,6 +67,29 @@ module.exports = {
     });
   },
 
+  testAgents: function (test) {
+    var data = {
+      firstName: 'Fred',
+      lastName: 'Flintstone',
+      emailAddr: 'fred@example.com'
+    };
+
+    server = http.createServer(function (req, res) {
+      res.setHeader('Content-Type', 'application/json;charset=utf-8');
+      res.end(JSON.stringify(data));
+    }).listen(4444, function () {
+      var httpAgent = new http.Agent();
+      axios.get('http://localhost:4444/', {
+        agents: {
+          http: httpAgent
+        }
+      }).then(function (res) {
+        test.equal(res.request.agent, httpAgent);
+        test.done();
+      });
+    });
+  },
+
   testRedirect: function (test) {
     var str = 'test response';
 
@@ -81,9 +104,15 @@ module.exports = {
         res.end(str);
       }
     }).listen(4444, function () {
-      axios.get('http://localhost:4444/one').then(function (res) {
+      var httpAgent = new http.Agent();
+      axios.get('http://localhost:4444/one', {
+        agents: {
+          http: httpAgent
+        }
+      }).then(function (res) {
         test.equal(res.data, str);
         test.equal(res.request.path, '/two');
+        test.equal(res.request.agent, httpAgent);
         test.done();
       });
     });


### PR DESCRIPTION
This PR transforms the httpAgent and httpsAgent options into a single agents option with http and https properties. It also passes them to the follow-redirects module so they can be used in case of redirections to different protocols.