### PR TITLE
Set maxBodyLength on follow-redirects to match maxContentLength on AxiosOptions

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -128,6 +128,10 @@ module.exports = function httpAdapter(config) {
       transport = isHttps ? httpsFollow : httpFollow;
     }
 
+    if (config.maxContentLength) {
+      options.maxBodyLength = config.maxContentLength;
+    }
+
     // Create the request
     var req = transport.request(options, function handleResponse(res) {
       if (req.aborted) return;

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -128,7 +128,7 @@ module.exports = function httpAdapter(config) {
       transport = isHttps ? httpsFollow : httpFollow;
     }
 
-    if (config.maxContentLength && maxBodyLength > -1) {
+    if (config.maxContentLength && config.maxContentLength > -1) {
       options.maxBodyLength = config.maxContentLength;
     }
 

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -128,7 +128,7 @@ module.exports = function httpAdapter(config) {
       transport = isHttps ? httpsFollow : httpFollow;
     }
 
-    if (config.maxContentLength) {
+    if (config.maxContentLength && maxBodyLength > -1) {
       options.maxBodyLength = config.maxContentLength;
     }
 


### PR DESCRIPTION
Set the `maxBodyLength` on the options sent to `follow-redirects` to match the `AxiosOptions` property `maxContentLength`, so `axios` can support content lengths greater than 10mb.

Addresses https://github.com/axios/axios/issues/1286