### PR TITLE
Adding axios-extensions to the ecosystem

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -15,3 +15,4 @@ This is a list of axios related libraries and resources. If you have a suggestio
 * [mocha-axios](https://github.com/jdrydn/mocha-axios) - Streamlined integration testing with Mocha & Axios
 * [axiosist](https://github.com/Gerhut/axiosist) - Axios based supertest: convert node.js request handler to axios adapter, used for node.js server unit test.
 * [axios-cache-plugin](https://github.com/jin5354/axios-cache-plugin) - Help you cache GET request when using axios.
+* [axios-extensions](https://github.com/kuitos/axios-extensions) - A collection of axios extensions, including throttle and cache GET request plugin.


### PR DESCRIPTION
Adding axios-extensions to the ecosystem which provides throttle and cache get request feature for axios.

btw, the [axios-cache-plugin](https://github.com/jin5354/axios-cache-plugin) in ecosystem doc was not implements with axios adapter mechanism, the fatal design error would make the interceptors and transformers power loss,  I don't know if it should be removed from the doc to avoid misleading the users of axios, but I will report this issue to the author at firest.