### PR TITLE
clarify maxContentLength is not implemented for the browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ These are the available config options for making requests. Only the `url` is re
     // Do whatever you want with the native progress event
   },
 
-  // `maxContentLength` defines the max size of the http response content in bytes allowed
+  // `maxContentLength` defines the max size of the http response content in bytes allowed (works only in node, not in browser)
   maxContentLength: 2000,
 
   // `validateStatus` defines whether to resolve or reject the promise for a given


### PR DESCRIPTION
maxContentLength is only implemented in adapters/http.js and not in adapters/xhr.js so it does not work in the browser