### PR TITLE
implement maxContentLength in xhr

### DIFF
--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -167,7 +167,7 @@ module.exports = function xhrAdapter(config) {
     if (typeof config.onUploadProgress === 'function' && request.upload) {
       request.upload.addEventListener('progress', config.onUploadProgress);
     }
-    
+
     // Check maxContentLength if needed
     if (config.maxContentLength > 0) {
       request.addEventListener('progress', function checkMaxContentLength(event) {

--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -167,6 +167,21 @@ module.exports = function xhrAdapter(config) {
     if (typeof config.onUploadProgress === 'function' && request.upload) {
       request.upload.addEventListener('progress', config.onUploadProgress);
     }
+    
+    // Check maxContentLength if needed
+    if (config.maxContentLength > 0) {
+      request.addEventListener('progress', function checkMaxContentLength(event) {
+        // make sure the content length is not over the maxContentLength if specified
+        if (event.total && event.total > config.maxContentLength) {
+          reject(createError('maxContentLength size of ' + config.maxContentLength + ' exceeded',
+            config, null, request));
+        }
+        if (event.loaded > config.maxContentLength) {
+          reject(createError('maxContentLength size of ' + config.maxContentLength + ' exceeded',
+            config, null, request));
+        }
+      });
+    }
 
     if (config.cancelToken) {
       // Handle cancellation


### PR DESCRIPTION
maxcontentlength was only respected by adapters/http.js.
I added an implementation in adapters/xhr.js for the browser.