### PR TITLE
Completely delete ejected interceptor handlers

### DIFF
--- a/lib/core/InterceptorManager.js
+++ b/lib/core/InterceptorManager.js
@@ -1,9 +1,8 @@
 'use strict';
 
-var utils = require('./../utils');
-
 function InterceptorManager() {
-  this.handlers = [];
+  this.handlers = {};
+  this.count = 0;
 }
 
 /**
@@ -15,11 +14,12 @@ function InterceptorManager() {
  * @return {Number} An ID used to remove interceptor later
  */
 InterceptorManager.prototype.use = function use(fulfilled, rejected) {
-  this.handlers.push({
+  this.handlers[this.count] = {
     fulfilled: fulfilled,
     rejected: rejected
-  });
-  return this.handlers.length - 1;
+  };
+  this.count++;
+  return this.count - 1;
 };
 
 /**
@@ -29,7 +29,7 @@ InterceptorManager.prototype.use = function use(fulfilled, rejected) {
  */
 InterceptorManager.prototype.eject = function eject(id) {
   if (this.handlers[id]) {
-    this.handlers[id] = null;
+    delete this.handlers[id];
   }
 };
 
@@ -42,11 +42,14 @@ InterceptorManager.prototype.eject = function eject(id) {
  * @param {Function} fn The function to call for each interceptor
  */
 InterceptorManager.prototype.forEach = function forEach(fn) {
-  utils.forEach(this.handlers, function forEachHandler(h) {
-    if (h !== null) {
-      fn(h);
+  var i;
+  var handler;
+  for (i = 0; i < this.count; i++) {
+    handler = this.handlers[i];
+    if (handler !== undefined) {
+      fn(handler);
     }
-  });
+  }
 };
 
 module.exports = InterceptorManager;

--- a/test/specs/interceptors.spec.js
+++ b/test/specs/interceptors.spec.js
@@ -5,8 +5,8 @@ describe('interceptors', function () {
 
   afterEach(function () {
     jasmine.Ajax.uninstall();
-    axios.interceptors.request.handlers = [];
-    axios.interceptors.response.handlers = [];
+    axios.interceptors.request.handlers = {};
+    axios.interceptors.response.handlers = {};
   });
 
   it('should add a request interceptor', function (done) {


### PR DESCRIPTION
[This issue](https://github.com/axios/axios/issues/1380) talks about the fact that the frequent use of interceptors.use and interceptors.reject can cause the creation of very big arrays as none of the handlers are deleted, but are simply replaced by null.

It looks like it could potentially cause memory problem.
In this fix, I replace the handlers array by a simple object. The API stays exactly the same but the interceptors handlers are now completely deleted. 