### PR TITLE
docs: specify maxContentLength is in bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ These are the available config options for making requests. Only the `url` is re
     // Do whatever you want with the native progress event
   },
 
-  // `maxContentLength` defines the max size of the http response content allowed
+  // `maxContentLength` defines the max size of the http response content in bytes allowed
   maxContentLength: 2000,
 
   // `validateStatus` defines whether to resolve or reject the promise for a given


### PR DESCRIPTION
Super simple docs change to let folks know maxContentLength in the options is specified in bytes.  

Resolves #1431 