### PR TITLE
Allow setting of content-type

### DIFF
--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -130,13 +130,7 @@ module.exports = function xhrAdapter(config) {
     // Add headers to the request
     if ('setRequestHeader' in request) {
       utils.forEach(requestHeaders, function setRequestHeader(val, key) {
-        if (typeof requestData === 'undefined' && key.toLowerCase() === 'content-type') {
-          // Remove Content-Type if data is undefined
-          delete requestHeaders[key];
-        } else {
-          // Otherwise add header to the request
-          request.setRequestHeader(key, val);
-        }
+        request.setRequestHeader(key, val);
       });
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "axios",
-  "version": "0.18.0",
+  "name": "aaxios",
+  "version": "0.18.1",
   "description": "Promise based HTTP client for the browser and node.js",
   "main": "index.js",
   "scripts": {
@@ -16,7 +16,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/axios/axios.git"
+    "url": "https://github.com/andrew-templeton/axios"
   },
   "keywords": [
     "xhr",
@@ -28,9 +28,9 @@
   "author": "Matt Zabriskie",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/axios/axios/issues"
+    "url": "https://github.com/andrew-templeton/axios/issues"
   },
-  "homepage": "https://github.com/axios/axios",
+  "homepage": "https://github.com/andrew-templeton/axios/axios",
   "devDependencies": {
     "bundlesize": "^0.17.0",
     "coveralls": "^3.0.0",

--- a/test/specs/headers.spec.js
+++ b/test/specs/headers.spec.js
@@ -69,15 +69,6 @@ describe('headers', function () {
     });
   });
 
-  it('should remove content-type if data is empty', function (done) {
-    axios.post('/foo');
-
-    getAjaxRequest().then(function (request) {
-      testHeaderValue(request.requestHeaders, 'Content-Type', undefined);
-      done();
-    });
-  });
-
   it('should preserve content-type if data is false', function (done) {
     axios.post('/foo', false);
 


### PR DESCRIPTION
Undoes the logic that prevents setting of Content-Type for requests with undefined bodies