### PR TITLE
Simplifying redundant config merge.

### DIFF
--- a/lib/core/Axios.js
+++ b/lib/core/Axios.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var defaults = require('./../defaults');
 var utils = require('./../utils');
 var InterceptorManager = require('./InterceptorManager');
 var dispatchRequest = require('./dispatchRequest');
@@ -32,7 +31,7 @@ Axios.prototype.request = function request(config) {
     }, arguments[1]);
   }
 
-  config = utils.merge(defaults, {method: 'get'}, this.defaults, config);
+  config = utils.merge({ method: 'get' }, this.defaults, config);
   config.method = config.method.toLowerCase();
 
   // Hook up interceptors middleware


### PR DESCRIPTION
I noticed this when reviewing #1342/#723.

When Axios is configured either as an instance [here](https://github.com/axios/axios/blob/master/lib/axios.js#L35) or when used normally [here](https://github.com/axios/axios/blob/master/lib/axios.js#L28), `defaults` is already part of `this.defaults` and therefore, it's redundant to merge with defaults again in the instance `request` method. 

Can someone check this and confirm?
(@rubennorte you were involved in the original issue, this should be an easy one for you to check out).