### PR TITLE
Adding example of cancelling a POST request to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,6 +525,29 @@ axios.get('/user/12345', {
 source.cancel('Operation canceled by the user.');
 ```
 
+```js
+var CancelToken = axios.CancelToken;
+var source = CancelToken.source();
+
+axios(
+      method: 'POST',
+      url:    '/user/12345',
+      data: {
+        name: 'new name'
+      },
+      cancelToken: source.token
+}).catch(function(thrown) {
+  if (axios.isCancel(thrown)) {
+    console.log('Request canceled', thrown.message);
+  } else {
+    // handle error
+  }
+});
+
+// cancel the request (the message parameter is optional)
+source.cancel('Operation canceled by the user.');
+```
+
 You can also create a cancel token by passing an executor function to the `CancelToken` constructor:
 
 ```js


### PR DESCRIPTION
it seems when cancelling a post request we need to specify cancellation token as an axios parameter and not as a data item.

<!-- Click "Preview" for a more readable version -->

#### Instructions

Please read and follow the instructions before creating and submitting a pull request:

- Create an issue explaining the feature. It could save you some effort in case we don't consider it should be included in axios.
- If you're fixing a bug, try to commit the failing test/s and the code fixing it in different commits.
- Ensure you're following our [contributing guide](https://github.com/axios/axios/blob/master/CONTRIBUTING.md).

**⚠️👆 Delete the instructions before submitting the pull request 👆⚠️**

Describe your pull request here.
