### PR TITLE
Fix AxiosTransformer interface declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 export interface AxiosTransformer {
-  (data: any): any;
+  (data: any, headers: any): any;
 }
 
 export interface AxiosAdapter {


### PR DESCRIPTION
This will allow TypeScript users to use the `headers` argument given to a transformer callback.