### PR TITLE
Preserve order of request interceptors. Fixes #841

### DIFF
--- a/lib/core/Axios.js
+++ b/lib/core/Axios.js
@@ -36,12 +36,14 @@ Axios.prototype.request = function request(config) {
   config.method = config.method.toLowerCase();
 
   // Hook up interceptors middleware
-  var chain = [dispatchRequest, undefined];
+  var chain = [];
   var promise = Promise.resolve(config);
 
-  this.interceptors.request.forEach(function unshiftRequestInterceptors(interceptor) {
-    chain.unshift(interceptor.fulfilled, interceptor.rejected);
+  this.interceptors.request.forEach(function pushRequestInterceptors(interceptor) {
+    chain.push(interceptor.fulfilled, interceptor.rejected);
   });
+
+  chain.push(dispatchRequest, undefined);
 
   this.interceptors.response.forEach(function pushResponseInterceptors(interceptor) {
     chain.push(interceptor.fulfilled, interceptor.rejected);

--- a/test/specs/interceptors.spec.js
+++ b/test/specs/interceptors.spec.js
@@ -66,24 +66,22 @@ describe('interceptors', function () {
 
   it('should add multiple request interceptors', function (done) {
     axios.interceptors.request.use(function (config) {
-      config.headers.test1 = '1';
+      config.headers.test = '1';
       return config;
     });
     axios.interceptors.request.use(function (config) {
-      config.headers.test2 = '2';
+      config.headers.test += '2';
       return config;
     });
     axios.interceptors.request.use(function (config) {
-      config.headers.test3 = '3';
+      config.headers.test += '3';
       return config;
     });
 
     axios('/foo');
 
     getAjaxRequest().then(function (request) {
-      expect(request.requestHeaders.test1).toBe('1');
-      expect(request.requestHeaders.test2).toBe('2');
-      expect(request.requestHeaders.test3).toBe('3');
+      expect(request.requestHeaders.test).toBe('123');
       done();
     });
   });


### PR DESCRIPTION
Fixes: https://github.com/mzabriskie/axios/issues/841

Currently request interceptors are applied in reversed order. This PR fixes it and preserves their order.

Example:

```js
axios.interceptors.request.use(config => {
  console.log('First');
  return config;
});
axios.interceptors.request.use(config => {
  console.log('Second');
  return config;
});
```

Console before this PR:
```
> Second
> First
```

Console after this PR:
```
> First
> Second
```


**Note**: even though the order of request interceptors wasn't documented I think this is a breaking change and should be released with a new major version because for a quite long time people had to rely on this behavior in their projects.