### PR TITLE
[WIP] Fix transformResponse to transform accordingly to responseType

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -13,6 +13,12 @@ function setContentTypeIfUnset(headers, value) {
   }
 }
 
+function isJSONResponse(headers) {
+  return headers
+    && headers['Content-Type']
+    && headers['Content-Type'].indexOf('application/json') === -1;
+}
+
 function getDefaultAdapter() {
   var adapter;
   if (typeof XMLHttpRequest !== 'undefined') {
@@ -53,9 +59,10 @@ var defaults = {
     return data;
   }],
 
-  transformResponse: [function transformResponse(data) {
+  transformResponse: [function transformResponse(data, headers) {
+    normalizeHeaderName(headers, 'Content-Type');
     /*eslint no-param-reassign:0*/
-    if (typeof data === 'string') {
+    if (isJSONResponse(headers) && utils.isString(data)) {
       try {
         data = JSON.parse(data);
       } catch (e) { /* Ignore */ }


### PR DESCRIPTION
I started working to fix https://github.com/axios/axios/issues/811 and thought I should parse the response data based on the response content-type, but I'm having issues with the tests.

The tests are calling the raw `transformResponse` method without actually performing a request, so there is no way I can check the headers or the options.

I'm submitting this as a work in progress. I'm looking for some guidance on how we should approach the problem: should we check the responseType or the response content-type? should we change the test handling to pass either fake response headers or fake options?
