### PR TITLE
- instance headers shouldn't mess with global common headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,7 +412,7 @@ var instance = axios.create({
 });
 
 // Alter defaults after instance has been created
-instance.defaults.headers.common['Authorization'] = AUTH_TOKEN;
+instance.defaults.headers['Authorization'] = AUTH_TOKEN;
 ```
 
 ### Config order of precedence


### PR DESCRIPTION
- we can set the instance headers on `defaults.headers` rather than `defaults.headers.common`

<!-- Click "Preview" for a more readable version -->

In the `ReadMe.md`, setting headers globally and setting headers of an instance refers to global common headers. I think we should change example code of setting headers in an instance to refer to `instance.defaults.headers` rather than `instance.defaults.headers.common`.  

The main problem is `instance.defaults.headers.common` and `axios.defaults.headers.common` refer to the same object, thereby making changes of common headers in one instance reflects in other instances as well as globally. There are multiple issues being reported because of this. 
