### PR TITLE
chore: ignore package-lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ typings/
 coverage/
 test/typescript/axios.js*
 sauce_connect.log
+package-lock.json


### PR DESCRIPTION
So `package-lock.json` is a funny thing.  It locks the exact version of npm dependencies down, ensuring that every build gets the same exact deps.

On the surface, this sounds great.  If you're an end-user building a web app, it's fantastic.  However, if you're a library author it's not so great.  When end users `npm install axios`, they're going to get the latest version of transitive dependencies in accordance to semver, ignoring what's actually in our package-lock.json.  This means that while things are locked down and cheery in this repository, end users may actually be getting errors. 

This is something we debated intensely at Google, and to be honest - there are good arguments for both.  Since there's currently no package-lock.json in this repo, I'm choosing to just go ahead and ignore it.  I'd love to hear others opinions!