### PR TITLE
Follow up to #1070 - adding documentation and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,8 @@ These are the available config options for making requests. Only the `url` is re
 
   // `socketPath` defines a UNIX Socket to be used in node.js.
   // e.g. '/var/run/docker.sock' to send requests to the docker daemon.
+  // Only either `socketPath` or `proxy` can be specified.
+  // If both are specified, `socketPath` is used.
   socketPath: null, // default
 
   // `httpAgent` and `httpsAgent` define a custom agent to be used when performing http

--- a/test/unit/adapters/http.js
+++ b/test/unit/adapters/http.js
@@ -1,5 +1,6 @@
 var axios = require('../../../index');
 var http = require('http');
+var net = require('net');
 var url = require('url');
 var zlib = require('zlib');
 var fs = require('fs');
@@ -225,6 +226,24 @@ module.exports = {
         test.equal(error.message, 'maxContentLength size of 2000 exceeded');
         test.done();
       }, 100);
+    });
+  },
+
+  testSocket: function (test) {
+    server = net.createServer(function (socket) {
+      socket.on('data', function() {
+        socket.end('HTTP/1.1 200 OK\r\n\r\n');
+      });
+    }).listen('./test.sock', function() {
+      axios({
+        socketPath: './test.sock',
+        url: '/'
+      })
+      .then(function(resp) {
+        test.equal(resp.status, 200);
+        test.equal(resp.statusText, 'OK');
+        test.done();
+      });
     });
   },
 


### PR DESCRIPTION
Follow up to #1070 - adding documentation and tests:
- Adding information in README for socketPath when used with a proxy
- Adding an HTTP test for socketPath option