### PR TITLE
[WIP] feat: adapt the wechat/alipay mini app

### DIFF
--- a/lib/adapters/mini-app.js
+++ b/lib/adapters/mini-app.js
@@ -1,0 +1,95 @@
+"use strict";
+
+var settle = require("./../core/settle");
+var buildURL = require("./../helpers/buildURL");
+var createError = require("../core/createError");
+var btoa =
+  (typeof window !== "undefined" && window.btoa && window.btoa.bind(window)) ||
+  require("./../helpers/btoa");
+
+module.exports = function xhrAdapter(config) {
+  return new Promise(function dispatchXhrRequest(resolve, reject) {
+    var requestData = config.data;
+    var requestHeaders = config.headers;
+    var isWechat = typeof wx !== "undefined";
+    var isAlipay = typeof my !== "undefined";
+    var requestTask;
+    var request = isWechat // wechat
+      ? wx.request
+      : isAlipay // alipay
+        ? my.httpRequest
+        : null;
+    if (typeof request !== "function") {
+      reject(createError("Not Support", config, null, {}));
+    }
+    var availableResponseType = isWechat ? ["text", "arraybuffer"] : [];
+
+    // HTTP basic authentication
+    if (config.auth) {
+      var username = config.auth.username || "";
+      var password = config.auth.password || "";
+      requestHeaders.Authorization = "Basic " + btoa(username + ":" + password);
+    }
+
+    var requestConfig = {
+      url: buildURL(config.url, config.params, config.paramsSerializer),
+      method: config.method.toUpperCase(),
+      header: requestHeaders,
+      success: function(res) {
+        var responseData = res.data;
+        // wechat mini app use statusCode
+        // alipay mini app use status
+        var status = res.statusCode !== undefined ? res.statusCode : res.status;
+        var responseHeaders = res.header;
+        var response = {
+          data: responseData,
+          status: status,
+          // no statusText, it you want, you can fill it by statusCode
+          statusText: "",
+          headers: responseHeaders,
+          config: config,
+          // in alipay, requestTask is undefined
+          // so we set the requestTask to empty object to avoid throw an error
+          request: requestTask || {}
+        };
+        settle(resolve, reject, response);
+      },
+      fail: function(error) {
+        // in alipay, requestTask is undefined
+        // so we set the requestTask to empty object to avoid throw an error
+        reject(createError("Network Error", config, null, requestTask || {}));
+      }
+    };
+
+    // only alipay support timeout
+    if (isAlipay) {
+      if (config.timeout) {
+        requestConfig.timeout = config.timeout;
+      }
+    }
+
+    // Check valid response type
+    // only wechat support responseType
+    if (isWechat && config.responseType) {
+      if (config.responseType) {
+        if (availableResponseType.indexOf(config.responseType) < 0) {
+          reject(createError("Invalid response type", config, null, {}));
+          return;
+        }
+        requestConfig.responseType = config.responseType;
+      }
+    }
+
+    // send the request
+    requestTask = request.call(wx, requestConfig);
+
+    // only wechat support abort request
+    if (isWechat && config.cancelToken) {
+      // Handle cancellation
+      config.cancelToken.promise.then(function onCanceled(cancel) {
+        requestTask.abort();
+        reject(cancel);
+      });
+    }
+  });
+};

--- a/lib/adapters/mini-app.js
+++ b/lib/adapters/mini-app.js
@@ -1,41 +1,44 @@
-"use strict";
+'use strict';
 
-var settle = require("./../core/settle");
-var buildURL = require("./../helpers/buildURL");
-var createError = require("../core/createError");
+var settle = require('./../core/settle');
+var buildURL = require('./../helpers/buildURL');
+var createError = require('../core/createError');
 var btoa =
-  (typeof window !== "undefined" && window.btoa && window.btoa.bind(window)) ||
-  require("./../helpers/btoa");
+  (typeof window !== 'undefined' && window.btoa && window.btoa.bind(window)) ||
+  require('./../helpers/btoa');
 
 module.exports = function xhrAdapter(config) {
   return new Promise(function dispatchXhrRequest(resolve, reject) {
     var requestData = config.data;
     var requestHeaders = config.headers;
-    var isWechat = typeof wx !== "undefined";
-    var isAlipay = typeof my !== "undefined";
+    var isWechat = typeof wx !== 'undefined';
+    var isAlipay = typeof my !== 'undefined';
     var requestTask;
-    var request = isWechat // wechat
-      ? wx.request
-      : isAlipay // alipay
-        ? my.httpRequest
-        : null;
-    if (typeof request !== "function") {
-      reject(createError("Not Support", config, null, {}));
+    var request = null;
+    if (isWechat) {
+      request = wx.request;
+    } else if (isAlipay) {
+      request = my.httpRequest;
     }
-    var availableResponseType = isWechat ? ["text", "arraybuffer"] : [];
+    if (typeof request !== 'function') {
+      reject(createError('Not Support', config, null, {}));
+    }
+    var availableResponseType = isWechat ? ['text', 'arraybuffer'] : [];
 
     // HTTP basic authentication
     if (config.auth) {
-      var username = config.auth.username || "";
-      var password = config.auth.password || "";
-      requestHeaders.Authorization = "Basic " + btoa(username + ":" + password);
+      var username = config.auth.username || '';
+      var password = config.auth.password || '';
+      requestHeaders.Authorization = 'Basic ' + btoa(username + ':' + password);
     }
 
     var requestConfig = {
       url: buildURL(config.url, config.params, config.paramsSerializer),
       method: config.method.toUpperCase(),
       header: requestHeaders,
-      success: function(res) {
+      data: requestData,
+      /*eslint func-names: ["error", "always"]*/
+      success: function success(res) {
         var responseData = res.data;
         // wechat mini app use statusCode
         // alipay mini app use status
@@ -45,7 +48,7 @@ module.exports = function xhrAdapter(config) {
           data: responseData,
           status: status,
           // no statusText, it you want, you can fill it by statusCode
-          statusText: "",
+          statusText: '',
           headers: responseHeaders,
           config: config,
           // in alipay, requestTask is undefined
@@ -54,10 +57,10 @@ module.exports = function xhrAdapter(config) {
         };
         settle(resolve, reject, response);
       },
-      fail: function(error) {
+      fail: function fail() {
         // in alipay, requestTask is undefined
         // so we set the requestTask to empty object to avoid throw an error
-        reject(createError("Network Error", config, null, requestTask || {}));
+        reject(createError('Network Error', config, null, requestTask || {}));
       }
     };
 
@@ -73,7 +76,7 @@ module.exports = function xhrAdapter(config) {
     if (isWechat && config.responseType) {
       if (config.responseType) {
         if (availableResponseType.indexOf(config.responseType) < 0) {
-          reject(createError("Invalid response type", config, null, {}));
+          reject(createError('Invalid response type', config, null, {}));
           return;
         }
         requestConfig.responseType = config.responseType;

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -22,6 +22,8 @@ function getDefaultAdapter() {
   } else if (typeof XMLHttpRequest !== 'undefined') {
     // For browsers use XHR adapter
     adapter = require('./adapters/xhr');
+  } else if ((typeof wx !== 'undefined' && typeof wx.request === 'function') || (typeof my !== 'undefined' && typeof my.httpRequest === 'function')){
+    adapter = require('./adapters/mini-app');
   }
   return adapter;
 }

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -22,7 +22,7 @@ function getDefaultAdapter() {
   } else if (typeof XMLHttpRequest !== 'undefined') {
     // For browsers use XHR adapter
     adapter = require('./adapters/xhr');
-  } else if ((typeof wx !== 'undefined' && typeof wx.request === 'function') || (typeof my !== 'undefined' && typeof my.httpRequest === 'function')){
+  } else if ((typeof wx !== 'undefined' && typeof wx.request === 'function') || (typeof my !== 'undefined' && typeof my.httpRequest === 'function')) {
     adapter = require('./adapters/mini-app');
   }
   return adapter;


### PR DESCRIPTION
try to adapt the wechat/alipay mini app HTTP module.

Here are the docs about them. (write-in Chinese)

[wechat](https://developers.weixin.qq.com/miniprogram/dev/api/network-request.html#wxrequestobject)

[alipay](https://docs.alipay.com/mini/api/network)

Those HTTP modules send in native. not XMLHttp.

So, some feature is not supported.

I am trying to make them compatible with axios's API.

Working in Process...

and need more test