### PR TITLE
Added toJSON to enhanced Axios errors to facilitate serialization

### DIFF
--- a/lib/core/enhanceError.js
+++ b/lib/core/enhanceError.js
@@ -17,5 +17,23 @@ module.exports = function enhanceError(error, config, code, request, response) {
   }
   error.request = request;
   error.response = response;
+  error.toJSON = function() {
+    return {
+      // Standard
+      message: this.message,
+      name: this.name,
+      // Microsoft
+      description: this.description,
+      number: this.number,
+      // Mozilla
+      fileName: this.fileName,
+      lineNumber: this.lineNumber,
+      columnNumber: this.columnNumber,
+      stack: this.stack,
+      // Axios
+      config: this.config,
+      code: this.code
+    };
+  };
   return error;
 };

--- a/test/specs/core/createError.spec.js
+++ b/test/specs/core/createError.spec.js
@@ -12,4 +12,17 @@ describe('core::createError', function() {
     expect(error.request).toBe(request);
     expect(error.response).toBe(response);
   });
+  it('should create an Error that can be serialized to JSON', function() {
+    // Attempting to serialize request and response results in
+    //    TypeError: Converting circular structure to JSON
+    var request = { path: '/foo' };
+    var response = { status: 200, data: { foo: 'bar' } };
+    var error = createError('Boom!', { foo: 'bar' }, 'ESOMETHING', request, response);
+    var json = error.toJSON();
+    expect(json.message).toBe('Boom!');
+    expect(json.config).toEqual({ foo: 'bar' });
+    expect(json.code).toBe('ESOMETHING');
+    expect(json.request).toBe(undefined);
+    expect(json.response).toBe(undefined);
+  });
 });


### PR DESCRIPTION
This PR addresses issues #836 and #1301, and possibly #1220 and #460, as well.

Other Error objects in JSON are serializable by default using `JSON.stringify()`, which is often used for logging and debugging when errors occur, and in some cases for persisting to a db or transmitting over the wire in the form of a crash report. Axios Error objects, however, are not serializable by default due to the circular structures in the request and response.

This is particularly problematic because conditions that result in errors are less likely to occur during the normal course of operation (i.e. when testing the 'happy path'), and so the corresponding code paths are less often tested. When they are tested, they may be tested with mocks that do not include the circular structures, and therefore this behavior is not detected until the corresponding error condition actually occurs in a production environment.

This PR leaves the request and response in place in the JavaScript object, but adds a `.toJSON()` property to the enhanced error objects, that is used by `JSON.stringify()` to successfully serialize the objects.

Prior to this change, the following would result in `UnhandledPromiseRejectionWarning: TypeError: Converting circular structure to JSON`:

```
const axios = require("axios");

axios.get('/somepaththatdoesnotexist')
  .catch(function (error) {
    console.log('error:', JSON.stringify(error, null, 2));
  });

```

After the change, the output is:

```
bash-3.2$ node index.js 
error: {
  "message": "connect ECONNREFUSED 127.0.0.1:80",
  "name": "Error",
  "stack": "Error: connect ECONNREFUSED 127.0.0.1:80\n    at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1174:14)",
  "config": {
    "url": "/somepaththatdoesnotexist",
    "method": "get",
    "headers": {
      "Accept": "application/json, text/plain, */*",
      "User-Agent": "axios/0.18.0"
    },
    "transformRequest": [
      null
    ],
    "transformResponse": [
      null
    ],
    "timeout": 0,
    "xsrfCookieName": "XSRF-TOKEN",
    "xsrfHeaderName": "X-XSRF-TOKEN",
    "maxContentLength": -1
  },
  "code": "ECONNREFUSED"
}
```

