### PR TITLE
Adding tests and maxBodyLength for PUT requests

### DIFF
--- a/test/unit/adapters/http.js
+++ b/test/unit/adapters/http.js
@@ -125,6 +125,44 @@ module.exports = {
     });
   },
 
+  testMaxContentLengthError: function (test) {
+    var data = {
+      firstName: 'Fred',
+      lastName: 'Flintstone',
+      emailAddr: 'fred@example.com'
+    };
+    var len = JSON.stringify(data).length
+
+    server = http.createServer(function (req, res) {
+      res.end();
+    }).listen(4444, function () {
+      axios.put('http://localhost:4444/', data, {
+        maxContentLength: len - 1
+      }).catch(function (error) {
+        test.done();
+      });
+    });
+  },
+
+  testMaxContentLengthSuccess: function (test) {
+    var data = {
+      firstName: 'Fred',
+      lastName: 'Flintstone',
+      emailAddr: 'fred@example.com'
+    };
+    var len = JSON.stringify(data).length
+
+    server = http.createServer(function (req, res) {
+      res.end();
+    }).listen(4444, function () {
+      axios.put('http://localhost:4444/', data, {
+        maxContentLength: len
+      }).then(function (res) {
+        test.done();
+      });
+    });
+  },
+
   testTransparentGunzip: function (test) {
     var data = {
       firstName: 'Fred',


### PR DESCRIPTION
Allow put requests to specify a config with maxBodyLength to override
the default (10 MB) limit on PUT requests to follow-request.

Corresponding commit and Issue in follow-request library:
https://github.com/olalonde/follow-redirects/commit/847a47fb00ea2dcb7a8886ca16d9d82dc6accb5d
https://github.com/olalonde/follow-redirects/issues/68
  