### PR TITLE
Fixing defaults to use httpAdapter if available

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -15,12 +15,12 @@ function setContentTypeIfUnset(headers, value) {
 
 function getDefaultAdapter() {
   var adapter;
-  if (typeof XMLHttpRequest !== 'undefined') {
-    // For browsers use XHR adapter
-    adapter = require('./adapters/xhr');
-  } else if (typeof process !== 'undefined') {
+  if (typeof process !== 'undefined' && process.env && typeof process.env.HOME === 'string') {
     // For node use HTTP adapter
     adapter = require('./adapters/http');
+  } else if (typeof XMLHttpRequest !== 'undefined') {
+    // For browsers use XHR adapter
+    adapter = require('./adapters/xhr');
   }
   return adapter;
 }


### PR DESCRIPTION
Default to the httpAdapter if process.env.HOME is a string (if we're in a Node environment).  This makes the httpAdapter the default in Electron or in a Node environment with an XMLHttpRequest polyfill.

Addresses https://github.com/axios/axios/issues/1284