### PR TITLE
Adding support for UNIX Sockets

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,10 @@ These are the available config options for making requests. Only the `url` is re
   // If set to 0, no redirects will be followed.
   maxRedirects: 5, // default
 
+  // `socketPath` defines a UNIX Socket to be used in node.js.
+  // e.g. '/var/run/docker.sock' to send requests to the docker daemon.
+  socketPath: null, // default
+
   // `httpAgent` and `httpsAgent` define a custom agent to be used when performing http
   // and https requests, respectively, in node.js. This allows options to be added like
   // `keepAlive` that are not enabled by default.

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -72,14 +72,19 @@ module.exports = function httpAdapter(config) {
     var agent = isHttps ? config.httpsAgent : config.httpAgent;
 
     var options = {
-      hostname: parsed.hostname,
-      port: parsed.port,
       path: buildURL(parsed.path, config.params, config.paramsSerializer).replace(/^\?/, ''),
       method: config.method,
       headers: headers,
       agent: agent,
       auth: auth
     };
+
+    if (config.socketPath) {
+      options.socketPath = config.socketPath;
+    } else {
+      options.hostname = parsed.hostname;
+      options.port = parsed.port;
+    }
 
     var proxy = config.proxy;
     if (!proxy && proxy !== false) {


### PR DESCRIPTION
Adds support for sending requests to a server running on a UNIX Socket (`.sock` files).
This will only work in Node.js with the http adapter.

Closes #975 