### PR TITLE
Adding better 'responseType' and 'method' type definitions by using a…

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -18,7 +18,7 @@ export interface AxiosProxyConfig {
 
 export interface AxiosRequestConfig {
   url?: string;
-  method?: string;
+  method?: 'get' | 'delete' | 'head' | 'options' | 'post' | 'put' | 'patch';
   baseURL?: string;
   transformRequest?: AxiosTransformer | AxiosTransformer[];
   transformResponse?: AxiosTransformer | AxiosTransformer[];
@@ -30,7 +30,7 @@ export interface AxiosRequestConfig {
   withCredentials?: boolean;
   adapter?: AxiosAdapter;
   auth?: AxiosBasicCredentials;
-  responseType?: string;
+  responseType?: 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream';
   xsrfCookieName?: string;
   xsrfHeaderName?: string;
   onUploadProgress?: (progressEvent: any) => void;


### PR DESCRIPTION
… string literal union type of possible values

The possible values for `responseType?: string` and `method?: string` are fixed, so using union type of string literals of the possible values improves the type safety for users of these properties.

I took the possible values from the docs.