### PR TITLE
Avoid concatenating chunks to calculate their total lenght

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -165,11 +165,13 @@ module.exports = function httpAdapter(config) {
         settle(resolve, reject, response);
       } else {
         var responseBuffer = [];
+        var responseLength = 0;
         stream.on('data', function handleStreamData(chunk) {
           responseBuffer.push(chunk);
+          responseLength += chunk.length;
 
           // make sure the content length is not over the maxContentLength if specified
-          if (config.maxContentLength > -1 && Buffer.concat(responseBuffer).length > config.maxContentLength) {
+          if (config.maxContentLength > -1 && responseLength > config.maxContentLength) {
             reject(createError('maxContentLength size of ' + config.maxContentLength + ' exceeded',
               config, null, lastRequest));
           }
@@ -181,7 +183,7 @@ module.exports = function httpAdapter(config) {
         });
 
         stream.on('end', function handleStreamEnd() {
-          var responseData = Buffer.concat(responseBuffer);
+          var responseData = Buffer.concat(responseBuffer, responseLength);
           if (config.responseType !== 'arraybuffer') {
             responseData = responseData.toString('utf8');
           }


### PR DESCRIPTION
Currently the HTTP adapter to check that the _content length_ doesn't exceed the `maxContentLenght`, whenever a new chunk is received it performs a `Buffer.concat` on all the received chunks to calculate their total length.

The problem with this approach is that every `Buffer.concat` involves the creation of a _new Buffer_ of that _total length_ and also involves copying the content of each chunk into the newly created buffer
(see the [docs] and the actual [implementation][source]).

All this can be avoided at the cost of a local variable, and that's basically what this PR is all about!

[docs]: https://nodejs.org/dist/latest-v4.x/docs/api/buffer.html#buffer_class_method_buffer_concat_list_totallength
[source]: https://github.com/nodejs/node/blob/v4.x/lib/buffer.js#L278