### PR TITLE
Ensure reasonable error message is given when headers value is not object

### DIFF
--- a/lib/helpers/normalizeHeaderName.js
+++ b/lib/helpers/normalizeHeaderName.js
@@ -4,6 +4,7 @@ var utils = require('../utils');
 
 module.exports = function normalizeHeaderName(headers, normalizedName) {
   utils.forEach(headers, function processHeader(value, name) {
+    if (!utils.isObject(headers)) throw new TypeError('expecting "headers" to be an object');
     if (name !== normalizedName && name.toUpperCase() === normalizedName.toUpperCase()) {
       headers[normalizedName] = value;
       delete headers[name];

--- a/test/specs/helpers/normalizeHeaderName.spec.js
+++ b/test/specs/helpers/normalizeHeaderName.spec.js
@@ -18,4 +18,10 @@ describe('helpers::normalizeHeaderName', function () {
     expect(headers['content-type']).toBe('foo/bar');
     expect(headers['Content-Length']).toBeUndefined();
   });
+
+  it('should not fail on name.toUpperCase when headers value ain\'t object', function () {
+    var headers = 'NotAnObject'
+    var normalizer = function () { normalizeHeaderName(headers, 'Content-Length'); };
+    expect(normalizer).toThrow(new TypeError('expecting "headers" to be an object'));
+  });
 });


### PR DESCRIPTION
No issue for this really but I prefer reasonable message from the client when I make a mistake like setting headers to a string instead of an object.
