### PR TITLE
Companion for #1286 and #1287 - also updating follow-redirects version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   },
   "typings": "./index.d.ts",
   "dependencies": {
-    "follow-redirects": "^1.2.5",
+    "follow-redirects": "^1.3.0",
     "is-buffer": "^1.1.5"
   },
   "bundlesize": [


### PR DESCRIPTION
Updating follow-redirects version in package.json to ensure that maxBodyLength option is supported, as noted in feedback for #1287