### PR TITLE
security: upgrade follow-redirects

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   },
   "typings": "./index.d.ts",
   "dependencies": {
-    "follow-redirects": "^1.2.3",
+    "follow-redirects": "^1.2.5",
     "is-buffer": "^1.1.5"
   },
   "bundlesize": [


### PR DESCRIPTION
This would prevent tools like nsp to complain about a security issue from axios. It's something that got fixed in the package debug, and in order to benefit from that fix, it's necessary to upgrade to at least follow-redirects@1.2.5

This happens when updating axios version: npm won't upgrade the already installed version of follow-redirects. It doesn't affect fresh installs
