### PR TITLE
Move window defined check before window.XMLHttpRequest check

### DIFF
--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -24,9 +24,9 @@ module.exports = function xhrAdapter(config) {
     // For IE 8/9 CORS support
     // Only supports POST and GET calls and doesn't returns the response headers.
     // DON'T do this for testing b/c XMLHttpRequest is mocked, not XDomainRequest.
-    if (!window.XMLHttpRequest &&
-        process.env.NODE_ENV !== 'test' &&
+    if (process.env.NODE_ENV !== 'test' &&
         typeof window !== 'undefined' &&
+        !window.XMLHttpRequest &&
         window.XDomainRequest && !('withCredentials' in request) &&
         !isURLSameOrigin(config.url)) {
       request = new window.XDomainRequest();


### PR DESCRIPTION
There was an error being thrown due to the fact that we were checking for the `XMLHttpRequest` property on the `window` object before asserting that `window` was defined.

Buy moving the window defined check ahead of the `window.XMLHttpRequest` check, the error is eliminated!