### PR TITLE
Improve node/browser detection

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -15,12 +15,12 @@ function setContentTypeIfUnset(headers, value) {
 
 function getDefaultAdapter() {
   var adapter;
-  if (typeof XMLHttpRequest !== 'undefined') {
-    // For browsers use XHR adapter
-    adapter = require('./adapters/xhr');
-  } else if (typeof process !== 'undefined') {
+  if (typeof process !== 'undefined') {
     // For node use HTTP adapter
     adapter = require('./adapters/http');
+  } else if (typeof XMLHttpRequest !== 'undefined') {
+    // For browsers use XHR adapter
+    adapter = require('./adapters/xhr');
   }
   return adapter;
 }


### PR DESCRIPTION
Thanks for sharing the `axios` project. It is a wonderful project, and a joy to use!

I was recently working on a project using `apisauce`, which in turn uses `axios`. Axios's Xhr/Http detection (node vs browser) was intermittently broken for me, which caused a lot of confusing "network error" problems, and took a while to isolate and understand, since I wasn't using `axios` directly. I was able to figure it out and fix it by forcing use of the Http adapter in my node app.

I know that there are a million ways to detect browser/node, and that none of them are perfect. I'm not looking to bikeshed. In my case, it would have been enough to reverse the order of the conditions to fix the problem. I think that this simple change will make detection a bit more reliable—there likely are a lot more node apps defining `XMLHttpRequest` here or there than browser apps defining `process(.versions.node)`, and no node app won't have `process` defined. Of course, I am biased! 😃

I am happy to make further changes and re-submit based on feedback, if you wish. I defer to your expertise on the matter. Thanks again for sharing! You are all doing a really great job!