### PR TITLE
Adding second then on axios call in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,15 @@ Performing a `GET` request
 // Make a request for a user with a given ID
 axios.get('/user?ID=12345')
   .then(function (response) {
+    // handle success
     console.log(response);
   })
   .catch(function (error) {
+    // handle error
     console.log(error);
+  })
+  .then(function () {
+    // always executed
   });
 
 // Optionally the request above could also be done as
@@ -73,7 +78,10 @@ axios.get('/user', {
   })
   .catch(function (error) {
     console.log(error);
-  });
+  })
+  .then(function () {
+    // always executed
+  });  
 
 // Want to use async/await? Add the `async` keyword to your outer function/method.
 async function getUser() {


### PR DESCRIPTION
Inspired by this issue : https://github.com/axios/axios/issues/792#issuecomment-289306590

Adding this kind of example in the readme :
```javascript
axios.post('/api/foo', {
    foo: 'bar'
}).then((response) => {
    // success
}).catch((error) => {
    // error
}).then(() => {
    // always executed
});
```