### PR TITLE
Correctly catch exception in http test

### DIFF
--- a/test/unit/adapters/http.js
+++ b/test/unit/adapters/http.js
@@ -243,6 +243,10 @@ module.exports = {
         test.equal(resp.status, 200);
         test.equal(resp.statusText, 'OK');
         test.done();
+      })
+      .catch(function (error) {
+        test.ifError(error);
+        test.done();
       });
     });
   },


### PR DESCRIPTION
From this (doesn't exit):

```bash
$ grunt nodeunit:all
Running "nodeunit:all" (nodeunit) task
Testing http.js...........(node:89954) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 6): Error: connect ENOENT ./wrong.sock
(node:89954) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

To this:

```bash
$ grunt nodeunit:all
Running "nodeunit:all" (nodeunit) task
Testing http.js...........F..........
>> testSocket
>> Error: connect ENOENT ./wrong.sock
>>   at Object._errnoException (util.js:1024:11)
>>   at _exceptionWithHostPort (util.js:1046:20)
>>   at PipeConnectWrap.afterConnect [as oncomplete] (net.js:1182:14)

Warning: 1/29 assertions failed (656ms) Use --force to continue.

Aborted due to warnings.
```

Test it locally by changing this line in test `testSocket` in file `test/unit/adapters/http.js`:

```js
socketPath: './test.sock',
// change to e.g.
socketPath: './wrong.sock',
```

Problems fixed:

- test would leave hanging in case of exception
- socket `test.sock` would never be closed -> subsequent runs would fail

Wanted to fix this after it caused trouble to figure out why a test was failing in [another PR](https://github.com/axios/axios/pull/1395).