### PR TITLE
[TypeScript] fix Property 'then' does not exist on type 'AxiosInstance'.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -101,6 +101,8 @@ export interface AxiosInterceptorManager<V> {
 }
 
 export interface AxiosInstance {
+  (config: AxiosRequestConfig): AxiosPromise;
+  (url: string, config?: AxiosRequestConfig): AxiosPromise;
   defaults: AxiosRequestConfig;
   interceptors: {
     request: AxiosInterceptorManager<AxiosRequestConfig>;
@@ -116,8 +118,6 @@ export interface AxiosInstance {
 }
 
 export interface AxiosStatic extends AxiosInstance {
-  (config: AxiosRequestConfig): AxiosPromise;
-  (url: string, config?: AxiosRequestConfig): AxiosPromise;
   create(config?: AxiosRequestConfig): AxiosInstance;
   Cancel: CancelStatic;
   CancelToken: CancelTokenStatic;


### PR DESCRIPTION
Using typescript. Creating an AxiosInstance with axios::create(...) the returned object cannot be used like this: 

```javascript
import axios from "axios";

const axiosInstance = axios.create({
  baseURL: 'whatever.api',
  timeout: 1000,
  headers: {
    "Content-Type": "application/x-www-form-urlencoded"
    "stuff"..
  },
  withCredentials: true
});

axiosInstance({
   method: "post",
   url: "/resource"
}).then(res => console.log(res.data))
// err 
```
In javascript this is working perfectly but in typescript you get an error because of wrong typings. 

Typings specify that you can do `AxiosInstance.get().then` or `AxiosInstance.put().then` but doesn't allow you to do the same as with AxiosStatic and this isn't correct.

The error from TypeScript:
`Cannot invoke an expression whose type lacks a call signature. Type 'AxiosInstance' has no compatible call signatures.`

My fix properly sets function signatures to axiosInstance and then axiosstatic will extend those signatures as expected.

### Its sad that almost nobody uses typescript :(

Any comments appreciated