### PR TITLE
Update TypeScript typings with generic type parameters

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,7 @@ export interface AxiosTransformer {
 }
 
 export interface AxiosAdapter {
-  (config: AxiosRequestConfig): AxiosPromise;
+  (config: AxiosRequestConfig): AxiosPromise<any>;
 }
 
 export interface AxiosBasicCredentials {
@@ -44,8 +44,8 @@ export interface AxiosRequestConfig {
   cancelToken?: CancelToken;
 }
 
-export interface AxiosResponse {
-  data: any;
+export interface AxiosResponse<T = any>  {
+  data: T;
   status: number;
   statusText: string;
   headers: any;
@@ -59,7 +59,7 @@ export interface AxiosError extends Error {
   response?: AxiosResponse;
 }
 
-export interface AxiosPromise extends Promise<AxiosResponse> {
+export interface AxiosPromise<T = any> extends Promise<AxiosResponse<T>> {
 }
 
 export interface CancelStatic {
@@ -101,13 +101,13 @@ export interface AxiosInstance {
     request: AxiosInterceptorManager<AxiosRequestConfig>;
     response: AxiosInterceptorManager<AxiosResponse>;
   };
-  request(config: AxiosRequestConfig): AxiosPromise;
-  get(url: string, config?: AxiosRequestConfig): AxiosPromise;
+  request<T = any>(config: AxiosRequestConfig): AxiosPromise<T>;
+  get<T = any>(url: string, config?: AxiosRequestConfig): AxiosPromise<T>;
   delete(url: string, config?: AxiosRequestConfig): AxiosPromise;
   head(url: string, config?: AxiosRequestConfig): AxiosPromise;
-  post(url: string, data?: any, config?: AxiosRequestConfig): AxiosPromise;
-  put(url: string, data?: any, config?: AxiosRequestConfig): AxiosPromise;
-  patch(url: string, data?: any, config?: AxiosRequestConfig): AxiosPromise;
+  post<T = any>(url: string, data?: any, config?: AxiosRequestConfig): AxiosPromise<T>;
+  put<T = any>(url: string, data?: any, config?: AxiosRequestConfig): AxiosPromise<T>;
+  patch<T = any>(url: string, data?: any, config?: AxiosRequestConfig): AxiosPromise<T>;
 }
 
 export interface AxiosStatic extends AxiosInstance {

--- a/test/typescript/axios.ts
+++ b/test/typescript/axios.ts
@@ -97,6 +97,45 @@ axios.patch('/user', { foo: 'bar' })
   .then(handleResponse)
   .catch(handleError);
 
+// Typed methods
+interface User {
+  id: number;
+  name: string;
+}
+
+const handleUserResponse = (response: AxiosResponse<User>) => {
+	console.log(response.data.id);
+	console.log(response.data.name);
+	console.log(response.status);
+	console.log(response.statusText);
+	console.log(response.headers);
+	console.log(response.config);
+};
+
+axios.get<User>('/user?id=12345')
+	.then(handleUserResponse)
+	.catch(handleError);
+
+axios.get<User>('/user', { params: { id: 12345 } })
+	.then(handleUserResponse)
+	.catch(handleError);
+
+axios.post<User>('/user', { foo: 'bar' })
+	.then(handleUserResponse)
+	.catch(handleError);
+
+axios.post<User>('/user', { foo: 'bar' }, { headers: { 'X-FOO': 'bar' } })
+	.then(handleUserResponse)
+	.catch(handleError);
+
+axios.put<User>('/user', { foo: 'bar' })
+	.then(handleUserResponse)
+	.catch(handleError);
+
+axios.patch<User>('/user', { foo: 'bar' })
+	.then(handleUserResponse)
+	.catch(handleError);
+
 // Instances
 
 const instance1: AxiosInstance = axios.create();


### PR DESCRIPTION
This aims to fix #718.
I know there's already an effort to fix this in #730. However, this PR differs in a few ways:

- Rather than creating a new type that people would have to explicitly use in their variable declarations or as a cast, it adds an optional generic type parameter to `AxiosPromise` and `AxiosResponse` as well as `AxiosInstance.get` and similar methods. All instances of these new type parameters default to `any`, so backwards compatibility is ensured. If users want to add a type to the response data, they can do it using `get<MyType>(...)`, and if they don't, they just keep their code as is and it still works the same.
- It includes tests.