### PR TITLE
Allow custom return types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -109,13 +109,13 @@ export interface AxiosInstance {
     request: AxiosInterceptorManager<AxiosRequestConfig>;
     response: AxiosInterceptorManager<AxiosResponse>;
   };
-  request<T = any>(config: AxiosRequestConfig): AxiosPromise<T>;
-  get<T = any>(url: string, config?: AxiosRequestConfig): AxiosPromise<T>;
-  delete<T = any>(url: string, config?: AxiosRequestConfig): AxiosPromise<T>;
-  head<T = any>(url: string, config?: AxiosRequestConfig): AxiosPromise<T>;
-  post<T = any>(url: string, data?: any, config?: AxiosRequestConfig): AxiosPromise<T>;
-  put<T = any>(url: string, data?: any, config?: AxiosRequestConfig): AxiosPromise<T>;
-  patch<T = any>(url: string, data?: any, config?: AxiosRequestConfig): AxiosPromise<T>;
+  request<T = any, R = AxiosResponse<T>> (config: AxiosRequestConfig): Promise<R>;
+  get<T = any, R = AxiosResponse<T>>(url: string, config?: AxiosRequestConfig): Promise<R>;
+  delete<T = any, R = AxiosResponse<T>>(url: string, config?: AxiosRequestConfig): Promise<R>;
+  head<T = any, R = AxiosResponse<T>>(url: string, config?: AxiosRequestConfig): Promise<R>;
+  post<T = any, R = AxiosResponse<T>>(url: string, data?: any, config?: AxiosRequestConfig): Promise<R>;
+  put<T = any, R = AxiosResponse<T>>(url: string, data?: any, config?: AxiosRequestConfig): Promise<R>;
+  patch<T = any, R = AxiosResponse<T>>(url: string, data?: any, config?: AxiosRequestConfig): Promise<R>;
 }
 
 export interface AxiosStatic extends AxiosInstance {

--- a/test/typescript/axios.ts
+++ b/test/typescript/axios.ts
@@ -103,6 +103,8 @@ interface User {
   name: string;
 }
 
+// with default AxiosResponse<T> result
+
 const handleUserResponse = (response: AxiosResponse<User>) => {
 	console.log(response.data.id);
 	console.log(response.data.name);
@@ -121,11 +123,11 @@ axios.get<User>('/user', { params: { id: 12345 } })
 	.catch(handleError);
 
 axios.head<User>('/user')
-	.then(handleResponse)
+	.then(handleUserResponse)
 	.catch(handleError);
 
 axios.delete<User>('/user')
-	.then(handleResponse)
+	.then(handleUserResponse)
 	.catch(handleError);
 
 axios.post<User>('/user', { foo: 'bar' })
@@ -142,7 +144,52 @@ axios.put<User>('/user', { foo: 'bar' })
 
 axios.patch<User>('/user', { foo: 'bar' })
 	.then(handleUserResponse)
-	.catch(handleError);
+  .catch(handleError);
+
+// (Typed methods) with custom response type
+
+const handleStringResponse = (response: string) => {
+  console.log(response)
+}
+
+axios.get<User, string>('/user?id=12345')
+  .then(handleStringResponse)
+  .catch(handleError);
+
+axios.get<User, string>('/user', { params: { id: 12345 } })
+  .then(handleStringResponse)
+  .catch(handleError);
+
+axios.head<User, string>('/user')
+  .then(handleStringResponse)
+  .catch(handleError);
+
+axios.delete<User, string>('/user')
+  .then(handleStringResponse)
+  .catch(handleError);
+
+axios.post<User, string>('/user', { foo: 'bar' })
+  .then(handleStringResponse)
+  .catch(handleError);
+
+axios.post<User, string>('/user', { foo: 'bar' }, { headers: { 'X-FOO': 'bar' } })
+  .then(handleStringResponse)
+  .catch(handleError);
+
+axios.put<User, string>('/user', { foo: 'bar' })
+  .then(handleStringResponse)
+  .catch(handleError);
+
+axios.patch<User, string>('/user', { foo: 'bar' })
+  .then(handleStringResponse)
+  .catch(handleError);
+
+axios.request<User, string>({
+  method: 'get',
+  url: '/user?id=12345'
+})
+  .then(handleStringResponse)
+  .catch(handleError);
 
 // Instances
 


### PR DESCRIPTION
As discussed in #1510, you can change the return type in a response interceptor.

Currently this cannot be accounted for in the TypeScript typings.

With this change we allow telling the compiler that we expect a specific return type. You still need to make sure that this type of data is returned by your last interceptor, as this cannot be reliably inferred.