### PR TITLE
Fixing Axios.create() has no all & spread & Cancel & CancelToken & isCancel function

### DIFF
--- a/lib/axios.js
+++ b/lib/axios.js
@@ -22,6 +22,17 @@ function createInstance(defaultConfig) {
   // Copy context to instance
   utils.extend(instance, context);
 
+  // Expose Cancel & CancelToken & all/spread
+  utils.extend(instance, {
+    Cancel: require('./cancel/Cancel'),
+    CancelToken: require('./cancel/CancelToken'),
+    isCancel: require('./cancel/isCancel'),
+    all: function all(promises) {
+      return Promise.all(promises);
+    },
+    spread: require('./helpers/spread')
+  }, context);
+  
   return instance;
 }
 
@@ -35,17 +46,6 @@ axios.Axios = Axios;
 axios.create = function create(instanceConfig) {
   return createInstance(mergeConfig(axios.defaults, instanceConfig));
 };
-
-// Expose Cancel & CancelToken
-axios.Cancel = require('./cancel/Cancel');
-axios.CancelToken = require('./cancel/CancelToken');
-axios.isCancel = require('./cancel/isCancel');
-
-// Expose all/spread
-axios.all = function all(promises) {
-  return Promise.all(promises);
-};
-axios.spread = require('./helpers/spread');
 
 module.exports = axios;
 


### PR DESCRIPTION
## Instructions
Solve. After using the `axios.create()` function, can't use `all`、`spread`、`Cancel`、`CancelToken`、`isCancel`

### Before
```javascript
let newAxios = axios.create({
  baseURL: 'https://www.google.com.hk',
  timeout: 1000
})

newAxios.all() //  is not a function
newAxios.spread() //  is not a function
```

### Now
```javascript
let newAxios = axios.create({
  baseURL: 'https://www.google.com.hk',
  timeout: 1000
})

newAxios.all() //  It can be used normally
newAxios.spread() // It can be used normally
```