### PR TITLE
Fixing type definitions so AxiosInstance can be invoked

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -101,6 +101,8 @@ export interface AxiosInterceptorManager<V> {
 }
 
 export interface AxiosInstance {
+  (config: AxiosRequestConfig): AxiosPromise;
+  (url: string, config?: AxiosRequestConfig): AxiosPromise;
   defaults: AxiosRequestConfig;
   interceptors: {
     request: AxiosInterceptorManager<AxiosRequestConfig>;
@@ -116,8 +118,6 @@ export interface AxiosInstance {
 }
 
 export interface AxiosStatic extends AxiosInstance {
-  (config: AxiosRequestConfig): AxiosPromise;
-  (url: string, config?: AxiosRequestConfig): AxiosPromise;
   create(config?: AxiosRequestConfig): AxiosInstance;
   Cancel: CancelStatic;
   CancelToken: CancelTokenStatic;

--- a/test/typescript/axios.ts
+++ b/test/typescript/axios.ts
@@ -141,6 +141,10 @@ axios.patch<User>('/user', { foo: 'bar' })
 const instance1: AxiosInstance = axios.create();
 const instance2: AxiosInstance = axios.create(config);
 
+instance1(config)
+  .then(handleResponse)
+  .catch(handleError);
+
 instance1.request(config)
   .then(handleResponse)
   .catch(handleError);


### PR DESCRIPTION
Enables instances created using `axios.create` to be invoked, similar to the default module export.

```ts
const axios = require('axios')
const instance = axios.create(OPTIONS)

// This will now work in TypeScript
instance(CONFIG)
```

