### PR TITLE
Use Babel 7 & Webpack3 (via blocks)

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,9 @@
+{
+  "presets": [
+    ["@babel/preset-env", {
+      "targets": {
+        "node": "6.10"
+      }
+    }]
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ typings/
 coverage/
 test/typescript/axios.js*
 sauce_connect.log
+dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ email:
   on_failure: change
   on_success: never
 before_script:
+  - npm run build
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
   - sleep 3 # give xvfb some time to start

--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-module.exports = require('./lib/axios');
+module.exports = require('./dist/commonjs/axios');

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -9,9 +9,9 @@ var httpFollow = require('follow-redirects').http;
 var httpsFollow = require('follow-redirects').https;
 var url = require('url');
 var zlib = require('zlib');
-var pkg = require('./../../package.json');
 var createError = require('../core/createError');
 var enhanceError = require('../core/enhanceError');
+var pkginfo = require('pkginfo')(module);
 
 /*eslint consistent-return:0*/
 module.exports = function httpAdapter(config) {
@@ -24,7 +24,7 @@ module.exports = function httpAdapter(config) {
     // Only set header if it hasn't been set in config
     // See https://github.com/axios/axios/issues/69
     if (!headers['User-Agent'] && !headers['user-agent']) {
-      headers['User-Agent'] = 'axios/' + pkg.version;
+      headers['User-Agent'] = 'axios/' + pkginfo.version;
     }
 
     if (data && !utils.isStream(data)) {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,8 @@
   "typings": "./index.d.ts",
   "dependencies": {
     "follow-redirects": "^1.2.5",
-    "is-buffer": "^1.1.5"
+    "is-buffer": "^1.1.5",
+    "pkginfo": "^0.4.1"
   },
   "bundlesize": [
     {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,11 @@
   "scripts": {
     "test": "grunt test && bundlesize",
     "start": "node ./sandbox/server.js",
-    "build": "NODE_ENV=production grunt build",
+    "clean": "rimraf dist",
+    "cjs": "babel lib --out-dir dist/commonjs",
+    "browser": "NODE_ENV=production webpack",
+    "browser:dev": "webpack",
+    "build": "npm run clean && npm run cjs && npm run browser",
     "preversion": "npm test",
     "version": "npm run build && grunt version && git add -A dist && git add CHANGELOG.md bower.json package.json",
     "postversion": "git push && git push --tags",
@@ -31,6 +35,12 @@
   },
   "homepage": "https://github.com/axios/axios",
   "devDependencies": {
+    "@babel/core": "^7.0.0-beta.39",
+    "@babel/preset-env": "^7.0.0-beta.39",
+    "@webpack-blocks/babel": "^1.0.0-rc",
+    "@webpack-blocks/uglify": "^1.1.0",
+    "@webpack-blocks/webpack": "^1.0.0-rc",
+    "babel-cli": "^7.0.0-beta.3",
     "bundlesize": "^0.5.7",
     "coveralls": "^2.11.9",
     "es6-promise": "^4.0.5",
@@ -60,11 +70,11 @@
     "karma-webpack": "^1.7.0",
     "load-grunt-tasks": "^3.5.2",
     "minimist": "^1.2.0",
+    "rimraf": "^2.6.2",
     "sinon": "^1.17.4",
-    "webpack": "^1.13.1",
-    "webpack-dev-server": "^1.14.1",
     "url-search-params": "^0.6.1",
-    "typescript": "^2.0.3"
+    "webpack": "^3.10.0",
+    "webpack-dev-server": "^1.16.5"
   },
   "browser": {
     "./lib/adapters/http.js": "./lib/adapters/xhr.js"


### PR DESCRIPTION
Umbrella: #1333

- Gets Babel into play, so that ESM is working
- Upgrades Webpack to v3 and uses an abstraction layer that simplifies config creation.
