### PR TITLE
Unzipping response body only for statuses != 204

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -142,7 +142,7 @@ module.exports = function httpAdapter(config) {
       case 'compress':
       case 'deflate':
         // add the unzipper to the body stream processing pipeline
-        stream = stream.pipe(zlib.createUnzip());
+        stream = (res.statusCode === 204) ? stream : stream.pipe(zlib.createUnzip());
 
         // remove the content-encoding in order to not confuse downstream operations
         delete res.headers['content-encoding'];


### PR DESCRIPTION
# Bugfix

When request has `Content-Encoding: gzip|deflate|compress` header and response has `204 No Content` status code the following error is thrown: `HttpClientError: unexpected end of file`.

This pull request fixes the issue by calling `stream = stream.pipe(zip.createUnzip())` for all status codes but 204.