### PR TITLE
Updating xhr adapter to inherit withCredentials flag from the config

### DIFF
--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -141,8 +141,8 @@ module.exports = function xhrAdapter(config) {
     }
 
     // Add withCredentials to request if needed
-    if (config.withCredentials) {
-      request.withCredentials = true;
+    if (config.withCredentials !== undefined) {
+      request.withCredentials = config.withCredentials;
     }
 
     // Add responseType to request if needed

--- a/test/specs/xsrf.spec.js
+++ b/test/specs/xsrf.spec.js
@@ -75,6 +75,7 @@ describe('xsrf', function () {
     });
 
     getAjaxRequest().then(function (request) {
+      expect(request.withCredentials).toEqual(true);
       expect(request.requestHeaders[axios.defaults.xsrfHeaderName]).toEqual('12345');
       done();
     });


### PR DESCRIPTION
This change is necessary to allow updating withCredentials XHR flag in React Native environment where for historical reasons unlike on the web the default value is `true`.

Link to the web spec: https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/withCredentials

See the default being set to `true` in React Native here: https://github.com/facebook/react-native/blob/26684cf3adf4094eb6c405d345a75bf8c7c0bf88/Libraries/Network/XMLHttpRequest.js#L133

Prior this change we would only update withCredentials XHR flag if the config was set to `true`. This was preventing overriding the flag with `false` in React Native apps. Now we just pass through the config value as long as it is specified. This does not affect the default behaviour on web or React Native as if the flag wasn't set in the config we won't set it on XHR request either.

This also fixes #1101

