### PR TITLE
Clone config defaults on axios.create

### DIFF
--- a/lib/axios.js
+++ b/lib/axios.js
@@ -32,17 +32,7 @@ axios.Axios = Axios;
 
 // Factory for creating new instances
 axios.create = function create(instanceConfig) {
-  function Clone(obj) {
-    for (var prop in obj) {
-      if (typeof obj[prop] === 'object') {
-        this[prop] = new Clone(obj[prop]);
-      } else {
-        this[prop] = obj[prop];
-      }
-    }
-  }
-
-  return createInstance(utils.merge(new Clone(defaults), instanceConfig));
+  return createInstance(utils.merge(new utils.Clone(defaults), instanceConfig));
 };
 
 // Expose Cancel & CancelToken

--- a/lib/axios.js
+++ b/lib/axios.js
@@ -32,7 +32,17 @@ axios.Axios = Axios;
 
 // Factory for creating new instances
 axios.create = function create(instanceConfig) {
-  return createInstance(utils.merge(defaults, instanceConfig));
+  function Clone(obj) {
+    for (var prop in obj) {
+      if (typeof obj[prop] === 'object') {
+        this[prop] = new Clone(obj[prop]);
+      } else {
+        this[prop] = obj[prop];
+      }
+    }
+  }
+
+  return createInstance(utils.merge(new Clone(defaults), instanceConfig));
 };
 
 // Expose Cancel & CancelToken

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -249,8 +249,6 @@ function merge(/* obj1, obj2, obj3, ... */) {
   function assignValue(val, key) {
     if (typeof result[key] === 'object' && typeof val === 'object') {
       result[key] = merge(result[key], val);
-    } else if (typeof val !== 'function' && !Array.isArray(val) && (!val instanceof Promise)) {
-      result[key] = JSON.parse(JSON.stringify(val));
     } else {
       result[key] = val;
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -189,8 +189,8 @@ function isStandardBrowserEnv() {
 }
 
 /**
- * Simulates pass-by-reference on an arbitrary Object by
- * recursing through each property and leveraging `new`.
+ * Simulates pass-by-value on an arbitrary Object by iterating
+ * through each property and recusrively invoking `new Clone`.
  *
  * Reference: https://stackoverflow.com/questions/7574054/javascript-how-to-pass-object-by-value
  *

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -249,6 +249,8 @@ function merge(/* obj1, obj2, obj3, ... */) {
   function assignValue(val, key) {
     if (typeof result[key] === 'object' && typeof val === 'object') {
       result[key] = merge(result[key], val);
+    } else if (key === 'headers') {
+      result[key] = JSON.parse(JSON.stringify(val));
     } else {
       result[key] = val;
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -189,6 +189,25 @@ function isStandardBrowserEnv() {
 }
 
 /**
+ * Simulates pass-by-reference on an arbitrary Object by
+ * recursing through each property and leveraging `new`.
+ *
+ * Reference: https://stackoverflow.com/questions/7574054/javascript-how-to-pass-object-by-value
+ *
+ * @param {Object|Array} obj The object to clone
+ * @returns {Object|Array} The cloned object.
+ */
+function Clone(obj) {
+  for (var prop in obj) {
+    if (typeof obj[prop] === 'object') {
+      this[prop] = new Clone(obj[prop]);
+    } else {
+      this[prop] = obj[prop];
+    }
+  }
+}
+
+/**
  * Iterate over an Array or an Object invoking a function for each item.
  *
  * If `obj` is an Array callback will be called passing
@@ -296,6 +315,7 @@ module.exports = {
   isStream: isStream,
   isURLSearchParams: isURLSearchParams,
   isStandardBrowserEnv: isStandardBrowserEnv,
+  Clone: Clone,
   forEach: forEach,
   merge: merge,
   extend: extend,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -249,7 +249,7 @@ function merge(/* obj1, obj2, obj3, ... */) {
   function assignValue(val, key) {
     if (typeof result[key] === 'object' && typeof val === 'object') {
       result[key] = merge(result[key], val);
-    } else if (key === 'headers') {
+    } else if (typeof val !== 'function' && !Array.isArray(val) && (!val instanceof Promise)) {
       result[key] = JSON.parse(JSON.stringify(val));
     } else {
       result[key] = val;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -190,7 +190,7 @@ function isStandardBrowserEnv() {
 
 /**
  * Simulates pass-by-value on an arbitrary Object by iterating
- * through each property and recusrively invoking `new Clone`.
+ * through each property and recursively invoking `new Clone`.
  *
  * Reference: https://stackoverflow.com/questions/7574054/javascript-how-to-pass-object-by-value
  *

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axios",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "Promise based HTTP client for the browser and node.js",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axios",
-  "version": "0.19.0",
+  "version": "0.18.0",
   "description": "Promise based HTTP client for the browser and node.js",
   "main": "index.js",
   "scripts": {

--- a/test/specs/options.spec.js
+++ b/test/specs/options.spec.js
@@ -81,4 +81,32 @@ describe('options', function () {
       done();
     });
   });
+
+  it('should change only the baseURL of the specified instance', function() {
+    var instance1 = axios.create();
+    var instance2 = axios.create();
+
+    instance1.defaults.baseURL = 'http://instance1.example.com/';
+
+    expect(instance2.defaults.baseURL).not.toBe('http://instance1.example.com/');
+  });
+
+  it('should change only the headers of the specified instance', function() {
+    var instance1 = axios.create();
+    var instance2 = axios.create();
+
+    instance1.defaults.headers.common.Authorization = 'faketoken';
+    instance2.defaults.headers.common.Authorization = 'differentfaketoken';
+
+    instance1.defaults.headers.common['Content-Type'] = 'application/xml';
+    instance2.defaults.headers.common['Content-Type'] = 'application/x-www-form-urlencoded';
+
+    expect(axios.defaults.headers.common.Authorization).toBe(undefined);
+    expect(instance1.defaults.headers.common.Authorization).toBe('faketoken');
+    expect(instance2.defaults.headers.common.Authorization).toBe('differentfaketoken');
+
+    expect(axios.defaults.headers.common['Content-Type']).toBe(undefined);
+    expect(instance1.defaults.headers.common['Content-Type']).toBe('application/xml');
+    expect(instance2.defaults.headers.common['Content-Type']).toBe('application/x-www-form-urlencoded');
+  });
 });


### PR DESCRIPTION
Addresses #385, #812, #1170, #1117, #1387, and more...

## Problem
* Setting `defaults.headers.common['YOUR HEADER HERE']` on a child instance of axios also sets the global instance's property.
* The same is true for any other object containing nested data, such as `auth` and `proxy`.

## Fix
* Create a perfect clone of the `defaults` object when creating a child instance of axios. [[1]](https://stackoverflow.com/questions/7574054/javascript-how-to-pass-object-by-value)

## Justification
* Minimal invasiveness to existing code.
* Passes existing tests and new tests provided by @emilyemorehouse and myself.

## Caveats
* This bug fix could break implementations that rely on changes to `defaults` applying to all existing axios instances.

PR source: [getethos/haxios](https://github.com/getethos/haxios)