### PR TITLE
Add request field to AxiosResponse type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -50,6 +50,7 @@ export interface AxiosResponse {
   statusText: string;
   headers: any;
   config: AxiosRequestConfig;
+  request?: any;
 }
 
 export interface AxiosError extends Error {


### PR DESCRIPTION
The `AxiosResponse` type definition is missing the `request` field. This same issue was fixed recently for `AxiosError`:

- Original Issue for `AxiosError`: https://github.com/axios/axios/issues/1014
- PR for `AxiosError`: https://github.com/axios/axios/pull/1015

I applied the same change to add the field to `AxiosResponse` (`request?: any`)