### PR TITLE
update readme, for post cancel

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,8 +546,7 @@ axios.get('/user/12345', {
 });
 
 axios.post('/user/12345', {
-  name: 'new name'
-}, {
+  name: 'new name',
   cancelToken: source.token
 })
 


### PR DESCRIPTION
It was not woking for me to have the cancelToken in a separate object in the third input param, when cancelling a post rest call.

Instead it works like a charm to add the cancelToken attribute to the object of the second input param.
