### PR TITLE
Fix type error when socketPath option in AxiosRequestConfig

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -42,6 +42,7 @@ export interface AxiosRequestConfig {
   maxContentLength?: number;
   validateStatus?: (status: number) => boolean;
   maxRedirects?: number;
+  socketPath?: string | null;
   httpAgent?: any;
   httpsAgent?: any;
   proxy?: AxiosProxyConfig | false;


### PR DESCRIPTION
This is a small issue which is `socketPath` has missing in interface AxiosRequestConfig. Because testing with unix socket is quite hard, I did no touch any specs and test files.