### PR TITLE
refactor: !isArray(obj) is always true

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -207,7 +207,7 @@ function forEach(obj, fn) {
   }
 
   // Force an array if not already something iterable
-  if (typeof obj !== 'object' && !isArray(obj)) {
+  if (typeof obj !== 'object') {
     /*eslint no-param-reassign:0*/
     obj = [obj];
   }


### PR DESCRIPTION
`typeof` of array is `object`, so if `typeof` of `obj` is not `object`, `obj` won't be array.