### PR TITLE
Finish adjustments to specs

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/commonjs/axios.js",
   "scripts": {
     "pretest": "npm run build",
-    "test": "npm run test:karma && npm run test:unit && npm run lint & bundlesize",
+    "test": "npm run test:karma && npm run test:unit && npm run lint && bundlesize",
     "test:karma": "NODE_ENV=test karma start --single-run",
     "test:unit": "jasmine test/unit/**/*.js",
     "start": "node ./sandbox/server.js",

--- a/test/specs/api.spec.js
+++ b/test/specs/api.spec.js
@@ -29,11 +29,6 @@ describe('static api', function () {
     expect(typeof axios.interceptors.response).toEqual('object')
   })
 
-  it('should have all/spread helpers', function () {
-    expect(typeof axios.all).toEqual('function')
-    expect(typeof axios.spread).toEqual('function')
-  })
-
   it('should have factory method', function () {
     expect(typeof axios.create).toEqual('function')
   })

--- a/test/specs/defaults.spec.js
+++ b/test/specs/defaults.spec.js
@@ -2,7 +2,7 @@
 
 import axios from '../../lib/axios'
 import defaults from '../../lib/defaults'
-import utils from '../../lib/utils'
+import { merge } from 'lodash'
 
 describe('defaults', function () {
   const XSRF_COOKIE_NAME = 'CUSTOM-XSRF-TOKEN'
@@ -128,7 +128,7 @@ describe('defaults', function () {
 
     getAjaxRequest().then(function (request) {
       expect(request.requestHeaders).toEqual(
-        utils.merge(defaults.headers.common, defaults.headers.get, {
+        merge({}, defaults.headers.common, defaults.headers.get, {
           'X-COMMON-HEADER': 'commonHeaderValue',
           'X-GET-HEADER': 'getHeaderValue',
           'X-FOO-HEADER': 'fooHeaderValue',

--- a/test/specs/helpers/buildURL.spec.js
+++ b/test/specs/helpers/buildURL.spec.js
@@ -1,6 +1,6 @@
 /* global sinon */
 import buildURL from '../../../lib/helpers/buildURL'
-import * as URLSearchParams from 'url-search-params'
+import URLSearchParams from 'url-search-params'
 
 describe('helpers::buildURL', function () {
   it('should support null params', function () {

--- a/test/specs/instance.spec.js
+++ b/test/specs/instance.spec.js
@@ -30,17 +30,6 @@ describe('instance', function () {
     }
   })
 
-  it('should make an http request without verb helper', function (done) {
-    const instance = axios.create()
-
-    instance('/foo')
-
-    getAjaxRequest().then(function (request) {
-      expect(request.url).toBe('/foo')
-      done()
-    })
-  })
-
   it('should make an http request', function (done) {
     const instance = axios.create()
 

--- a/test/specs/interceptors.spec.js
+++ b/test/specs/interceptors.spec.js
@@ -19,7 +19,7 @@ describe('interceptors', function () {
       return config
     })
 
-    axios('/foo')
+    axios.get('/foo')
 
     getAjaxRequest().then(function (request) {
       request.respondWith({
@@ -40,7 +40,7 @@ describe('interceptors', function () {
       }
     })
 
-    axios('/foo')
+    axios.get('/foo')
 
     getAjaxRequest().then(function (request) {
       expect(request.method).toBe('POST')
@@ -60,7 +60,7 @@ describe('interceptors', function () {
       })
     })
 
-    axios('/foo')
+    axios.get('/foo')
 
     getAjaxRequest().then(function (request) {
       expect(request.requestHeaders.async).toBe('promise')
@@ -82,7 +82,7 @@ describe('interceptors', function () {
       return config
     })
 
-    axios('/foo')
+    axios.get('/foo')
 
     getAjaxRequest().then(function (request) {
       expect(request.requestHeaders.test1).toBe('1')
@@ -100,7 +100,7 @@ describe('interceptors', function () {
       return data
     })
 
-    axios('/foo').then(function (data) {
+    axios.get('/foo').then(function (data) {
       response = data
     })
 
@@ -126,7 +126,7 @@ describe('interceptors', function () {
       }
     })
 
-    axios('/foo').then(function (data) {
+    axios.get('/foo').then(function (data) {
       response = data
     })
 
@@ -156,7 +156,7 @@ describe('interceptors', function () {
       })
     })
 
-    axios('/foo').then(function (data) {
+    axios.get('/foo').then(function (data) {
       response = data
     })
 
@@ -189,7 +189,7 @@ describe('interceptors', function () {
       return data
     })
 
-    axios('/foo').then(function (data) {
+    axios.get('/foo').then(function (data) {
       response = data
     })
 
@@ -224,7 +224,7 @@ describe('interceptors', function () {
 
     axios.interceptors.response.eject(intercept)
 
-    axios('/foo').then(function (data) {
+    axios.get('/foo').then(function (data) {
       response = data
     })
 

--- a/test/specs/promise.spec.js
+++ b/test/specs/promise.spec.js
@@ -33,41 +33,4 @@ describe('promise', function () {
       }, 100)
     })
   })
-
-  it('should support all', function (done) {
-    let fulfilled = false
-
-    axios.all([true, 123]).then(function () {
-      fulfilled = true
-    })
-
-    setTimeout(function () {
-      expect(fulfilled).toEqual(true)
-      done()
-    }, 100)
-  })
-
-  it('should support spread', function (done) {
-    let sum = 0
-    let fulfilled = false
-    let result
-
-    axios
-      .all([123, 456])
-      .then(axios.spread(function (a, b) {
-        sum = a + b
-        fulfilled = true
-        return 'hello world'
-      }))
-      .then(function (res) {
-        result = res
-      })
-
-    setTimeout(function () {
-      expect(fulfilled).toEqual(true)
-      expect(sum).toEqual(123 + 456)
-      expect(result).toEqual('hello world')
-      done()
-    }, 100)
-  })
 })

--- a/test/specs/requests.spec.js
+++ b/test/specs/requests.spec.js
@@ -11,18 +11,8 @@ describe('requests', function () {
     jasmine.Ajax.uninstall()
   })
 
-  it('should treat single string arg as url', function (done) {
-    axios('/foo')
-
-    getAjaxRequest().then(function (request) {
-      expect(request.url).toBe('/foo')
-      expect(request.method).toBe('GET')
-      done()
-    })
-  })
-
   it('should treat method value as lowercase string', function (done) {
-    axios({
+    axios.request({
       url: '/foo',
       method: 'POST'
     }).then(function (response) {
@@ -48,7 +38,7 @@ describe('requests', function () {
   })
 
   it('should make an http request', function (done) {
-    axios('/foo')
+    axios.get('/foo')
 
     getAjaxRequest().then(function (request) {
       expect(request.url).toBe('/foo')
@@ -78,7 +68,7 @@ describe('requests', function () {
       done()
     }
 
-    axios('http://thisisnotaserver/foo')
+    axios.get('http://thisisnotaserver/foo')
       .then(resolveSpy, rejectSpy)
       .then(finish, finish)
   })
@@ -87,7 +77,7 @@ describe('requests', function () {
     const resolveSpy = jasmine.createSpy('resolve')
     const rejectSpy = jasmine.createSpy('reject')
 
-    axios('/foo', {
+    axios.get('/foo', {
       validateStatus: function (status) {
         return status !== 500
       }
@@ -117,7 +107,7 @@ describe('requests', function () {
     const resolveSpy = jasmine.createSpy('resolve')
     const rejectSpy = jasmine.createSpy('reject')
 
-    axios('/foo', {
+    axios.get('/foo', {
       validateStatus: function (status) {
         return status === 500
       }
@@ -140,7 +130,7 @@ describe('requests', function () {
   it('should return JSON when rejecting', function (done) {
     let response
 
-    axios('/api/account/signup', {
+    axios.get('/api/account/signup', {
       username: null,
       password: null
     }, {
@@ -227,7 +217,7 @@ describe('requests', function () {
   it('should fix IE no content error', function (done) {
     let response
 
-    axios('/foo').then(function (res) {
+    axios.get('/foo').then(function (res) {
       response = res
     })
 
@@ -325,7 +315,7 @@ describe('requests', function () {
       return buff
     }
 
-    axios('/foo', {
+    axios.get('/foo', {
       responseType: 'arraybuffer'
     }).then(function (data) {
       response = data

--- a/test/specs/utils/isX.spec.js
+++ b/test/specs/utils/isX.spec.js
@@ -10,8 +10,6 @@ describe('utils::isX', function a () {
       return
     }
 
-    console.log('dis is da utils', utils)
-
     expect(utils.isArrayBufferView(new DataView(new ArrayBuffer(2)))).toEqual(true)
   })
 


### PR DESCRIPTION
Umbrella: #1333 

Some inconsistencies found their way into the first spec-adjusting PR.
Also with lodash now being in, we can replace the first `merge` which would lead to wrong behavior.

* `all` / `spread` won't be available anymore. Alternatives are `Promise.all` & destructuring an array parameter
 