### PR TITLE
Allow overriding the used transport

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -117,7 +117,9 @@ module.exports = function httpAdapter(config) {
     }
 
     var transport;
-    if (config.maxRedirects === 0) {
+    if (config.transport) {
+      transport = config.transport;
+    } else if (config.maxRedirects === 0) {
       transport = isHttps ? https : http;
     } else {
       if (config.maxRedirects) {


### PR DESCRIPTION
This allows users of axios inside `electron` to provide the [`net`](https://electron.atom.io/docs/api/net/) module as the http transport instead of using nodes http/https modules.  This gives a whole bunch of things to Electron users including automatic proxy resolution.

> Create an issue explaining the feature.

Only saw this after making the change 😆 It's only a few lines so happy to discuss here 👍 