### PR TITLE
Case insensitive handling of headers

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -17,14 +17,14 @@ var enhanceError = require('../core/enhanceError');
 module.exports = function httpAdapter(config) {
   return new Promise(function dispatchHttpRequest(resolve, reject) {
     var data = config.data;
-    var headers = config.headers;
+    var headers = utils.toHeaders(config.headers);
     var timer;
 
     // Set User-Agent (required by some servers)
     // Only set header if it hasn't been set in config
     // See https://github.com/axios/axios/issues/69
-    if (!headers['User-Agent'] && !headers['user-agent']) {
-      headers['User-Agent'] = 'axios/' + pkg.version;
+    if (!headers.has('User-Agent')) {
+      headers.set('User-Agent', 'axios/' + pkg.version);
     }
 
     if (data && !utils.isStream(data)) {
@@ -42,7 +42,7 @@ module.exports = function httpAdapter(config) {
       }
 
       // Add Content-Length header if data exists
-      headers['Content-Length'] = data.length;
+      headers.set('Content-Length', data.length);
     }
 
     // HTTP basic authentication
@@ -65,7 +65,7 @@ module.exports = function httpAdapter(config) {
     }
 
     if (auth) {
-      delete headers.Authorization;
+      headers.unset('Authorization');
     }
 
     var isHttps = protocol === 'https:';
@@ -76,7 +76,6 @@ module.exports = function httpAdapter(config) {
       port: parsed.port,
       path: buildURL(parsed.path, config.params, config.paramsSerializer).replace(/^\?/, ''),
       method: config.method,
-      headers: headers,
       agent: agent,
       auth: auth
     };
@@ -105,14 +104,14 @@ module.exports = function httpAdapter(config) {
     if (proxy) {
       options.hostname = proxy.host;
       options.host = proxy.host;
-      options.headers.host = parsed.hostname + (parsed.port ? ':' + parsed.port : '');
+      headers.set('Host', parsed.hostname + (parsed.port ? ':' + parsed.port : ''));
       options.port = proxy.port;
       options.path = protocol + '//' + parsed.hostname + (parsed.port ? ':' + parsed.port : '') + options.path;
 
       // Basic proxy authorization
       if (proxy.auth) {
         var base64 = new Buffer(proxy.auth.username + ':' + proxy.auth.password, 'utf8').toString('base64');
-        options.headers['Proxy-Authorization'] = 'Basic ' + base64;
+        headers.set('Proxy-Authorization', 'Basic ' + base64);
       }
     }
 
@@ -127,6 +126,8 @@ module.exports = function httpAdapter(config) {
       }
       transport = isHttps ? httpsFollow : httpFollow;
     }
+
+    options.headers = headers.toJson();
 
     // Create the request
     var req = transport.request(options, function handleResponse(res) {

--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -11,10 +11,10 @@ var btoa = (typeof window !== 'undefined' && window.btoa && window.btoa.bind(win
 module.exports = function xhrAdapter(config) {
   return new Promise(function dispatchXhrRequest(resolve, reject) {
     var requestData = config.data;
-    var requestHeaders = config.headers;
+    var requestHeaders = utils.toHeaders(config.headers);
 
     if (utils.isFormData(requestData)) {
-      delete requestHeaders['Content-Type']; // Let the browser set it
+      requestHeaders.unset('Content-Type'); // Let the browser set it
     }
 
     var request = new XMLHttpRequest();
@@ -39,7 +39,7 @@ module.exports = function xhrAdapter(config) {
     if (config.auth) {
       var username = config.auth.username || '';
       var password = config.auth.password || '';
-      requestHeaders.Authorization = 'Basic ' + btoa(username + ':' + password);
+      requestHeaders.set('Authorization', 'Basic ' + btoa(username + ':' + password));
     }
 
     request.open(config.method.toUpperCase(), buildURL(config.url, config.params, config.paramsSerializer), true);
@@ -111,20 +111,19 @@ module.exports = function xhrAdapter(config) {
           undefined;
 
       if (xsrfValue) {
-        requestHeaders[config.xsrfHeaderName] = xsrfValue;
+        requestHeaders.set(config.xsrfHeaderName, xsrfValue);
       }
+    }
+
+    if (typeof requestData === 'undefined') {
+      // Remove Content-Type if data is undefined
+      requestHeaders.unset('Content-Type');
     }
 
     // Add headers to the request
     if ('setRequestHeader' in request) {
-      utils.forEach(requestHeaders, function setRequestHeader(val, key) {
-        if (typeof requestData === 'undefined' && key.toLowerCase() === 'content-type') {
-          // Remove Content-Type if data is undefined
-          delete requestHeaders[key];
-        } else {
-          // Otherwise add header to the request
-          request.setRequestHeader(key, val);
-        }
+      utils.forEach(requestHeaders.toJson(), function setRequestHeader(val, key) {
+        request.setRequestHeader(key, val);
       });
     }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,11 +3,13 @@
 var bind = require('./helpers/bind');
 var isBuffer = require('is-buffer');
 
-/*global toString:true*/
+/*global toString:true,hasOwnProperty:true*/
 
 // utils is a library of generic helper functions non-specific to axios
 
 var toString = Object.prototype.toString;
+
+var hasOwnProperty = Object.prototype.hasOwnProperty;
 
 /**
  * Determine if a value is an Array
@@ -220,7 +222,7 @@ function forEach(obj, fn) {
   } else {
     // Iterate over object keys
     for (var key in obj) {
-      if (Object.prototype.hasOwnProperty.call(obj, key)) {
+      if (hasOwnProperty.call(obj, key)) {
         fn.call(null, obj[key], key, obj);
       }
     }
@@ -245,18 +247,30 @@ function forEach(obj, fn) {
  * @returns {Object} Result of all merge properties
  */
 function merge(/* obj1, obj2, obj3, ... */) {
-  var result = {};
+  var values = {};
+  var names = {};
+
   function assignValue(val, key) {
-    if (typeof result[key] === 'object' && typeof val === 'object') {
-      result[key] = merge(result[key], val);
+    var propertyKey = key.toLowerCase();
+    if (typeof values[propertyKey] === 'object' && typeof val === 'object' && !isArray(values[propertyKey]) && !isArray(val)) {
+      values[propertyKey] = merge(values[propertyKey], val);
     } else {
-      result[key] = val;
+      values[propertyKey] = val;
+    }
+    if (!names[propertyKey]) {
+      names[propertyKey] = key;
     }
   }
 
   for (var i = 0, l = arguments.length; i < l; i++) {
     forEach(arguments[i], assignValue);
   }
+
+  var result = {};
+  forEach(values, function aggregate(val, key) {
+    result[names[key]] = val;
+  });
+
   return result;
 }
 
@@ -279,6 +293,93 @@ function extend(a, b, thisArg) {
   return a;
 }
 
+/**
+ * Class that provides case insensitive operations with headers
+ *
+ * @param {Object} headers original headers
+ * @constructor
+ */
+function Headers(headers) {
+  this.values = {};
+  this.names = {};
+  var self = this;
+
+  forEach(headers, function setAll(val, key) {
+    self.set(key, val);
+  });
+}
+
+/**
+ * Checks if header was already set to any value
+ *
+ * @param {String} name
+ * @returns {boolean} true if header is present
+ */
+Headers.prototype.has = function has(name) {
+  return hasOwnProperty.call(this.values, name.toLowerCase());
+};
+
+/**
+ * Returns header value by provided name
+ *
+ * @param {String} name header name
+ * @returns {String} header value
+ */
+Headers.prototype.get = function get(name) {
+  return this.values[name.toLowerCase()];
+};
+/**
+ * Sets header with name to specified value
+ *
+ * @param {String} name header name
+ * @param {String} value header value
+ */
+Headers.prototype.set = function set(name, value) {
+  var key = name.toLowerCase();
+  this.values[key] = value;
+  if (!hasOwnProperty.call(this.names, key)) {
+    this.names[key] = name;
+  }
+};
+
+/**
+ * Removes header with provided name
+ *
+ * @param {String} name
+ */
+Headers.prototype.unset = function unset(name) {
+  var key = name.toLowerCase();
+  delete this.values[key];
+  delete this.names[key];
+};
+
+/**
+ * Converts internal headers representation to plain Json object
+ * with header name as key and header value as value
+ *
+ * @returns {Object}
+ */
+Headers.prototype.toJson = function toJson() {
+  var result = {};
+  var self = this;
+
+  forEach(this.values, function aggregate(val, key) {
+    result[self.names[key]] = val;
+  });
+
+  return result;
+};
+
+/**
+ * Factory method that creates instance of Headers object
+ *
+ * @param {Object} headers original headers
+ * @returns {Headers}
+ */
+function toHeaders(headers) {
+  return new Headers(headers);
+}
+
 module.exports = {
   isArray: isArray,
   isArrayBuffer: isArrayBuffer,
@@ -299,5 +400,6 @@ module.exports = {
   forEach: forEach,
   merge: merge,
   extend: extend,
-  trim: trim
+  trim: trim,
+  toHeaders: toHeaders
 };

--- a/test/specs/headers.spec.js
+++ b/test/specs/headers.spec.js
@@ -1,20 +1,17 @@
 function testHeaderValue(headers, key, val) {
-  var found = false;
+  var found = 0;
 
   for (var k in headers) {
     if (k.toLowerCase() === key.toLowerCase()) {
-      found = true;
+      found += 1;
       expect(headers[k]).toEqual(val);
-      break;
     }
   }
 
-  if (!found) {
-    if (typeof val === 'undefined') {
-      expect(headers.hasOwnProperty(key)).toEqual(false);
-    } else {
-      throw new Error(key + ' was not found in headers');
-    }
+  if (typeof val === 'undefined') {
+    expect(found).toBe(0, 'header with name [' + key + '] must be absent');
+  } else {
+    expect(found).toBe(1, 'header with name [' + key + '] must be present only once');
   }
 }
 
@@ -53,6 +50,50 @@ describe('headers', function () {
           expect(request.requestHeaders[key]).toEqual(headers[key]);
         }
       }
+      done();
+    });
+  });
+
+  it('should ignore case when operating on header names', function (done) {
+    var axiosInstance = axios.create({
+      url: '/foo/bar',
+      headers: {
+        'test-Accept': 'text/plain, application/json'
+      }
+    });
+
+    axiosInstance({
+      headers: {
+        'Test-Accept': '*/*'
+      }
+    });
+
+    getAjaxRequest().then(function (request) {
+      // Non-compliant implementation of setRequestHeader will leave both headers
+      // Jasmine.Ajax is not following step 6 of https://xhr.spec.whatwg.org/#the-setrequestheader()-method
+      // https://github.com/jasmine/jasmine-ajax/blob/master/lib/mock-ajax.js
+      // compliant will combine them, but axios implementation should set header that was passed by user
+      // to desired value, in this case '*/*'
+      // This method will check that only one header was set using case insensitive comparison
+      testHeaderValue(request.requestHeaders, 'Test-Accept', '*/*');
+
+      done();
+    });
+  });
+
+  it('should use header values set by adapter and ignore case', function (done) {
+    axios('/foo/bar', {
+      auth: {
+        username: 'Aladdin',
+        password: 'open sesame'
+      },
+      headers: {
+        authorization: 'Bearer some-token'
+      }
+    });
+
+    getAjaxRequest().then(function (request) {
+      testHeaderValue(request.requestHeaders, 'Authorization', 'Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==');
       done();
     });
   });

--- a/test/specs/utils/merge.spec.js
+++ b/test/specs/utils/merge.spec.js
@@ -13,7 +13,7 @@ describe('utils::merge', function () {
     expect(typeof b.bar).toEqual('undefined');
     expect(typeof c.foo).toEqual('undefined');
   });
-  
+
   it('should merge properties', function () {
     var a = {foo: 123};
     var b = {bar: 456};
@@ -27,7 +27,7 @@ describe('utils::merge', function () {
   it('should merge recursively', function () {
     var a = {foo: {bar: 123}};
     var b = {foo: {baz: 456}, bar: {qux: 789}};
-    
+
     expect(merge(a, b)).toEqual({
       foo: {
         bar: 123,
@@ -38,5 +38,23 @@ describe('utils::merge', function () {
       }
     });
   });
-});
 
+  it('should ignore case when merging', function () {
+    var a = {FOO: 123};
+    var b = {bar: 456};
+    var c = {foo: 789};
+    var d = merge(a, b, c);
+
+    expect(d.FOO).toEqual(789);
+    expect(d.bar).toEqual(456);
+  });
+
+  it('should treat arrays as atomic value', function () {
+    var a = {foo: [1], bar: {}};
+    var b = {foo: {}, bar: [2]};
+    var c = merge(a, b);
+
+    expect(c.foo).toEqual({});
+    expect(c.bar).toEqual([2]);
+  });
+});

--- a/test/specs/utils/toHeaders.spec.js
+++ b/test/specs/utils/toHeaders.spec.js
@@ -1,0 +1,48 @@
+var toHeaders = require('../../../lib/utils').toHeaders;
+
+describe('utils::toHeaders', function () {
+  beforeEach(function () {
+    this.headers = toHeaders({
+      headerA: 'valueA',
+      headerB: 'valueB'
+    });
+  });
+
+  it('should transform JS hash to headers object', function () {
+    expect(this.headers.has('headerA')).toBeTruthy();
+    expect(this.headers.has('headerB')).toBeTruthy();
+  });
+
+  it('should ignore header name case', function () {
+    expect(this.headers.has('HEADERa')).toBeTruthy();
+  });
+
+  it('should support basic operations', function () {
+    expect(this.headers.has('header')).toBeFalsy();
+
+    this.headers.set('header', 'value');
+    expect(this.headers.has('header')).toBeTruthy();
+    expect(this.headers.get('header')).toBe('value');
+    expect(this.headers.toJson()).toEqual(jasmine.objectContaining({
+      header: 'value'
+    }));
+
+    this.headers.unset('header', 'value');
+    expect(this.headers.has('header')).toBeFalsy();
+  });
+
+  it('should use case from first header set', function () {
+    this.headers.set('HEader', 'value');
+    this.headers.set('header', 'new value');
+    expect(this.headers.toJson()).toEqual(jasmine.objectContaining({
+      HEader: 'new value'
+    }));
+
+    this.headers.unset('HEADER');
+    this.headers.set('header', 'value');
+    this.headers.set('HEader', 'new value');
+    expect(this.headers.toJson()).toEqual(jasmine.objectContaining({
+      header: 'new value'
+    }));
+  });
+});


### PR DESCRIPTION
Fixes #1237 

One breaking change was introduced to internal util merge method: it merges objects ignoring case of keys. This change is covered with tests to highlight new behaviour.

This was a trade-off to minimize impact on bundle size. Currently this method is used to merge configuration objects, so I don't see any issues with this change.