### PR TITLE
Fix utils.merge for objects with inheritance

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -228,6 +228,25 @@ function forEach(obj, fn) {
 }
 
 /**
+ * Extends object a by mutably adding to it the properties of object b.
+ *
+ * @param {Object} a The object to be extended
+ * @param {Object} b The object to copy properties from
+ * @param {Object} thisArg The object to bind function to
+ * @return {Object} The resulting value of object a
+ */
+function extend(a, b, thisArg) {
+  forEach(b, function assignValue(val, key) {
+    if (thisArg && typeof val === 'function') {
+      a[key] = bind(val, thisArg);
+    } else {
+      a[key] = val;
+    }
+  });
+  return a;
+}
+
+/**
  * Accepts varargs expecting each argument to be an object, then
  * immutably merges the properties of each object and returns result.
  *
@@ -248,7 +267,12 @@ function merge(/* obj1, obj2, obj3, ... */) {
   var result = {};
   function assignValue(val, key) {
     if (typeof result[key] === 'object' && typeof val === 'object') {
-      result[key] = merge(result[key], val);
+      // detect inheritance
+      if (Object.getPrototypeOf(val) instanceof Object) {
+        result[key] = extend(result[key], val);
+      } else {
+        result[key] = merge(result[key], val);
+      }
     } else {
       result[key] = val;
     }
@@ -258,25 +282,6 @@ function merge(/* obj1, obj2, obj3, ... */) {
     forEach(arguments[i], assignValue);
   }
   return result;
-}
-
-/**
- * Extends object a by mutably adding to it the properties of object b.
- *
- * @param {Object} a The object to be extended
- * @param {Object} b The object to copy properties from
- * @param {Object} thisArg The object to bind function to
- * @return {Object} The resulting value of object a
- */
-function extend(a, b, thisArg) {
-  forEach(b, function assignValue(val, key) {
-    if (thisArg && typeof val === 'function') {
-      a[key] = bind(val, thisArg);
-    } else {
-      a[key] = val;
-    }
-  });
-  return a;
 }
 
 module.exports = {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -228,25 +228,6 @@ function forEach(obj, fn) {
 }
 
 /**
- * Extends object a by mutably adding to it the properties of object b.
- *
- * @param {Object} a The object to be extended
- * @param {Object} b The object to copy properties from
- * @param {Object} thisArg The object to bind function to
- * @return {Object} The resulting value of object a
- */
-function extend(a, b, thisArg) {
-  forEach(b, function assignValue(val, key) {
-    if (thisArg && typeof val === 'function') {
-      a[key] = bind(val, thisArg);
-    } else {
-      a[key] = val;
-    }
-  });
-  return a;
-}
-
-/**
  * Accepts varargs expecting each argument to be an object, then
  * immutably merges the properties of each object and returns result.
  *
@@ -267,12 +248,7 @@ function merge(/* obj1, obj2, obj3, ... */) {
   var result = {};
   function assignValue(val, key) {
     if (typeof result[key] === 'object' && typeof val === 'object') {
-      // detect inheritance
-      if (Object.getPrototypeOf(val) instanceof Object) {
-        result[key] = extend(result[key], val);
-      } else {
-        result[key] = merge(result[key], val);
-      }
+      result[key] = merge(result[key], val);
     } else {
       result[key] = val;
     }
@@ -282,6 +258,25 @@ function merge(/* obj1, obj2, obj3, ... */) {
     forEach(arguments[i], assignValue);
   }
   return result;
+}
+
+/**
+ * Extends object a by mutably adding to it the properties of object b.
+ *
+ * @param {Object} a The object to be extended
+ * @param {Object} b The object to copy properties from
+ * @param {Object} thisArg The object to bind function to
+ * @return {Object} The resulting value of object a
+ */
+function extend(a, b, thisArg) {
+  forEach(b, function assignValue(val, key) {
+    if (thisArg && typeof val === 'function') {
+      a[key] = bind(val, thisArg);
+    } else {
+      a[key] = val;
+    }
+  });
+  return a;
 }
 
 module.exports = {

--- a/test/specs/utils/merge.spec.js
+++ b/test/specs/utils/merge.spec.js
@@ -13,7 +13,7 @@ describe('utils::merge', function () {
     expect(typeof b.bar).toEqual('undefined');
     expect(typeof c.foo).toEqual('undefined');
   });
-  
+
   it('should merge properties', function () {
     var a = {foo: 123};
     var b = {bar: 456};
@@ -27,7 +27,7 @@ describe('utils::merge', function () {
   it('should merge recursively', function () {
     var a = {foo: {bar: 123}};
     var b = {foo: {baz: 456}, bar: {qux: 789}};
-    
+
     expect(merge(a, b)).toEqual({
       foo: {
         bar: 123,
@@ -38,5 +38,24 @@ describe('utils::merge', function () {
       }
     });
   });
-});
 
+  it('should merge object with inheritance without erasing protype', function() {
+
+    function A() {}
+    A.prototype.method = function method() {
+    };
+
+    function B(foo) {
+      this.foo = foo;
+    }
+    B.prototype = A.prototype;
+
+    var a = { bar: new B(123) };
+    var b = { bar: new B(255) };
+
+    var c = merge(a, b);
+
+    expect(c.bar.foo).toEqual(255);
+    expect(c.bar.method).toBeDefined();
+  });
+});


### PR DESCRIPTION
This PR intent to fix this issue #1077.

Currently when you merge two objects inheriting from an parent object(class), the parent prototype is deleted during the merge process.

By `objects inheriting from an parent object` in mean prototype inheritance, this:

```javascript
const A = function A() {
}
A.prototype.method = function method() {};

const B = function B() {
}
B.prototype = A.prototype;
```

No this is what happen when we merge two objects containing an instance of `B`

```javascript
const a = {foo: new B()};
const b = {foo: new B();}

const c = merge(a, b);

c.foo.method; // undefined
b.method; // ƒ method() {}
``` 

To solve this I've updated `utils.merge` to use `utils.extend` when we try to merge two object with an inheritance chain.