### PR TITLE
Fixing maxContentLength config not working for exceeded content-length response

### DIFF
--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -49,7 +49,20 @@ module.exports = function xhrAdapter(config) {
 
     // Listen for ready state
     request[loadEvent] = function handleLoad() {
-      if (!request || (request.readyState !== 4 && !xDomain)) {
+      if (!request) {
+        return;
+      }
+
+      if (request.readyState === this.HEADERS_RECEIVED && config.maxContentLength > -1 &&
+        request.getResponseHeader('Content-Length') > config.maxContentLength) {
+        reject(createError('maxContentLength size of ' + config.maxContentLength + ' exceeded',
+          config, 'ECONNABORTED', request));
+        request.abort();
+        request = null;
+        return;
+      }
+
+      if (request.readyState !== 4 && !xDomain) {
         return;
       }
 

--- a/test/specs/adapter.spec.js
+++ b/test/specs/adapter.spec.js
@@ -1,6 +1,14 @@
 var axios = require('../../index');
 
 describe('adapter', function () {
+  beforeEach(function () {
+    jasmine.Ajax.install();
+  });
+
+  afterEach(function () {
+    jasmine.Ajax.uninstall();
+  });
+
   it('should support custom adapter', function (done) {
     var called = false;
 
@@ -14,6 +22,28 @@ describe('adapter', function () {
       expect(called).toBe(true);
       done();
     }, 100);
+  });
+
+  it('should throw maxContentLength is exceed error', function(done) {
+    var testMaxContentLength = 10
+    axios.get('/foo', {maxContentLength: testMaxContentLength})
+      .then(function() {
+        fail('Ajax call should not success when the response is over maxContentLength.');
+        done();
+      })
+      .catch(function(err) {
+        expect(err.message).toBe(`maxContentLength size of ${testMaxContentLength} exceeded`);
+        done();
+      });
+    getAjaxRequest().then(function (request) {
+      request.respondWith({
+        status: 200,
+        responseText: 'OK',
+        responseHeaders: {
+          'Content-Length': testMaxContentLength + 1
+        }
+      });
+    });
   });
 });
 


### PR DESCRIPTION
Fixing #1491 (maxContentLength config not working for exceeded content-length response) by checking Content-Length of the response header before downloading the full content.