### PR TITLE
get is forced upon all reqeusts by default, moved it to default options instead

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 export interface AxiosTransformer {
-  (data: any): any;
+  (data?: any, headers?: any): any;
 }
 
 export interface AxiosAdapter {

--- a/lib/core/Axios.js
+++ b/lib/core/Axios.js
@@ -32,7 +32,7 @@ Axios.prototype.request = function request(config) {
     }, arguments[1]);
   }
 
-  config = utils.merge(defaults, this.defaults, { method: 'get' }, config);
+  config = utils.merge(defaults, this.defaults, {}, config);
   config.method = config.method.toLowerCase();
 
   // Hook up interceptors middleware

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -64,7 +64,7 @@ var defaults = {
   }],
 
   method: 'get',
-  
+
   timeout: 0,
 
   xsrfCookieName: 'XSRF-TOKEN',

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -63,6 +63,8 @@ var defaults = {
     return data;
   }],
 
+  method: 'get',
+  
   timeout: 0,
 
   xsrfCookieName: 'XSRF-TOKEN',


### PR DESCRIPTION
when you perform
`axiosinstance.request()` 
,
[this line](https://github.com/mzabriskie/axios/blob/07a7b7c84c3ea82ea3f624330be9e0d3f738ac70/lib/core/Axios.js#L35):
 ` config = utils.merge(defaults, this.defaults, { method: 'get' }, config);`
is forcing the "get" method upon ALL requests by default, unless you explicitly call 
`axiosinstance.request({method:'post'})` 
even tho in axios.create you set it to post/put/etc.
so I just moved method: 'get' to [defaults](https://github.com/vasilevich/axios/blob/8e02f424732f869399975375c7242cdfb25ed7b4/lib/defaults.js#L66).
it should be in the defaults anyway, rather than [here](https://github.com/mzabriskie/axios/blob/07a7b7c84c3ea82ea3f624330be9e0d3f738ac70/lib/core/Axios.js#L35).

how to reproduce the problem:
```js
const axiosInstance = axios.create({
      baseURL: 'http://localhost',
      responseType: 'json',
       method: 'POST',
      withCredentials: true,
      validateStatus: function (status) {
        return status >= 200 && status < 300; // default
      },
    });
axiosInstance.request(); //the request will be 'GET' not 'POST'
axiosInstance.request({method:'POST'});  /the request will be 'POST' good.
```



