### PR TITLE
Remove file: protocol check when response status is 0

### DIFF
--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -56,8 +56,9 @@ module.exports = function xhrAdapter(config) {
       // The request errored out and we didn't get a response, this will be
       // handled by onerror instead
       // With one exception: request that using file: protocol, most browsers
-      // will return status as 0 even though it's a successful request
-      if (typeof request.status !== 'number') {
+      // will return status as 0 even though it's a successful request, but the
+      // responseURL will be set
+      if (request.status === 0 && !request.responseURL) {
         return;
       }
 

--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -57,7 +57,7 @@ module.exports = function xhrAdapter(config) {
       // handled by onerror instead
       // With one exception: request that using file: protocol, most browsers
       // will return status as 0 even though it's a successful request
-      if (request.status === 0 && !(request.responseURL && request.responseURL.indexOf('file:') === 0)) {
+      if (request.status === 0) {
         return;
       }
 

--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -57,7 +57,7 @@ module.exports = function xhrAdapter(config) {
       // handled by onerror instead
       // With one exception: request that using file: protocol, most browsers
       // will return status as 0 even though it's a successful request
-      if (request.status === 0) {
+      if (typeof request.status !== 'number') {
         return;
       }
 

--- a/test/specs/requests.spec.js
+++ b/test/specs/requests.spec.js
@@ -79,6 +79,20 @@ describe('requests', function () {
       .then(finish, finish);
   });
 
+
+  it('should resolve status 0 when responseURL is set', function (done) {
+    axios('file://some/file.txt')
+      .then(done);
+
+    getAjaxRequest().then(function (request) {
+      expect(request.url).toBe('file://some/file.txt');
+      request.respondWith({
+        status: 0,
+        responseURL: 'file://some/file.txt'
+      });
+    });
+  });
+
   it('should reject when validateStatus returns false', function (done) {
     var resolveSpy = jasmine.createSpy('resolve');
     var rejectSpy = jasmine.createSpy('reject');


### PR DESCRIPTION
Fix for #945.

Edit: I've removed the check for the `file:` protocol. If `response.status` is 0, but the `responseURL` is truthy, it's considered okay.

~~I've added two tests:~~
~~1. A test for the `file:` protocol, as that wasn't there~~
~~2. A similar test for the `safari-extension:` protocol~~

~~I've also fixed a few ESLint errors.~~
