### PR TITLE
Fixing issue 662: request fail when request https url througth http proxy, base v0.18.0

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -92,17 +92,20 @@ module.exports = function httpAdapter(config) {
       var proxyUrl = process.env[proxyEnv] || process.env[proxyEnv.toUpperCase()];
       if (proxyUrl) {
         var parsedProxyUrl = url.parse(proxyUrl);
-        proxy = {
-          host: parsedProxyUrl.hostname,
-          port: parsedProxyUrl.port
-        };
 
-        if (parsedProxyUrl.auth) {
-          var proxyUrlAuth = parsedProxyUrl.auth.split(':');
-          proxy.auth = {
-            username: proxyUrlAuth[0],
-            password: proxyUrlAuth[1]
+        if (parsedProxyUrl.protocol === protocol) {
+          proxy = {
+            host: parsedProxyUrl.hostname,
+            port: parsedProxyUrl.port
           };
+
+          if (parsedProxyUrl.auth) {
+            var proxyUrlAuth = parsedProxyUrl.auth.split(':');
+            proxy.auth = {
+              username: proxyUrlAuth[0],
+              password: proxyUrlAuth[1]
+            };
+          }
         }
       }
     }


### PR DESCRIPTION
This PR addresses issues #662: request fail when request https url through http proxy. 

The solution is:  ignore proxy ` if ( parsedProxyUrl.protocol !== protocol )`
