### PR TITLE
Do not pipe stream to gunzip with HEAD request.

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -152,8 +152,10 @@ module.exports = function httpAdapter(config) {
       case 'gzip':
       case 'compress':
       case 'deflate':
-        // add the unzipper to the body stream processing pipeline
-        stream = stream.pipe(zlib.createUnzip());
+        if (options.method !== 'head') {
+          // add the unzipper to the body stream processing pipeline
+          stream = stream.pipe(zlib.createUnzip());
+        }
 
         // remove the content-encoding in order to not confuse downstream operations
         delete res.headers['content-encoding'];

--- a/test/unit/adapters/http.js
+++ b/test/unit/adapters/http.js
@@ -148,6 +148,20 @@ module.exports = {
     });
   },
 
+  testTransparentGunzipSkipHead: function (test) {
+    server = http.createServer(function (req, res) {
+      res.setHeader('Content-Type', 'application/json;charset=utf-8');
+      res.setHeader('Content-Encoding', 'gzip');
+      res.end();
+    }).listen(4444, function () {
+      axios.head('http://localhost:4444/').then(function (res) {
+        test.done();
+      }).catch(function (err) {
+        test.done(err);
+      });
+    });
+  },
+
   testGunzipErrorHandling: function (test) {
     server = http.createServer(function (req, res) {
       res.setHeader('Content-Type', 'application/json;charset=utf-8');


### PR DESCRIPTION
The PR fixes the problem when the server responds a HEAD request with `Content-Encoding: gzip` set where there is no content being sent and Zlib will throw an exception complaining `unexpected end of file`.