### PR TITLE
Remove content-length header after unzip

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -157,6 +157,10 @@ module.exports = function httpAdapter(config) {
 
         // remove the content-encoding in order to not confuse downstream operations
         delete res.headers['content-encoding'];
+
+        if (res.headers['content-length']) {
+          delete res.headers['content-length'];
+        }
         break;
       }
 

--- a/test/unit/adapters/http.js
+++ b/test/unit/adapters/http.js
@@ -137,10 +137,12 @@ module.exports = {
       server = http.createServer(function (req, res) {
         res.setHeader('Content-Type', 'application/json;charset=utf-8');
         res.setHeader('Content-Encoding', 'gzip');
+        res.setHeader('Content-Length', Buffer.byteLength(zipped));
         res.end(zipped);
       }).listen(4444, function () {
         axios.get('http://localhost:4444/').then(function (res) {
           test.deepEqual(res.data, data);
+          test.equal('content-length' in res.headers, false);
           test.done();
         });
       });


### PR DESCRIPTION
After unzipping the stream content-length header is preserved and contains a wrong value. I suggest to delete it, if it exists, or have a flag to skip stream unzipping. There is no convenient way now to find out whether the original response was unzipped or not.

I used axios for a simple node proxy but I found out that some of the requests to the third party APIs are truncated due to content-length header being preserved after the stream was decoded, browsers ended the requests when they received the amount of bytes specified in the content-length which was smaller than after the decompression