### PR TITLE
Updating the docs to use Promises. Fixes #1042

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,10 +101,10 @@ function getUserPermissions() {
   return axios.get('/user/12345/permissions');
 }
 
-axios.all([getUserAccount(), getUserPermissions()])
-  .then(axios.spread(function (acct, perms) {
+Promise.all([getUserAccount(), getUserPermissions()])
+  .then(function([acct, perms]) {
     // Both requests are now complete
-  }));
+  });
 ```
 
 ## axios API
@@ -160,12 +160,6 @@ For convenience aliases have been provided for all supported request methods.
 ###### NOTE
 When using the alias methods `url`, `method`, and `data` properties don't need to be specified in config.
 
-### Concurrency
-
-Helper functions for dealing with concurrent requests.
-
-##### axios.all(iterable)
-##### axios.spread(callback)
 
 ### Creating an instance
 


### PR DESCRIPTION
Upgraded to use native promises and destructuring on the arguments. The syntax is supported natively in the same situations as for the Promises. Follows the discussion in https://github.com/axios/axios/issues/1042