### PR TITLE
Fixing interface of axios instance

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -118,8 +118,6 @@ export interface AxiosInstance {
 }
 
 export interface AxiosStatic extends AxiosInstance {
-  (config: AxiosRequestConfig): AxiosPromise;
-  (url: string, config?: AxiosRequestConfig): AxiosPromise;
   create(config?: AxiosRequestConfig): AxiosInstance;
   Cancel: CancelStatic;
   CancelToken: CancelTokenStatic;

--- a/index.d.ts
+++ b/index.d.ts
@@ -101,6 +101,8 @@ export interface AxiosInterceptorManager<V> {
 }
 
 export interface AxiosInstance {
+  (config: AxiosRequestConfig): AxiosPromise;
+  (url: string, config?: AxiosRequestConfig): AxiosPromise;
   defaults: AxiosRequestConfig;
   interceptors: {
     request: AxiosInterceptorManager<AxiosRequestConfig>;


### PR DESCRIPTION
Issue - 
- Axios instance returns a function which can be called directly, but the signature to call it is not provided in AxiosInstance interface.

Ex: 
let $http = axios.create({...});
$http({...}) //Gives error in typescript (Cannot invoke an expression whose type lacks a call signature. Type 'AxiosInstance' has no compatible call signatures.)

Fix -
- Added function signature in AxiosInstance interface