### PR TITLE
[NS]: Send `false` flag isStandardBrowserEnv for Nativescript

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -182,8 +182,8 @@ function trim(str) {
  */
 function isStandardBrowserEnv() {
   if (typeof navigator !== 'undefined' && (navigator.product === 'ReactNative' ||
-                                          navigator.product === 'NativeScript' ||
-                                          navigator.product === 'NS') {
+                                           navigator.product === 'NativeScript' ||
+                                           navigator.product === 'NS')) {
     return false;
   }
   return (

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -177,9 +177,13 @@ function trim(str) {
  *
  * react-native:
  *  navigator.product -> 'ReactNative'
+ * nativescript
+ *  navigator.product -> 'NativeScript' or 'NS'
  */
 function isStandardBrowserEnv() {
-  if (typeof navigator !== 'undefined' && navigator.product === 'ReactNative') {
+  if (typeof navigator !== 'undefined' && (navigator.product === 'ReactNative' ||
+                                          navigator.product === 'NativeScript' ||
+                                          navigator.product === 'NS') {
     return false;
   }
   return (


### PR DESCRIPTION
Currently we don't disable browser env for **Nativescript** like what we have for **ReactNative**, we want to support `axios` for Nativescript