### PR TITLE
Fixing http adapter to allow HTTPS connections via HTTP

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -17,7 +17,8 @@ export interface AxiosProxyConfig {
   auth?: {
     username: string;
     password:string;
-  }
+  };
+  protocol?: string;
 }
 
 export interface AxiosRequestConfig {

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -13,6 +13,8 @@ var pkg = require('./../../package.json');
 var createError = require('../core/createError');
 var enhanceError = require('../core/enhanceError');
 
+var isHttps = /https:?/;
+
 /*eslint consistent-return:0*/
 module.exports = function httpAdapter(config) {
   return new Promise(function dispatchHttpRequest(resolve, reject) {
@@ -68,8 +70,8 @@ module.exports = function httpAdapter(config) {
       delete headers.Authorization;
     }
 
-    var isHttps = protocol === 'https:';
-    var agent = isHttps ? config.httpsAgent : config.httpAgent;
+    var isHttpsRequest = isHttps.test(protocol);
+    var agent = isHttpsRequest ? config.httpsAgent : config.httpAgent;
 
     var options = {
       hostname: parsed.hostname,
@@ -117,15 +119,16 @@ module.exports = function httpAdapter(config) {
     }
 
     var transport;
+    var isHttpsProxy = isHttpsRequest && (proxy ? isHttps.test(proxy.protocol) : true);
     if (config.transport) {
       transport = config.transport;
     } else if (config.maxRedirects === 0) {
-      transport = isHttps ? https : http;
+      transport = isHttpsProxy ? https : http;
     } else {
       if (config.maxRedirects) {
         options.maxRedirects = config.maxRedirects;
       }
-      transport = isHttps ? httpsFollow : httpFollow;
+      transport = isHttpsProxy ? httpsFollow : httpFollow;
     }
 
     // Create the request


### PR DESCRIPTION
## Summary 

We are using axios at [Contentful](https://contentful.com) for both our JS SDKs [contentful.js](https://github.com/contentful/contentful.js) and [contentful-management.js](https://github.com/contentful/contentful.js).

Axios was assuming always that the `proxy` protocol is the same as the URL it is requesting. This a problem when you use a `http` proxy when requesting data from `https` endpoint.
see more at https://github.com/mzabriskie/axios/issues/925 and https://github.com/mzabriskie/axios/issues/753

## Purpose of the PR
This PR make `httpAdapter` to allow https connections via http by introducing a new config param to the `proxy` object called `isHttps` which defaults to false

## TODO
- [ ] Add Integration test ?
- [ ] Add documentation
