### PR TITLE
Adds option to specify character set in responses (with http adapter)

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,10 @@ These are the available config options for making requests. Only the `url` is re
   // options are 'arraybuffer', 'blob', 'document', 'json', 'text', 'stream'
   responseType: 'json', // default
 
+  // `responseEncoding` indicates encoding to use for decoding responses
+  // Note: Ignored for `responseType` of 'stream' or client-side requests
+  responseEncoding: 'utf8', // default
+
   // `xsrfCookieName` is the name of the cookie to use as a value for xsrf token
   xsrfCookieName: 'XSRF-TOKEN', // default
 

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -185,7 +185,7 @@ module.exports = function httpAdapter(config) {
         stream.on('end', function handleStreamEnd() {
           var responseData = Buffer.concat(responseBuffer);
           if (config.responseType !== 'arraybuffer') {
-            responseData = responseData.toString('utf8');
+            responseData = responseData.toString(config.responseEncoding);
           }
 
           response.data = responseData;


### PR DESCRIPTION
We have a service that returns responses encoded with the ISO-8859-1 character set, and needed a way to decode these correctly. This change allows us to decode correctly in our server:

```javascript
axios.post('http://service-with-latin-encoding.com', {}, { charset: 'latin1' })
  .then(/* do something */);
```