### PR TITLE
Converting traditional function expressions to arrow functions

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,4 +1,4 @@
-module.exports = function(grunt) {
+module.exports = grunt => {
   require('load-grunt-tasks')(grunt);
 
   grunt.initConfig({

--- a/examples/get/server.js
+++ b/examples/get/server.js
@@ -25,7 +25,7 @@ var people = [
   }
 ];
 
-module.exports = function (req, res) {
+module.exports = (req, res) => {
   res.writeHead(200, {
     'Content-Type': 'text/json'
   });

--- a/examples/post/server.js
+++ b/examples/post/server.js
@@ -1,11 +1,11 @@
-module.exports = function (req, res) {
+module.exports = (req, res) => {
   var data = '';
   
-  req.on('data', function (chunk) {
+  req.on('data', chunk => {
     data += chunk;
   });
 
-  req.on('end', function () {
+  req.on('end', () => {
     console.log('POST data received');
     res.writeHead(200, {
       'Content-Type': 'text/json'

--- a/examples/server.js
+++ b/examples/server.js
@@ -24,7 +24,7 @@ function listDirs(root) {
 }
 
 function getIndexTemplate() {
-  var links = dirs.map(function (dir) {
+  var links = dirs.map(dir => {
     var url = '/' + dir;
     return '<li onclick="document.location=\'' + url + '\'"><a href="' + url + '">' + url + '</a></li>';
   });
@@ -74,7 +74,7 @@ function pipeFileToResponse(res, file, type) {
 
 dirs = listDirs(__dirname);
 
-server = http.createServer(function (req, res) {
+server = http.createServer((req, res) => {
   var url = req.url;
 
   // Process axios itself

--- a/examples/upload/server.js
+++ b/examples/upload/server.js
@@ -1,11 +1,11 @@
-module.exports = function (req, res) {
+module.exports = (req, res) => {
   var data = '';
 
-  req.on('data', function (chunk) {
+  req.on('data', chunk => {
     data += chunk;
   });
 
-  req.on('end', function () {
+  req.on('end', () => {
     console.log('File uploaded');
     res.writeHead(200);
     res.end();

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -12,7 +12,7 @@ function createCustomLauncher(browser, version, platform) {
   };
 }
 
-module.exports = function(config) {
+module.exports = config => {
   var customLaunchers = {};
   var browsers = [];
 
@@ -31,7 +31,7 @@ module.exports = function(config) {
       'SAUCE_ANDROID'
     ];
 
-    options.forEach(function (opt) {
+    options.forEach(opt => {
       if (process.env[opt]) {
         runAll = false;
       }

--- a/sandbox/server.js
+++ b/sandbox/server.js
@@ -14,7 +14,7 @@ function pipeFileToResponse(res, file, type) {
   fs.createReadStream(path.join(__dirname, file)).pipe(res);
 }
 
-server = http.createServer(function (req, res) {
+server = http.createServer((req, res) => {
   req.setEncoding('utf8');
 
   var parsed = url.parse(req.url, true);
@@ -37,11 +37,11 @@ server = http.createServer(function (req, res) {
     var result;
     var data = '';
 
-    req.on('data', function (chunk) {
+    req.on('data', chunk => {
       data += chunk;
     });
 
-    req.on('end', function () {
+    req.on('end', () => {
       try {
         status = 200;
         result = {

--- a/test/specs/__helpers.js
+++ b/test/specs/__helpers.js
@@ -12,13 +12,13 @@ jasmine.DEFAULT_TIMEOUT_INTERVAL = 20000;
 jasmine.getEnv().defaultTimeoutInterval = 20000;
 
 // Get Ajax request using an increasing timeout to retry
-getAjaxRequest = (function () {
+getAjaxRequest = (() => {
 var attempts = 0;
 var MAX_ATTEMPTS = 5;
 var ATTEMPT_DELAY_FACTOR = 5;
 
 function getAjaxRequest() {
-  return new Promise(function (resolve, reject) {
+  return new Promise((resolve, reject) => {
     attempts = 0;
     attemptGettingAjaxRequest(resolve, reject);
   });
@@ -32,7 +32,7 @@ function attemptGettingAjaxRequest(resolve, reject) {
     return;
   }
 
-  setTimeout(function () {
+  setTimeout(() => {
     var request = jasmine.Ajax.requests.mostRecent();
     if (request) {
       resolve(request);
@@ -52,15 +52,15 @@ validateInvalidCharacterError = function validateInvalidCharacterError(error) {
 
 // Setup basic auth tests
 setupBasicAuthTest = function setupBasicAuthTest() {
-  beforeEach(function () {
+  beforeEach(() => {
     jasmine.Ajax.install();
   });
 
-  afterEach(function () {
+  afterEach(() => {
     jasmine.Ajax.uninstall();
   });
 
-  it('should accept HTTP Basic auth with username/password', function (done) {
+  it('should accept HTTP Basic auth with username/password', done => {
     axios('/foo', {
       auth: {
         username: 'Aladdin',
@@ -68,7 +68,7 @@ setupBasicAuthTest = function setupBasicAuthTest() {
       }
     });
 
-    setTimeout(function () {
+    setTimeout(() => {
       var request = jasmine.Ajax.requests.mostRecent();
 
       expect(request.requestHeaders['Authorization']).toEqual('Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==');
@@ -76,15 +76,15 @@ setupBasicAuthTest = function setupBasicAuthTest() {
     }, 100);
   });
 
-  it('should fail to encode HTTP Basic auth credentials with non-Latin1 characters', function (done) {
+  it('should fail to encode HTTP Basic auth credentials with non-Latin1 characters', done => {
     axios('/foo', {
       auth: {
         username: 'Aladßç£☃din',
         password: 'open sesame'
       }
-    }).then(function(response) {
+    }).then(response => {
       done(new Error('Should not succeed to make a HTTP Basic auth request with non-latin1 chars in credentials.'));
-    }).catch(function(error) {
+    }).catch(error => {
       validateInvalidCharacterError(error);
       done();
     });

--- a/test/specs/adapter.spec.js
+++ b/test/specs/adapter.spec.js
@@ -1,16 +1,16 @@
 var axios = require('../../index');
 
-describe('adapter', function () {
-  it('should support custom adapter', function (done) {
+describe('adapter', () => {
+  it('should support custom adapter', done => {
     var called = false;
 
     axios('/foo', {
-      adapter: function (config) {
+      adapter: config => {
         called = true;
       }
     });
 
-    setTimeout(function () {
+    setTimeout(() => {
       expect(called).toBe(true);
       done();
     }, 100);

--- a/test/specs/api.spec.js
+++ b/test/specs/api.spec.js
@@ -1,5 +1,5 @@
-describe('static api', function () {
-  it('should have request method helpers', function () {
+describe('static api', () => {
+  it('should have request method helpers', () => {
     expect(typeof axios.request).toEqual('function');
     expect(typeof axios.get).toEqual('function');
     expect(typeof axios.head).toEqual('function');
@@ -10,43 +10,43 @@ describe('static api', function () {
     expect(typeof axios.patch).toEqual('function');
   });
 
-  it('should have promise method helpers', function () {
+  it('should have promise method helpers', () => {
     var promise = axios();
 
     expect(typeof promise.then).toEqual('function');
     expect(typeof promise.catch).toEqual('function');
   });
 
-  it('should have defaults', function () {
+  it('should have defaults', () => {
     expect(typeof axios.defaults).toEqual('object');
     expect(typeof axios.defaults.headers).toEqual('object');
   });
 
-  it('should have interceptors', function () {
+  it('should have interceptors', () => {
     expect(typeof axios.interceptors.request).toEqual('object');
     expect(typeof axios.interceptors.response).toEqual('object');
   });
 
-  it('should have all/spread helpers', function () {
+  it('should have all/spread helpers', () => {
     expect(typeof axios.all).toEqual('function');
     expect(typeof axios.spread).toEqual('function');
   });
 
-  it('should have factory method', function () {
+  it('should have factory method', () => {
     expect(typeof axios.create).toEqual('function');
   });
 
-  it('should have Cancel, CancelToken, and isCancel properties', function () {
+  it('should have Cancel, CancelToken, and isCancel properties', () => {
     expect(typeof axios.Cancel).toEqual('function');
     expect(typeof axios.CancelToken).toEqual('function');
     expect(typeof axios.isCancel).toEqual('function');
   });
 });
 
-describe('instance api', function () {
+describe('instance api', () => {
   var instance = axios.create();
 
-  it('should have request methods', function () {
+  it('should have request methods', () => {
     expect(typeof instance.request).toEqual('function');
     expect(typeof instance.get).toEqual('function');
     expect(typeof instance.options).toEqual('function');
@@ -57,7 +57,7 @@ describe('instance api', function () {
     expect(typeof instance.patch).toEqual('function');
   });
 
-  it('should have interceptors', function () {
+  it('should have interceptors', () => {
     expect(typeof instance.interceptors.request).toEqual('object');
     expect(typeof instance.interceptors.response).toEqual('object');
   });

--- a/test/specs/basicAuth.spec.js
+++ b/test/specs/basicAuth.spec.js
@@ -1,3 +1,3 @@
-describe('basicAuth', function () {
+describe('basicAuth', () => {
   setupBasicAuthTest();
 });

--- a/test/specs/cancel.spec.js
+++ b/test/specs/cancel.spec.js
@@ -1,22 +1,22 @@
 var Cancel = axios.Cancel;
 var CancelToken = axios.CancelToken;
 
-describe('cancel', function() {
-  beforeEach(function() {
+describe('cancel', () => {
+  beforeEach(() => {
     jasmine.Ajax.install();
   });
 
-  afterEach(function() {
+  afterEach(() => {
     jasmine.Ajax.uninstall();
   });
 
-  describe('when called before sending request', function() {
-    it('rejects Promise with a Cancel object', function (done) {
+  describe('when called before sending request', () => {
+    it('rejects Promise with a Cancel object', done => {
       var source = CancelToken.source();
       source.cancel('Operation has been canceled.');
       axios.get('/foo', {
         cancelToken: source.token
-      }).catch(function (thrown) {
+      }).catch(thrown => {
         expect(thrown).toEqual(jasmine.any(Cancel));
         expect(thrown.message).toBe('Operation has been canceled.');
         done();
@@ -24,18 +24,18 @@ describe('cancel', function() {
     });
   });
 
-  describe('when called after request has been sent', function() {
-    it('rejects Promise with a Cancel object', function (done) {
+  describe('when called after request has been sent', () => {
+    it('rejects Promise with a Cancel object', done => {
       var source = CancelToken.source();
       axios.get('/foo/bar', {
         cancelToken: source.token
-      }).catch(function (thrown) {
+      }).catch(thrown => {
         expect(thrown).toEqual(jasmine.any(Cancel));
         expect(thrown.message).toBe('Operation has been canceled.');
         done();
       });
 
-      getAjaxRequest().then(function (request) {
+      getAjaxRequest().then(request => {
         // call cancel() when the request has been sent, but a response has not been received
         source.cancel('Operation has been canceled.');
         request.respondWith({
@@ -45,18 +45,18 @@ describe('cancel', function() {
       });
     });
 
-    it('calls abort on request object', function (done) {
+    it('calls abort on request object', done => {
       var source = CancelToken.source();
       var request;
       axios.get('/foo/bar', {
         cancelToken: source.token
-      }).catch(function() {
+      }).catch(() => {
         // jasmine-ajax sets statusText to 'abort' when request.abort() is called
         expect(request.statusText).toBe('abort');
         done();
       });
 
-      getAjaxRequest().then(function (req) {
+      getAjaxRequest().then(req => {
         // call cancel() when the request has been sent, but a response has not been received
         source.cancel();
         request = req;
@@ -64,21 +64,21 @@ describe('cancel', function() {
     });
   });
 
-  describe('when called after response has been received', function() {
+  describe('when called after response has been received', () => {
     // https://github.com/axios/axios/issues/482
-    it('does not cause unhandled rejection', function (done) {
+    it('does not cause unhandled rejection', done => {
       var source = CancelToken.source();
       axios.get('/foo', {
         cancelToken: source.token
-      }).then(function () {
-        window.addEventListener('unhandledrejection', function () {
+      }).then(() => {
+        window.addEventListener('unhandledrejection', () => {
           done.fail('Unhandled rejection.');
         });
         source.cancel();
         setTimeout(done, 100);
       });
 
-      getAjaxRequest().then(function (request) {
+      getAjaxRequest().then(request => {
         request.respondWith({
           status: 200,
           responseText: 'OK'

--- a/test/specs/cancel/Cancel.spec.js
+++ b/test/specs/cancel/Cancel.spec.js
@@ -1,13 +1,13 @@
 var Cancel = require('../../../lib/cancel/Cancel');
 
-describe('Cancel', function() {
-  describe('toString', function() {
-    it('returns correct result when message is not specified', function() {
+describe('Cancel', () => {
+  describe('toString', () => {
+    it('returns correct result when message is not specified', () => {
       var cancel = new Cancel();
       expect(cancel.toString()).toBe('Cancel');
     });
 
-    it('returns correct result when message is specified', function() {
+    it('returns correct result when message is specified', () => {
       var cancel = new Cancel('Operation has been canceled.');
       expect(cancel.toString()).toBe('Cancel: Operation has been canceled.');
     });

--- a/test/specs/cancel/CancelToken.spec.js
+++ b/test/specs/cancel/CancelToken.spec.js
@@ -1,25 +1,25 @@
 var CancelToken = require('../../../lib/cancel/CancelToken');
 var Cancel = require('../../../lib/cancel/Cancel');
 
-describe('CancelToken', function() {
-  describe('constructor', function() {
-    it('throws when executor is not specified', function() {
-      expect(function() {
+describe('CancelToken', () => {
+  describe('constructor', () => {
+    it('throws when executor is not specified', () => {
+      expect(() => {
         new CancelToken();
       }).toThrowError(TypeError, 'executor must be a function.');
     });
 
-    it('throws when executor is not a function', function() {
-      expect(function() {
+    it('throws when executor is not a function', () => {
+      expect(() => {
         new CancelToken(123);
       }).toThrowError(TypeError, 'executor must be a function.');
     });
   });
 
-  describe('reason', function() {
-    it('returns a Cancel if cancellation has been requested', function() {
+  describe('reason', () => {
+    it('returns a Cancel if cancellation has been requested', () => {
       var cancel;
-      var token = new CancelToken(function(c) {
+      var token = new CancelToken(c => {
         cancel = c;
       });
       cancel('Operation has been canceled.');
@@ -27,16 +27,16 @@ describe('CancelToken', function() {
       expect(token.reason.message).toBe('Operation has been canceled.');
     });
 
-    it('returns undefined if cancellation has not been requested', function() {
-      var token = new CancelToken(function() {});
+    it('returns undefined if cancellation has not been requested', () => {
+      var token = new CancelToken(() => {});
       expect(token.reason).toBeUndefined();
     });
   });
 
-  describe('promise', function() {
-    it('returns a Promise that resolves when cancellation is requested', function(done) {
+  describe('promise', () => {
+    it('returns a Promise that resolves when cancellation is requested', done => {
       var cancel;
-      var token = new CancelToken(function(c) {
+      var token = new CancelToken(c => {
         cancel = c;
       });
       token.promise.then(function onFulfilled(value) {
@@ -48,11 +48,11 @@ describe('CancelToken', function() {
     });
   });
 
-  describe('throwIfRequested', function() {
-    it('throws if cancellation has been requested', function() {
+  describe('throwIfRequested', () => {
+    it('throws if cancellation has been requested', () => {
       // Note: we cannot use expect.toThrowError here as Cancel does not inherit from Error
       var cancel;
-      var token = new CancelToken(function(c) {
+      var token = new CancelToken(c => {
         cancel = c;
       });
       cancel('Operation has been canceled.');
@@ -67,14 +67,14 @@ describe('CancelToken', function() {
       }
     });
 
-    it('does not throw if cancellation has not been requested', function() {
-      var token = new CancelToken(function() {});
+    it('does not throw if cancellation has not been requested', () => {
+      var token = new CancelToken(() => {});
       token.throwIfRequested();
     });
   });
 
-  describe('source', function() {
-    it('returns an object containing token and cancel function', function() {
+  describe('source', () => {
+    it('returns an object containing token and cancel function', () => {
       var source = CancelToken.source();
       expect(source.token).toEqual(jasmine.any(CancelToken));
       expect(source.cancel).toEqual(jasmine.any(Function));

--- a/test/specs/cancel/isCancel.spec.js
+++ b/test/specs/cancel/isCancel.spec.js
@@ -1,12 +1,12 @@
 var isCancel = require('../../../lib/cancel/isCancel');
 var Cancel = require('../../../lib/cancel/Cancel');
 
-describe('isCancel', function() {
-  it('returns true if value is a Cancel', function() {
+describe('isCancel', () => {
+  it('returns true if value is a Cancel', () => {
     expect(isCancel(new Cancel())).toBe(true);
   });
 
-  it('returns false if value is not a Cancel', function() {
+  it('returns false if value is not a Cancel', () => {
     expect(isCancel({ foo: 'bar' })).toBe(false);
   });
 });

--- a/test/specs/core/createError.spec.js
+++ b/test/specs/core/createError.spec.js
@@ -1,7 +1,7 @@
 var createError = require('../../../lib/core/createError');
 
-describe('core::createError', function() {
-  it('should create an Error with message, config, code, request, response and isAxiosError', function() {
+describe('core::createError', () => {
+  it('should create an Error with message, config, code, request, response and isAxiosError', () => {
     var request = { path: '/foo' };
     var response = { status: 200, data: { foo: 'bar' } };
     var error = createError('Boom!', { foo: 'bar' }, 'ESOMETHING', request, response);
@@ -13,7 +13,7 @@ describe('core::createError', function() {
     expect(error.response).toBe(response);
     expect(error.isAxiosError).toBe(true);
   });
-  it('should create an Error that can be serialized to JSON', function() {
+  it('should create an Error that can be serialized to JSON', () => {
     // Attempting to serialize request and response results in
     //    TypeError: Converting circular structure to JSON
     var request = { path: '/foo' };

--- a/test/specs/core/enhanceError.spec.js
+++ b/test/specs/core/enhanceError.spec.js
@@ -1,7 +1,7 @@
 var enhanceError = require('../../../lib/core/enhanceError');
 
-describe('core::enhanceError', function() {
-  it('should add config, config, request and response to error', function() {
+describe('core::enhanceError', () => {
+  it('should add config, config, request and response to error', () => {
     var error = new Error('Boom!');
     var request = { path: '/foo' };
     var response = { status: 200, data: { foo: 'bar' } };
@@ -14,7 +14,7 @@ describe('core::enhanceError', function() {
     expect(error.isAxiosError).toBe(true);
   });
 
-  it('should return error', function() {
+  it('should return error', () => {
     var error = new Error('Boom!');
     expect(enhanceError(error, { foo: 'bar' }, 'ESOMETHING')).toBe(error);
   });

--- a/test/specs/core/mergeConfig.spec.js
+++ b/test/specs/core/mergeConfig.spec.js
@@ -1,22 +1,22 @@
 var defaults = require('../../../lib/defaults');
 var mergeConfig = require('../../../lib/core/mergeConfig');
 
-describe('core::mergeConfig', function() {
-  it('should accept undefined for second argument', function() {
+describe('core::mergeConfig', () => {
+  it('should accept undefined for second argument', () => {
     expect(mergeConfig(defaults, undefined)).toEqual(defaults);
   });
 
-  it('should accept an object for second argument', function() {
+  it('should accept an object for second argument', () => {
     expect(mergeConfig(defaults, {})).toEqual(defaults);
   });
 
-  it('should not leave references', function() {
+  it('should not leave references', () => {
     var merged = mergeConfig(defaults, {});
     expect(merged).not.toBe(defaults);
     expect(merged.headers).not.toBe(defaults.headers);
   });
 
-  it('should allow setting request options', function() {
+  it('should allow setting request options', () => {
     var config = {
       url: '__sample url__',
       method: '__sample method__',
@@ -30,7 +30,7 @@ describe('core::mergeConfig', function() {
     expect(merged.data).toEqual(config.data);
   });
 
-  it('should not inherit request options', function() {
+  it('should not inherit request options', () => {
     var localDefaults = {
       url: '__sample url__',
       method: '__sample method__',
@@ -44,7 +44,7 @@ describe('core::mergeConfig', function() {
     expect(merged.data).toEqual(undefined);
   });
 
-  it('should merge auth, headers, proxy with defaults', function() {
+  it('should merge auth, headers, proxy with defaults', () => {
     expect(mergeConfig({ auth: undefined }, { auth: { user: 'foo', pass: 'test' } })).toEqual({
       auth: { user: 'foo', pass: 'test' }
     });
@@ -53,7 +53,7 @@ describe('core::mergeConfig', function() {
     });
   });
 
-  it('should overwrite auth, headers, proxy with a non-object value', function() {
+  it('should overwrite auth, headers, proxy with a non-object value', () => {
     expect(mergeConfig({ auth: { user: 'foo', pass: 'test' } }, { auth: false })).toEqual({
       auth: false
     });
@@ -62,7 +62,7 @@ describe('core::mergeConfig', function() {
     });
   });
 
-  it('should allow setting other options', function() {
+  it('should allow setting other options', () => {
     var merged = mergeConfig(defaults, { timeout: 123 });
     expect(merged.timeout).toEqual(123);
   });

--- a/test/specs/core/settle.spec.js
+++ b/test/specs/core/settle.spec.js
@@ -1,20 +1,18 @@
 var settle = require('../../../lib/core/settle');
 
-describe('core::settle', function() {
+describe('core::settle', () => {
   var resolve;
   var reject;
 
-  beforeEach(function() {
+  beforeEach(() => {
     resolve = jasmine.createSpy('resolve');
     reject = jasmine.createSpy('reject');
   });
 
-  it('should resolve promise if status is not set', function() {
+  it('should resolve promise if status is not set', () => {
     var response = {
       config: {
-        validateStatus: function() {
-          return true;
-        }
+        validateStatus: () => true
       }
     };
     settle(resolve, reject, response);
@@ -22,7 +20,7 @@ describe('core::settle', function() {
     expect(reject).not.toHaveBeenCalled();
   });
 
-  it('should resolve promise if validateStatus is not set', function() {
+  it('should resolve promise if validateStatus is not set', () => {
     var response = {
       status: 500,
       config: {
@@ -33,13 +31,11 @@ describe('core::settle', function() {
     expect(reject).not.toHaveBeenCalled();
   });
 
-  it('should resolve promise if validateStatus returns true', function() {
+  it('should resolve promise if validateStatus returns true', () => {
     var response = {
       status: 500,
       config: {
-        validateStatus: function() {
-          return true;
-        }
+        validateStatus: () => true
       }
     };
     settle(resolve, reject, response);
@@ -47,16 +43,14 @@ describe('core::settle', function() {
     expect(reject).not.toHaveBeenCalled();
   });
 
-  it('should reject promise if validateStatus returns false', function() {
+  it('should reject promise if validateStatus returns false', () => {
     var req = {
       path: '/foo'
     };
     var response = {
       status: 500,
       config: {
-        validateStatus: function() {
-          return false;
-        }
+        validateStatus: () => false
       },
       request: req
     };
@@ -71,7 +65,7 @@ describe('core::settle', function() {
     expect(reason.response).toBe(response);
   });
 
-  it('should pass status to validateStatus', function() {
+  it('should pass status to validateStatus', () => {
     var validateStatus = jasmine.createSpy('validateStatus');
     var response = {
       status: 500,

--- a/test/specs/core/transformData.spec.js
+++ b/test/specs/core/transformData.spec.js
@@ -1,9 +1,9 @@
 var transformData = require('../../../lib/core/transformData');
 
-describe('core::transformData', function () {
-  it('should support a single transformer', function () {
+describe('core::transformData', () => {
+  it('should support a single transformer', () => {
     var data;
-    data = transformData(data, null, function (data) {
+    data = transformData(data, null, data => {
       data = 'foo';
       return data;
     });
@@ -11,15 +11,15 @@ describe('core::transformData', function () {
     expect(data).toEqual('foo');
   });
 
-  it('should support an array of transformers', function () {
+  it('should support an array of transformers', () => {
     var data = '';
-    data = transformData(data, null, [function (data) {
+    data = transformData(data, null, [data => {
       data += 'f';
       return data;
-    }, function (data) {
+    }, data => {
       data += 'o';
       return data;
-    }, function (data) {
+    }, data => {
       data += 'o';
       return data;
     }]);

--- a/test/specs/defaults.spec.js
+++ b/test/specs/defaults.spec.js
@@ -1,14 +1,14 @@
 var defaults = require('../../lib/defaults');
 var utils = require('../../lib/utils');
 
-describe('defaults', function () {
+describe('defaults', () => {
   var XSRF_COOKIE_NAME = 'CUSTOM-XSRF-TOKEN';
 
-  beforeEach(function () {
+  beforeEach(() => {
     jasmine.Ajax.install();
   });
 
-  afterEach(function () {
+  afterEach(() => {
     jasmine.Ajax.uninstall();
     delete axios.defaults.baseURL;
     delete axios.defaults.headers.get['X-CUSTOM-HEADER'];
@@ -16,57 +16,57 @@ describe('defaults', function () {
     document.cookie = XSRF_COOKIE_NAME + '=;expires=' + new Date(Date.now() - 86400000).toGMTString();
   });
 
-  it('should transform request json', function () {
+  it('should transform request json', () => {
     expect(defaults.transformRequest[0]({foo: 'bar'})).toEqual('{"foo":"bar"}');
   });
 
-  it('should do nothing to request string', function () {
+  it('should do nothing to request string', () => {
     expect(defaults.transformRequest[0]('foo=bar')).toEqual('foo=bar');
   });
 
-  it('should transform response json', function () {
+  it('should transform response json', () => {
     var data = defaults.transformResponse[0]('{"foo":"bar"}');
 
     expect(typeof data).toEqual('object');
     expect(data.foo).toEqual('bar');
   });
 
-  it('should do nothing to response string', function () {
+  it('should do nothing to response string', () => {
     expect(defaults.transformResponse[0]('foo=bar')).toEqual('foo=bar');
   });
 
-  it('should use global defaults config', function (done) {
+  it('should use global defaults config', done => {
     axios('/foo');
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       expect(request.url).toBe('/foo');
       done();
     });
   });
 
-  it('should use modified defaults config', function (done) {
+  it('should use modified defaults config', done => {
     axios.defaults.baseURL = 'http://example.com/';
 
     axios('/foo');
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       expect(request.url).toBe('http://example.com/foo');
       done();
     });
   });
 
-  it('should use request config', function (done) {
+  it('should use request config', done => {
     axios('/foo', {
       baseURL: 'http://www.example.com'
     });
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       expect(request.url).toBe('http://www.example.com/foo');
       done();
     });
   });
 
-  it('should use default config for custom instance', function (done) {
+  it('should use default config for custom instance', done => {
     var instance = axios.create({
       xsrfCookieName: XSRF_COOKIE_NAME,
       xsrfHeaderName: 'X-CUSTOM-XSRF-TOKEN'
@@ -75,33 +75,33 @@ describe('defaults', function () {
 
     instance.get('/foo');
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       expect(request.requestHeaders[instance.defaults.xsrfHeaderName]).toEqual('foobarbaz');
       done();
     });
   });
 
-  it('should use GET headers', function (done) {
+  it('should use GET headers', done => {
     axios.defaults.headers.get['X-CUSTOM-HEADER'] = 'foo';
     axios.get('/foo');
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       expect(request.requestHeaders['X-CUSTOM-HEADER']).toBe('foo');
       done();
     });
   });
 
-  it('should use POST headers', function (done) {
+  it('should use POST headers', done => {
     axios.defaults.headers.post['X-CUSTOM-HEADER'] = 'foo';
     axios.post('/foo', {});
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       expect(request.requestHeaders['X-CUSTOM-HEADER']).toBe('foo');
       done();
     });
   });
 
-  it('should use header config', function (done) {
+  it('should use header config', done => {
     var instance = axios.create({
       headers: {
         common: {
@@ -123,7 +123,7 @@ describe('defaults', function () {
       }
     });
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       expect(request.requestHeaders).toEqual(
         utils.merge(defaults.headers.common, defaults.headers.get, {
           'X-COMMON-HEADER': 'commonHeaderValue',
@@ -136,25 +136,25 @@ describe('defaults', function () {
     });
   });
 
-  it('should be used by custom instance if set before instance created', function (done) {
+  it('should be used by custom instance if set before instance created', done => {
     axios.defaults.baseURL = 'http://example.org/';
     var instance = axios.create();
 
     instance.get('/foo');
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       expect(request.url).toBe('http://example.org/foo');
       done();
     });
   });
 
-  it('should not be used by custom instance if set after instance created', function (done) {
+  it('should not be used by custom instance if set after instance created', done => {
     var instance = axios.create();
     axios.defaults.baseURL = 'http://example.org/';
 
     instance.get('/foo');
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       expect(request.url).toBe('/foo');
       done();
     });

--- a/test/specs/headers.spec.js
+++ b/test/specs/headers.spec.js
@@ -18,21 +18,21 @@ function testHeaderValue(headers, key, val) {
   }
 }
 
-describe('headers', function () {
-  beforeEach(function () {
+describe('headers', () => {
+  beforeEach(() => {
     jasmine.Ajax.install();
   });
 
-  afterEach(function () {
+  afterEach(() => {
     jasmine.Ajax.uninstall();
   });
 
-  it('should default common headers', function (done) {
+  it('should default common headers', done => {
     var headers = axios.defaults.headers.common;
 
     axios('/foo');
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       for (var key in headers) {
         if (headers.hasOwnProperty(key)) {
           expect(request.requestHeaders[key]).toEqual(headers[key]);
@@ -42,12 +42,12 @@ describe('headers', function () {
     });
   });
 
-  it('should add extra headers for post', function (done) {
+  it('should add extra headers for post', done => {
     var headers = axios.defaults.headers.common;
 
     axios.post('/foo', 'fizz=buzz');
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       for (var key in headers) {
         if (headers.hasOwnProperty(key)) {
           expect(request.requestHeaders[key]).toEqual(headers[key]);
@@ -57,31 +57,31 @@ describe('headers', function () {
     });
   });
 
-  it('should use application/json when posting an object', function (done) {
+  it('should use application/json when posting an object', done => {
     axios.post('/foo/bar', {
       firstName: 'foo',
       lastName: 'bar'
     });
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       testHeaderValue(request.requestHeaders, 'Content-Type', 'application/json;charset=utf-8');
       done();
     });
   });
 
-  it('should remove content-type if data is empty', function (done) {
+  it('should remove content-type if data is empty', done => {
     axios.post('/foo');
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       testHeaderValue(request.requestHeaders, 'Content-Type', undefined);
       done();
     });
   });
 
-  it('should preserve content-type if data is false', function (done) {
+  it('should preserve content-type if data is false', done => {
     axios.post('/foo', false);
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       testHeaderValue(request.requestHeaders, 'Content-Type', 'application/x-www-form-urlencoded');
       done();
     });

--- a/test/specs/helpers/bind.spec.js
+++ b/test/specs/helpers/bind.spec.js
@@ -1,7 +1,7 @@
 var bind = require('../../../lib/helpers/bind');
 
-describe('bind', function () {
-  it('should bind an object to a function', function () {
+describe('bind', () => {
+  it('should bind an object to a function', () => {
     var o = { val: 123 };
     var f = bind(function (num) {
       return this.val * num;

--- a/test/specs/helpers/buildURL.spec.js
+++ b/test/specs/helpers/buildURL.spec.js
@@ -1,18 +1,18 @@
 var buildURL = require('../../../lib/helpers/buildURL');
 var URLSearchParams = require('url-search-params');
 
-describe('helpers::buildURL', function () {
-  it('should support null params', function () {
+describe('helpers::buildURL', () => {
+  it('should support null params', () => {
     expect(buildURL('/foo')).toEqual('/foo');
   });
 
-  it('should support params', function () {
+  it('should support params', () => {
     expect(buildURL('/foo', {
       foo: 'bar'
     })).toEqual('/foo?foo=bar');
   });
 
-  it('should support object params', function () {
+  it('should support object params', () => {
     expect(buildURL('/foo', {
       foo: {
         bar: 'baz'
@@ -20,7 +20,7 @@ describe('helpers::buildURL', function () {
     })).toEqual('/foo?foo=' + encodeURI('{"bar":"baz"}'));
   });
 
-  it('should support date params', function () {
+  it('should support date params', () => {
     var date = new Date();
 
     expect(buildURL('/foo', {
@@ -28,25 +28,25 @@ describe('helpers::buildURL', function () {
     })).toEqual('/foo?date=' + date.toISOString());
   });
 
-  it('should support array params', function () {
+  it('should support array params', () => {
     expect(buildURL('/foo', {
       foo: ['bar', 'baz']
     })).toEqual('/foo?foo[]=bar&foo[]=baz');
   });
 
-  it('should support special char params', function () {
+  it('should support special char params', () => {
     expect(buildURL('/foo', {
       foo: '@:$, '
     })).toEqual('/foo?foo=@:$,+');
   });
 
-  it('should support existing params', function () {
+  it('should support existing params', () => {
     expect(buildURL('/foo?foo=bar', {
       bar: 'baz'
     })).toEqual('/foo?foo=bar&bar=baz');
   });
 
-  it('should support "length" parameter', function () {
+  it('should support "length" parameter', () => {
     expect(buildURL('/foo', {
       query: 'bar',
       start: 0,
@@ -54,13 +54,13 @@ describe('helpers::buildURL', function () {
     })).toEqual('/foo?query=bar&start=0&length=5');
   });
 
-  it('should correct discard url hash mark', function () {
+  it('should correct discard url hash mark', () => {
     expect(buildURL('/foo?foo=bar#hash', {
       query: 'baz'
     })).toEqual('/foo?foo=bar&query=baz');
   });
 
-  it('should use serializer if provided', function () {
+  it('should use serializer if provided', () => {
     serializer = sinon.stub();
     params = {foo: 'bar'};
     serializer.returns('foo=bar');
@@ -69,7 +69,7 @@ describe('helpers::buildURL', function () {
     expect(serializer.calledWith(params)).toBe(true);
   });
 
-  it('should support URLSearchParams', function () {
+  it('should support URLSearchParams', () => {
     expect(buildURL('/foo', new URLSearchParams('bar=baz'))).toEqual('/foo?bar=baz');
   });
 });

--- a/test/specs/helpers/combineURLs.spec.js
+++ b/test/specs/helpers/combineURLs.spec.js
@@ -1,23 +1,23 @@
 var combineURLs = require('../../../lib/helpers/combineURLs');
 
-describe('helpers::combineURLs', function () {
-  it('should combine URLs', function () {
+describe('helpers::combineURLs', () => {
+  it('should combine URLs', () => {
     expect(combineURLs('https://api.github.com', '/users')).toBe('https://api.github.com/users');
   });
 
-  it('should remove duplicate slashes', function () {
+  it('should remove duplicate slashes', () => {
     expect(combineURLs('https://api.github.com/', '/users')).toBe('https://api.github.com/users');
   });
 
-  it('should insert missing slash', function () {
+  it('should insert missing slash', () => {
     expect(combineURLs('https://api.github.com', 'users')).toBe('https://api.github.com/users');
   });
 
-  it('should not insert slash when relative url missing/empty', function () {
+  it('should not insert slash when relative url missing/empty', () => {
     expect(combineURLs('https://api.github.com/users', '')).toBe('https://api.github.com/users');
   });
 
-  it('should allow a single slash for relative url', function () {
+  it('should allow a single slash for relative url', () => {
     expect(combineURLs('https://api.github.com/users', '/')).toBe('https://api.github.com/users/');
   });
 });

--- a/test/specs/helpers/cookies.spec.js
+++ b/test/specs/helpers/cookies.spec.js
@@ -1,35 +1,33 @@
 var cookies = require('../../../lib/helpers/cookies');
 
-describe('helpers::cookies', function () {
-  afterEach(function () {
+describe('helpers::cookies', () => {
+  afterEach(() => {
     // Remove all the cookies
     var expires = Date.now() - (60 * 60 * 24 * 7);
-    document.cookie.split(';').map(function (cookie) {
-      return cookie.split('=')[0];
-    }).forEach(function (name) {
+    document.cookie.split(';').map(cookie => cookie.split('=')[0]).forEach(name => {
       document.cookie = name + '=; expires=' + new Date(expires).toGMTString();
     });
   });
 
-  it('should write cookies', function () {
+  it('should write cookies', () => {
     cookies.write('foo', 'baz');
     expect(document.cookie).toEqual('foo=baz');
   });
 
-  it('should read cookies', function () {
+  it('should read cookies', () => {
     cookies.write('foo', 'abc');
     cookies.write('bar', 'def');
     expect(cookies.read('foo')).toEqual('abc');
     expect(cookies.read('bar')).toEqual('def');
   });
 
-  it('should remove cookies', function () {
+  it('should remove cookies', () => {
     cookies.write('foo', 'bar');
     cookies.remove('foo');
     expect(cookies.read('foo')).toEqual(null);
   });
 
-  it('should uri encode values', function () {
+  it('should uri encode values', () => {
     cookies.write('foo', 'bar baz%');
     expect(document.cookie).toEqual('foo=bar%20baz%25');
   });

--- a/test/specs/helpers/isAbsoluteURL.spec.js
+++ b/test/specs/helpers/isAbsoluteURL.spec.js
@@ -1,22 +1,22 @@
 var isAbsoluteURL = require('../../../lib/helpers/isAbsoluteURL');
 
-describe('helpers::isAbsoluteURL', function () {
-  it('should return true if URL begins with valid scheme name', function () {
+describe('helpers::isAbsoluteURL', () => {
+  it('should return true if URL begins with valid scheme name', () => {
     expect(isAbsoluteURL('https://api.github.com/users')).toBe(true);
     expect(isAbsoluteURL('custom-scheme-v1.0://example.com/')).toBe(true);
     expect(isAbsoluteURL('HTTP://example.com/')).toBe(true);
   });
 
-  it('should return false if URL begins with invalid scheme name', function () {
+  it('should return false if URL begins with invalid scheme name', () => {
     expect(isAbsoluteURL('123://example.com/')).toBe(false);
     expect(isAbsoluteURL('!valid://example.com/')).toBe(false);
   });
 
-  it('should return true if URL is protocol-relative', function () {
+  it('should return true if URL is protocol-relative', () => {
     expect(isAbsoluteURL('//example.com/')).toBe(true);
   });
 
-  it('should return false if URL is relative', function () {
+  it('should return false if URL is relative', () => {
     expect(isAbsoluteURL('/foo')).toBe(false);
     expect(isAbsoluteURL('foo')).toBe(false);
   });

--- a/test/specs/helpers/isURLSameOrigin.spec.js
+++ b/test/specs/helpers/isURLSameOrigin.spec.js
@@ -1,11 +1,11 @@
 var isURLSameOrigin = require('../../../lib/helpers/isURLSameOrigin');
 
-describe('helpers::isURLSameOrigin', function () {
-  it('should detect same origin', function () {
+describe('helpers::isURLSameOrigin', () => {
+  it('should detect same origin', () => {
     expect(isURLSameOrigin(window.location.href)).toEqual(true);
   });
 
-  it('should detect different origin', function () {
+  it('should detect different origin', () => {
     expect(isURLSameOrigin('https://github.com/axios/axios')).toEqual(false);
   });
 });

--- a/test/specs/helpers/normalizeHeaderName.spec.js
+++ b/test/specs/helpers/normalizeHeaderName.spec.js
@@ -1,7 +1,7 @@
 var normalizeHeaderName = require('../../../lib/helpers/normalizeHeaderName');
 
-describe('helpers::normalizeHeaderName', function () {
-  it('should normalize matching header name', function () {
+describe('helpers::normalizeHeaderName', () => {
+  it('should normalize matching header name', () => {
     var headers = {
       'conTenT-Type': 'foo/bar',
     };
@@ -10,7 +10,7 @@ describe('helpers::normalizeHeaderName', function () {
     expect(headers['conTenT-Type']).toBeUndefined();
   });
 
-  it('should not change non-matching header name', function () {
+  it('should not change non-matching header name', () => {
     var headers = {
       'content-type': 'foo/bar',
     };

--- a/test/specs/helpers/parseHeaders.spec.js
+++ b/test/specs/helpers/parseHeaders.spec.js
@@ -1,7 +1,7 @@
 var parseHeaders = require('../../../lib/helpers/parseHeaders');
 
-describe('helpers::parseHeaders', function () {
-  it('should parse headers', function () {
+describe('helpers::parseHeaders', () =>{
+  it('should parse headers', () =>{
     var date = new Date();
     var parsed = parseHeaders(
       'Date: ' + date.toISOString() + '\n' +
@@ -16,7 +16,7 @@ describe('helpers::parseHeaders', function () {
     expect(parsed['transfer-encoding']).toEqual('chunked');
   });
 
-  it('should use array for set-cookie', function() {
+  it('should use array for set-cookie', () =>{
     var parsedZero = parseHeaders('');
     var parsedSingle = parseHeaders(
       'Set-Cookie: key=val;'
@@ -31,7 +31,7 @@ describe('helpers::parseHeaders', function () {
     expect(parsedMulti['set-cookie']).toEqual(['key=val;', 'key2=val2;']);
   });
 
-  it('should handle duplicates', function() {
+  it('should handle duplicates', () =>{
     var parsed = parseHeaders(
       'Age: age-a\n' + // age is in ignore duplicates blacklist
       'Age: age-b\n' +

--- a/test/specs/helpers/spread.spec.js
+++ b/test/specs/helpers/spread.spec.js
@@ -1,19 +1,17 @@
 var spread = require('../../../lib/helpers/spread');
 
-describe('helpers::spread', function () {
-  it('should spread array to arguments', function () {
+describe('helpers::spread', () => {
+  it('should spread array to arguments', () => {
     var value = 0;
-    spread(function (a, b) {
+    spread((a, b) => {
       value = a * b;
     })([5, 10]);
 
     expect(value).toEqual(50);
   });
 
-  it('should return callback result', function () {
-    var value = spread(function (a, b) {
-      return a * b;
-    })([5, 10]);
+  it('should return callback result', () => {
+    var value = spread((a, b) => a * b)([5, 10]);
 
     expect(value).toEqual(50);
   });

--- a/test/specs/instance.spec.js
+++ b/test/specs/instance.spec.js
@@ -1,13 +1,13 @@
-describe('instance', function () {
-  beforeEach(function () {
+describe('instance', () => {
+  beforeEach(() => {
     jasmine.Ajax.install();
   });
 
-  afterEach(function () {
+  afterEach(() => {
     jasmine.Ajax.uninstall();
   });
 
-  it('should have the same methods as default instance', function () {
+  it('should have the same methods as default instance', () => {
     var instance = axios.create();
 
     for (var prop in axios) {
@@ -26,40 +26,40 @@ describe('instance', function () {
     }
   });
 
-  it('should make an http request without verb helper', function (done) {
+  it('should make an http request without verb helper', done => {
     var instance = axios.create();
 
     instance('/foo');
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       expect(request.url).toBe('/foo');
       done();
     });
   });
 
-  it('should make an http request', function (done) {
+  it('should make an http request', done => {
     var instance = axios.create();
 
     instance.get('/foo');
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       expect(request.url).toBe('/foo');
       done();
     });
   });
 
-  it('should use instance options', function (done) {
+  it('should use instance options', done => {
     var instance = axios.create({ timeout: 1000 });
 
     instance.get('/foo');
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       expect(request.timeout).toBe(1000);
       done();
     });
   });
 
-  it('should have defaults.headers', function () {
+  it('should have defaults.headers', () => {
     var instance = axios.create({
       baseURL: 'https://api.example.com'
     });
@@ -68,29 +68,29 @@ describe('instance', function () {
     expect(typeof instance.defaults.headers.common, 'object');
   });
 
-  it('should have interceptors on the instance', function (done) {
-    axios.interceptors.request.use(function (config) {
+  it('should have interceptors on the instance', done => {
+    axios.interceptors.request.use(config => {
       config.foo = true;
       return config;
     });
 
     var instance = axios.create();
-    instance.interceptors.request.use(function (config) {
+    instance.interceptors.request.use(config => {
       config.bar = true;
       return config;
     });
 
     var response;
-    instance.get('/foo').then(function (res) {
+    instance.get('/foo').then(res => {
       response = res;
     });
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       request.respondWith({
         status: 200
       });
 
-      setTimeout(function () {
+      setTimeout(() => {
         expect(response.config.foo).toEqual(undefined);
         expect(response.config.bar).toEqual(true);
         done();

--- a/test/specs/interceptors.spec.js
+++ b/test/specs/interceptors.spec.js
@@ -1,23 +1,23 @@
-describe('interceptors', function () {
-  beforeEach(function () {
+describe('interceptors', () => {
+  beforeEach(() => {
     jasmine.Ajax.install();
   });
 
-  afterEach(function () {
+  afterEach(() => {
     jasmine.Ajax.uninstall();
     axios.interceptors.request.handlers = [];
     axios.interceptors.response.handlers = [];
   });
 
-  it('should add a request interceptor', function (done) {
-    axios.interceptors.request.use(function (config) {
+  it('should add a request interceptor', done => {
+    axios.interceptors.request.use(config => {
       config.headers.test = 'added by interceptor';
       return config;
     });
 
     axios('/foo');
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       request.respondWith({
         status: 200,
         responseText: 'OK'
@@ -28,59 +28,55 @@ describe('interceptors', function () {
     });
   });
 
-  it('should add a request interceptor that returns a new config object', function (done) {
-    axios.interceptors.request.use(function () {
-      return {
+  it('should add a request interceptor that returns a new config object', done => {
+    axios.interceptors.request.use(() => ({
         url: '/bar',
         method: 'post'
-      };
-    });
+      }));
 
     axios('/foo');
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       expect(request.method).toBe('POST');
       expect(request.url).toBe('/bar');
       done();
     });
   });
 
-  it('should add a request interceptor that returns a promise', function (done) {
-    axios.interceptors.request.use(function (config) {
-      return new Promise(function (resolve) {
+  it('should add a request interceptor that returns a promise', done => {
+    axios.interceptors.request.use(config => new Promise(resolve => {
         // do something async
-        setTimeout(function () {
+        setTimeout(() => {
           config.headers.async = 'promise';
           resolve(config);
         }, 100);
-      });
-    });
+      }));
 
     axios('/foo');
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       expect(request.requestHeaders.async).toBe('promise');
       done();
     });
   });
 
-  it('should add multiple request interceptors', function (done) {
-    axios.interceptors.request.use(function (config) {
+  it('should add multiple request interceptors', done => {
+    axios.interceptors.request.use(config => {
       config.headers.test1 = '1';
       return config;
     });
-    axios.interceptors.request.use(function (config) {
+    axios.interceptors.request.use(config => {
       config.headers.test2 = '2';
       return config;
     });
-    axios.interceptors.request.use(function (config) {
+    axios.interceptors.request.use(config => {
       config.headers.test3 = '3';
       return config;
     });
 
     axios('/foo');
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       expect(request.requestHeaders.test1).toBe('1');
       expect(request.requestHeaders.test2).toBe('2');
       expect(request.requestHeaders.test3).toBe('3');
@@ -88,157 +84,151 @@ describe('interceptors', function () {
     });
   });
 
-  it('should add a response interceptor', function (done) {
+  it('should add a response interceptor', done => {
     var response;
 
-    axios.interceptors.response.use(function (data) {
+    axios.interceptors.response.use(data => {
       data.data = data.data + ' - modified by interceptor';
       return data;
     });
 
-    axios('/foo').then(function (data) {
+    axios('/foo').then(data => {
       response = data;
     });
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       request.respondWith({
         status: 200,
         responseText: 'OK'
       });
 
-      setTimeout(function () {
+      setTimeout(() => {
         expect(response.data).toBe('OK - modified by interceptor');
         done();
       }, 100);
     });
   });
 
-  it('should add a response interceptor that returns a new data object', function (done) {
+  it('should add a response interceptor that returns a new data object', done => {
     var response;
 
-    axios.interceptors.response.use(function () {
-      return {
-        data: 'stuff'
-      };
-    });
+    axios.interceptors.response.use(() => ({data: 'stuff'}));
 
-    axios('/foo').then(function (data) {
+    axios('/foo').then(data => {
       response = data;
     });
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       request.respondWith({
         status: 200,
         responseText: 'OK'
       });
 
-      setTimeout(function () {
+      setTimeout(() => {
         expect(response.data).toBe('stuff');
         done();
       }, 100);
     });
   });
 
-  it('should add a response interceptor that returns a promise', function (done) {
+  it('should add a response interceptor that returns a promise', done => {
     var response;
 
-    axios.interceptors.response.use(function (data) {
-      return new Promise(function (resolve) {
+    axios.interceptors.response.use(data => new Promise(resolve => {
         // do something async
-        setTimeout(function () {
+        setTimeout(() => {
           data.data = 'you have been promised!';
           resolve(data);
         }, 10);
-      });
-    });
+      }));
 
-    axios('/foo').then(function (data) {
+    axios('/foo').then(data => {
       response = data;
     });
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       request.respondWith({
         status: 200,
         responseText: 'OK'
       });
 
-      setTimeout(function () {
+      setTimeout(() => {
         expect(response.data).toBe('you have been promised!');
         done();
       }, 100);
     });
   });
 
-  it('should add multiple response interceptors', function (done) {
+  it('should add multiple response interceptors', done => {
     var response;
 
-    axios.interceptors.response.use(function (data) {
+    axios.interceptors.response.use(data => {
       data.data = data.data + '1';
       return data;
     });
-    axios.interceptors.response.use(function (data) {
+    axios.interceptors.response.use(data => {
       data.data = data.data + '2';
       return data;
     });
-    axios.interceptors.response.use(function (data) {
+    axios.interceptors.response.use(data => {
       data.data = data.data + '3';
       return data;
     });
 
-    axios('/foo').then(function (data) {
+    axios('/foo').then(data => {
       response = data;
     });
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       request.respondWith({
         status: 200,
         responseText: 'OK'
       });
 
-      setTimeout(function () {
+      setTimeout(() => {
         expect(response.data).toBe('OK123');
         done();
       }, 100);
     });
   });
 
-  it('should allow removing interceptors', function (done) {
+  it('should allow removing interceptors', done => {
     var response, intercept;
 
-    axios.interceptors.response.use(function (data) {
+    axios.interceptors.response.use(data => {
       data.data = data.data + '1';
       return data;
     });
-    intercept = axios.interceptors.response.use(function (data) {
+    intercept = axios.interceptors.response.use(data => {
       data.data = data.data + '2';
       return data;
     });
-    axios.interceptors.response.use(function (data) {
+    axios.interceptors.response.use(data => {
       data.data = data.data + '3';
       return data;
     });
 
     axios.interceptors.response.eject(intercept);
 
-    axios('/foo').then(function (data) {
+    axios('/foo').then(data => {
       response = data;
     });
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       request.respondWith({
         status: 200,
         responseText: 'OK'
       });
 
-      setTimeout(function () {
+      setTimeout(() => {
         expect(response.data).toBe('OK13');
         done();
       }, 100);
     });
   });
 
-  it('should execute interceptors before transformers', function (done) {
-    axios.interceptors.request.use(function (config) {
+  it('should execute interceptors before transformers', done => {
+    axios.interceptors.request.use(config => {
       config.data.baz = 'qux';
       return config;
     });
@@ -247,25 +237,25 @@ describe('interceptors', function () {
       foo: 'bar'
     });
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       expect(request.params).toEqual('{"foo":"bar","baz":"qux"}');
       done();
     });
   });
 
-  it('should modify base URL in request interceptor', function (done) {
+  it('should modify base URL in request interceptor', done => {
     var instance = axios.create({
       baseURL: 'http://test.com/'
     });
 
-    instance.interceptors.request.use(function (config) {
+    instance.interceptors.request.use(config => {
       config.baseURL = 'http://rebase.com/';
       return config;
     });
 
     instance.get('/foo');
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       expect(request.url).toBe('http://rebase.com/foo');
       done();
     });

--- a/test/specs/options.spec.js
+++ b/test/specs/options.spec.js
@@ -1,35 +1,35 @@
-describe('options', function () {
-  beforeEach(function () {
+describe('options', () => {
+  beforeEach(() => {
     jasmine.Ajax.install();
   });
 
-  afterEach(function () {
+  afterEach(() => {
     jasmine.Ajax.uninstall();
   });
 
-  it('should default method to get', function (done) {
+  it('should default method to get', done => {
     axios('/foo');
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       expect(request.method).toBe('GET');
       done();
     });
   });
 
-  it('should accept headers', function (done) {
+  it('should accept headers', done => {
     axios('/foo', {
       headers: {
         'X-Requested-With': 'XMLHttpRequest'
       }
     });
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       expect(request.requestHeaders['X-Requested-With']).toEqual('XMLHttpRequest');
       done();
     });
   });
 
-  it('should accept params', function (done) {
+  it('should accept params', done => {
     axios('/foo', {
       params: {
         foo: 123,
@@ -37,52 +37,52 @@ describe('options', function () {
       }
     });
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       expect(request.url).toBe('/foo?foo=123&bar=456');
       done();
     });
   });
 
-  it('should allow overriding default headers', function (done) {
+  it('should allow overriding default headers', done => {
     axios('/foo', {
       headers: {
         'Accept': 'foo/bar'
       }
     });
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       expect(request.requestHeaders['Accept']).toEqual('foo/bar');
       done();
     });
   });
 
-  it('should accept base URL', function (done) {
+  it('should accept base URL', done => {
     var instance = axios.create({
       baseURL: 'http://test.com/'
     });
 
     instance.get('/foo');
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       expect(request.url).toBe('http://test.com/foo');
       done();
     });
   });
 
-  it('should ignore base URL if request URL is absolute', function (done) {
+  it('should ignore base URL if request URL is absolute', done => {
     var instance = axios.create({
       baseURL: 'http://someurl.com/'
     });
 
     instance.get('http://someotherurl.com/');
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       expect(request.url).toBe('http://someotherurl.com/');
       done();
     });
   });
 
-  it('should change only the baseURL of the specified instance', function() {
+  it('should change only the baseURL of the specified instance', () => {
     var instance1 = axios.create();
     var instance2 = axios.create();
 
@@ -91,7 +91,7 @@ describe('options', function () {
     expect(instance2.defaults.baseURL).not.toBe('http://instance1.example.com/');
   });
 
-  it('should change only the headers of the specified instance', function() {
+  it('should change only the headers of the specified instance', () => {
     var instance1 = axios.create();
     var instance2 = axios.create();
 

--- a/test/specs/progress.spec.js
+++ b/test/specs/progress.spec.js
@@ -1,18 +1,18 @@
-describe('progress events', function () {
-  beforeEach(function () {
+describe('progress events', () => {
+  beforeEach(() => {
     jasmine.Ajax.install();
   });
 
-  afterEach(function () {
+  afterEach(() => {
     jasmine.Ajax.uninstall();
   });
 
-  it('should add a download progress handler', function (done) {
+  it('should add a download progress handler', done => {
     var progressSpy = jasmine.createSpy('progress');
 
     axios('/foo', { onDownloadProgress: progressSpy } );
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       request.respondWith({
         status: 200,
         responseText: '{"foo": "bar"}'
@@ -22,25 +22,25 @@ describe('progress events', function () {
     });
   });
 
-  it('should add a upload progress handler', function (done) {
+  it('should add a upload progress handler', done => {
     var progressSpy = jasmine.createSpy('progress');
 
     axios('/foo', { onUploadProgress: progressSpy } );
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       // Jasmine AJAX doesn't trigger upload events. Waiting for upstream fix
       // expect(progressSpy).toHaveBeenCalled();
       done();
     });
   });
 
-  it('should add both upload and download progress handlers', function (done) {
+  it('should add both upload and download progress handlers', done => {
     var downloadProgressSpy = jasmine.createSpy('downloadProgress');
     var uploadProgressSpy = jasmine.createSpy('uploadProgress');
 
     axios('/foo', { onDownloadProgress: downloadProgressSpy, onUploadProgress: uploadProgressSpy });
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       // expect(uploadProgressSpy).toHaveBeenCalled();
       expect(downloadProgressSpy).not.toHaveBeenCalled();
       request.respondWith({
@@ -52,7 +52,7 @@ describe('progress events', function () {
     });
   });
 
-  it('should add a download progress handler from instance config', function (done) {
+  it('should add a download progress handler from instance config', done => {
     var progressSpy = jasmine.createSpy('progress');
 
     var instance = axios.create({
@@ -61,7 +61,7 @@ describe('progress events', function () {
 
     instance.get('/foo');
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       request.respondWith({
         status: 200,
         responseText: '{"foo": "bar"}'
@@ -71,7 +71,7 @@ describe('progress events', function () {
     });
   });
 
-  it('should add a upload progress handler from instance config', function (done) {
+  it('should add a upload progress handler from instance config', done => {
     var progressSpy = jasmine.createSpy('progress');
 
     var instance = axios.create({
@@ -80,13 +80,13 @@ describe('progress events', function () {
 
     instance.get('/foo');
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       // expect(progressSpy).toHaveBeenCalled();
       done();
     });
   });
 
-  it('should add upload and download progress handlers from instance config', function (done) {
+  it('should add upload and download progress handlers from instance config', done => {
     var downloadProgressSpy = jasmine.createSpy('downloadProgress');
     var uploadProgressSpy = jasmine.createSpy('uploadProgress');
 
@@ -97,7 +97,7 @@ describe('progress events', function () {
 
     instance.get('/foo');
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       // expect(uploadProgressSpy).toHaveBeenCalled();
       expect(downloadProgressSpy).not.toHaveBeenCalled();
       request.respondWith({

--- a/test/specs/promise.spec.js
+++ b/test/specs/promise.spec.js
@@ -1,26 +1,26 @@
-describe('promise', function () {
-  beforeEach(function () {
+describe('promise', () => {
+  beforeEach(() => {
     jasmine.Ajax.install();
   });
 
-  afterEach(function () {
+  afterEach(() => {
     jasmine.Ajax.uninstall();
   });
 
-  it('should provide succinct object to then', function (done) {
+  it('should provide succinct object to then', done => {
     var response;
 
-    axios('/foo').then(function (r) {
+    axios('/foo').then(r => {
       response = r;
     });
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       request.respondWith({
         status: 200,
         responseText: '{"hello":"world"}'
       });
 
-      setTimeout(function () {
+      setTimeout(() => {
         expect(typeof response).toEqual('object');
         expect(response.data.hello).toEqual('world');
         expect(response.status).toEqual(200);
@@ -31,36 +31,36 @@ describe('promise', function () {
     });
   });
 
-  it('should support all', function (done) {
+  it('should support all', done => {
     var fulfilled = false;
 
-    axios.all([true, 123]).then(function () {
+    axios.all([true, 123]).then(() => {
       fulfilled = true;
     });
 
-    setTimeout(function () {
+    setTimeout(() => {
       expect(fulfilled).toEqual(true);
       done();
     }, 100);
   });
 
-  it('should support spread', function (done) {
+  it('should support spread', done => {
     var sum = 0;
     var fulfilled = false;
     var result;
 
     axios
       .all([123, 456])
-      .then(axios.spread(function (a, b) {
+      .then(axios.spread((a, b) => {
         sum = a + b;
         fulfilled = true;
         return 'hello world';
       }))
-      .then(function (res) {
+      .then(res => {
         result = res;
       });
 
-    setTimeout(function () {
+    setTimeout(() => {
       expect(fulfilled).toEqual(true);
       expect(sum).toEqual(123 + 456);
       expect(result).toEqual('hello world');

--- a/test/specs/requests.spec.js
+++ b/test/specs/requests.spec.js
@@ -1,65 +1,65 @@
-describe('requests', function () {
-  beforeEach(function () {
+describe('requests', () => {
+  beforeEach(() => {
     jasmine.Ajax.install();
   });
 
-  afterEach(function () {
+  afterEach(() => {
     jasmine.Ajax.uninstall();
   });
 
-  it('should treat single string arg as url', function (done) {
+  it('should treat single string arg as url', done => {
     axios('/foo');
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       expect(request.url).toBe('/foo');
       expect(request.method).toBe('GET');
       done();
     });
   });
 
-  it('should treat method value as lowercase string', function (done) {
+  it('should treat method value as lowercase string', done => {
     axios({
       url: '/foo',
       method: 'POST'
-    }).then(function (response) {
+    }).then(response => {
       expect(response.config.method).toBe('post');
       done();
     });
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       request.respondWith({
         status: 200
       });
     });
   });
 
-  it('should allow string arg as url, and config arg', function (done) {
+  it('should allow string arg as url, and config arg', done => {
     axios.post('/foo');
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       expect(request.url).toBe('/foo');
       expect(request.method).toBe('POST');
       done();
     });
   });
 
-  it('should make an http request', function (done) {
+  it('should make an http request', done => {
     axios('/foo');
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       expect(request.url).toBe('/foo');
       done();
     });
   });
 
-  it('should reject on network errors', function (done) {
+  it('should reject on network errors', done => {
     // disable jasmine.Ajax since we're hitting a non-existant server anyway
     jasmine.Ajax.uninstall();
 
     var resolveSpy = jasmine.createSpy('resolve');
     var rejectSpy = jasmine.createSpy('reject');
 
-    var finish = function () {
+    var finish = () => {
       expect(resolveSpy).not.toHaveBeenCalled();
       expect(rejectSpy).toHaveBeenCalled();
       var reason = rejectSpy.calls.first().args[0];
@@ -79,11 +79,11 @@ describe('requests', function () {
       .then(finish, finish);
   });
 
-  it('should reject on abort', function (done) {
+  it('should reject on abort', done => {
     var resolveSpy = jasmine.createSpy('resolve');
     var rejectSpy = jasmine.createSpy('reject');
 
-    var finish = function () {
+    var finish = () => {
       expect(resolveSpy).not.toHaveBeenCalled();
       expect(rejectSpy).toHaveBeenCalled();
       var reason = rejectSpy.calls.first().args[0];
@@ -99,22 +99,20 @@ describe('requests', function () {
       .then(resolveSpy, rejectSpy)
       .then(finish, finish);
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       request.abort();
     });
   });
 
-  it('should reject when validateStatus returns false', function (done) {
+  it('should reject when validateStatus returns false', done => {
     var resolveSpy = jasmine.createSpy('resolve');
     var rejectSpy = jasmine.createSpy('reject');
 
     axios('/foo', {
-      validateStatus: function (status) {
-        return status !== 500;
-      }
+      validateStatus: status => status !== 500
     }).then(resolveSpy)
       .catch(rejectSpy)
-      .then(function () {
+      .then(() => {
         expect(resolveSpy).not.toHaveBeenCalled();
         expect(rejectSpy).toHaveBeenCalled();
         var reason = rejectSpy.calls.first().args[0];
@@ -127,30 +125,28 @@ describe('requests', function () {
         done();
       });
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       request.respondWith({
         status: 500
       });
     });
   });
 
-  it('should resolve when validateStatus returns true', function (done) {
+  it('should resolve when validateStatus returns true', done => {
     var resolveSpy = jasmine.createSpy('resolve');
     var rejectSpy = jasmine.createSpy('reject');
 
     axios('/foo', {
-      validateStatus: function (status) {
-        return status === 500;
-      }
+      validateStatus: status => status === 500
     }).then(resolveSpy)
       .catch(rejectSpy)
-      .then(function () {
+      .then(() => {
         expect(resolveSpy).toHaveBeenCalled();
         expect(rejectSpy).not.toHaveBeenCalled();
         done();
       });
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       request.respondWith({
         status: 500
       });
@@ -158,7 +154,7 @@ describe('requests', function () {
   });
 
   // https://github.com/axios/axios/issues/378
-  it('should return JSON when rejecting', function (done) {
+  it('should return JSON when rejecting', done => {
     var response;
 
     axios('/api/account/signup', {
@@ -170,18 +166,18 @@ describe('requests', function () {
         'Accept': 'application/json'
       }
     })
-    .catch(function (error) {
+    .catch(error => {
       response = error.response;
     });
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       request.respondWith({
         status: 400,
         statusText: 'Bad Request',
         responseText: '{"error": "BAD USERNAME", "code": 1}'
       });
 
-      setTimeout(function () {
+      setTimeout(() => {
         expect(typeof response.data).toEqual('object');
         expect(response.data.error).toEqual('BAD USERNAME');
         expect(response.data.code).toEqual(1);
@@ -190,14 +186,14 @@ describe('requests', function () {
     });
   });
 
-  it('should make cross domian http request', function (done) {
+  it('should make cross domian http request', done => {
     var response;
 
-    axios.post('www.someurl.com/foo').then(function(res){
+    axios.post('www.someurl.com/foo').then(res => {
       response = res;
     });
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       request.respondWith({
         status: 200,
         statusText: 'OK',
@@ -207,7 +203,7 @@ describe('requests', function () {
         }
       });
 
-      setTimeout(function () {
+      setTimeout(() => {
         expect(response.data.foo).toEqual('bar');
         expect(response.status).toEqual(200);
         expect(response.statusText).toEqual('OK');
@@ -218,14 +214,14 @@ describe('requests', function () {
   });
 
 
-  it('should supply correct response', function (done) {
+  it('should supply correct response', done => {
     var response;
 
-    axios.post('/foo').then(function (res) {
+    axios.post('/foo').then(res => {
       response = res;
     });
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       request.respondWith({
         status: 200,
         statusText: 'OK',
@@ -235,7 +231,7 @@ describe('requests', function () {
         }
       });
 
-      setTimeout(function () {
+      setTimeout(() => {
         expect(response.data.foo).toEqual('bar');
         expect(response.status).toEqual(200);
         expect(response.statusText).toEqual('OK');
@@ -245,7 +241,7 @@ describe('requests', function () {
     });
   });
 
-  it('should allow overriding Content-Type header case-insensitive', function (done) {
+  it('should allow overriding Content-Type header case-insensitive', done => {
     var response;
     var contentType = 'application/vnd.myapp.type+json';
 
@@ -253,24 +249,24 @@ describe('requests', function () {
       headers: {
         'content-type': contentType
       }
-    }).then(function (res) {
+    }).then(res => {
       response = res;
     });
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       expect(request.requestHeaders['Content-Type']).toEqual(contentType);
       done();
     });
   });
 
-  it('should support binary data as array buffer', function (done) {
+  it('should support binary data as array buffer', done => {
     var input = new Int8Array(2);
     input[0] = 1;
     input[1] = 2;
 
     axios.post('/foo', input.buffer);
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       var output = new Int8Array(request.params);
       expect(output.length).toEqual(2);
       expect(output[0]).toEqual(1);
@@ -279,14 +275,14 @@ describe('requests', function () {
     });
   });
 
-  it('should support binary data as array buffer view', function (done) {
+  it('should support binary data as array buffer view', done => {
     var input = new Int8Array(2);
     input[0] = 1;
     input[1] = 2;
 
     axios.post('/foo', input);
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       var output = new Int8Array(request.params);
       expect(output.length).toEqual(2);
       expect(output[0]).toEqual(1);
@@ -295,7 +291,7 @@ describe('requests', function () {
     });
   });
 
-  it('should support array buffer response', function (done) {
+  it('should support array buffer response', done => {
     var response;
 
     function str2ab(str) {
@@ -309,31 +305,31 @@ describe('requests', function () {
 
     axios('/foo', {
       responseType: 'arraybuffer'
-    }).then(function (data) {
+    }).then(data => {
       response = data;
     });
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       request.respondWith({
         status: 200,
         response: str2ab('Hello world')
       });
 
-      setTimeout(function () {
+      setTimeout(() => {
         expect(response.data.byteLength).toBe(22);
         done();
       }, 100);
     });
   });
 
-  it('should support URLSearchParams', function (done) {
+  it('should support URLSearchParams', done => {
     var params = new URLSearchParams();
     params.append('param1', 'value1');
     params.append('param2', 'value2');
 
     axios.post('/foo', params);
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       expect(request.requestHeaders['Content-Type']).toBe('application/x-www-form-urlencoded;charset=utf-8');
       expect(request.params).toBe('param1=value1&param2=value2');
       done();

--- a/test/specs/transform.spec.js
+++ b/test/specs/transform.spec.js
@@ -1,39 +1,39 @@
-describe('transform', function () {
-  beforeEach(function () {
+describe('transform', () => {
+  beforeEach(() => {
     jasmine.Ajax.install();
   });
 
-  afterEach(function () {
+  afterEach(() => {
     jasmine.Ajax.uninstall();
   });
 
-  it('should transform JSON to string', function (done) {
+  it('should transform JSON to string', done => {
     var data = {
       foo: 'bar'
     };
 
     axios.post('/foo', data);
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       expect(request.params).toEqual('{"foo":"bar"}');
       done();
     });
   });
 
-  it('should transform string to JSON', function (done) {
+  it('should transform string to JSON', done => {
     var response;
 
-    axios('/foo').then(function (data) {
+    axios('/foo').then(data => {
       response = data;
     });
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       request.respondWith({
         status: 200,
         responseText: '{"foo": "bar"}'
       });
 
-      setTimeout(function () {
+      setTimeout(() => {
         expect(typeof response.data).toEqual('object');
         expect(response.data.foo).toEqual('bar');
         done();
@@ -41,52 +41,48 @@ describe('transform', function () {
     });
   });
 
-  it('should override default transform', function (done) {
+  it('should override default transform', done => {
     var data = {
       foo: 'bar'
     };
 
     axios.post('/foo', data, {
-      transformRequest: function (data) {
-        return data;
-      }
+      transformRequest: data => data
     });
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       expect(typeof request.params).toEqual('object');
       done();
     });
   });
 
-  it('should allow an Array of transformers', function (done) {
+  it('should allow an Array of transformers', done => {
     var data = {
       foo: 'bar'
     };
 
     axios.post('/foo', data, {
       transformRequest: axios.defaults.transformRequest.concat(
-        function (data) {
-          return data.replace('bar', 'baz');
-        }
+        data => data.replace('bar', 'baz')
       )
     });
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       expect(request.params).toEqual('{"foo":"baz"}');
       done();
     });
   });
 
-  it('should allowing mutating headers', function (done) {
+  it('should allowing mutating headers', done => {
     var token = Math.floor(Math.random() * Math.pow(2, 64)).toString(36);
 
     axios('/foo', {
-      transformRequest: function (data, headers) {
+      transformRequest: (data, headers) => {
         headers['X-Authorization'] = token;
       }
     });
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       expect(request.requestHeaders['X-Authorization']).toEqual(token);
       done();
     });

--- a/test/specs/utils/deepMerge.spec.js
+++ b/test/specs/utils/deepMerge.spec.js
@@ -1,7 +1,7 @@
 var deepMerge = require('../../../lib/utils').deepMerge;
 
-describe('utils::deepMerge', function () {
-  it('should be immutable', function () {
+describe('utils::deepMerge', () => {
+  it('should be immutable', () => {
     var a = {};
     var b = {foo: 123};
     var c = {bar: 456};
@@ -14,7 +14,7 @@ describe('utils::deepMerge', function () {
     expect(typeof c.foo).toEqual('undefined');
   });
 
-  it('should deepMerge properties', function () {
+  it('should deepMerge properties', () => {
     var a = {foo: 123};
     var b = {bar: 456};
     var c = {foo: 789};
@@ -24,7 +24,7 @@ describe('utils::deepMerge', function () {
     expect(d.bar).toEqual(456);
   });
 
-  it('should deepMerge recursively', function () {
+  it('should deepMerge recursively', () => {
     var a = {foo: {bar: 123}};
     var b = {foo: {baz: 456}, bar: {qux: 789}};
 
@@ -39,7 +39,7 @@ describe('utils::deepMerge', function () {
     });
   });
 
-  it('should remove all references from nested objects', function () {
+  it('should remove all references from nested objects', () => {
     var a = {foo: {bar: 123}};
     var b = {};
     var d = deepMerge(a, b);
@@ -53,7 +53,7 @@ describe('utils::deepMerge', function () {
     expect(d.foo).not.toBe(a.foo);
   });
 
-  it('handles null and undefined arguments', function () {
+  it('handles null and undefined arguments', () => {
     expect(deepMerge(undefined, undefined)).toEqual({});
     expect(deepMerge(undefined, {foo: 123})).toEqual({foo: 123});
     expect(deepMerge({foo: 123}, undefined)).toEqual({foo: 123});

--- a/test/specs/utils/extend.spec.js
+++ b/test/specs/utils/extend.spec.js
@@ -1,7 +1,7 @@
 var extend = require('../../../lib/utils').extend;
 
-describe('utils::extend', function () {
-  it('should be mutable', function () {
+describe('utils::extend', () => {
+  it('should be mutable', () => {
     var a = {};
     var b = {foo: 123};
 
@@ -10,7 +10,7 @@ describe('utils::extend', function () {
     expect(a.foo).toEqual(b.foo);
   });
   
-  it('should extend properties', function () {
+  it('should extend properties', () => {
     var a = {foo: 123, bar: 456};
     var b = {bar: 789};
 
@@ -20,7 +20,7 @@ describe('utils::extend', function () {
     expect(a.bar).toEqual(789);
   });
 
-  it('should bind to thisArg', function () {
+  it('should bind to thisArg', () => {
     var a = {};
     var b = {getFoo: function getFoo() { return this.foo; }};
     var thisArg = { foo: 'barbaz' };

--- a/test/specs/utils/forEach.spec.js
+++ b/test/specs/utils/forEach.spec.js
@@ -1,17 +1,17 @@
 var forEach = require('../../../lib/utils').forEach;
 
-describe('utils::forEach', function () {
-  it('should loop over an array', function () {
+describe('utils::forEach', () => {
+  it('should loop over an array', () => {
     var sum = 0;
 
-    forEach([1, 2, 3, 4, 5], function (val) {
+    forEach([1, 2, 3, 4, 5], val => {
       sum += val;
     });
 
     expect(sum).toEqual(15);
   });
 
-  it('should loop over object keys', function () {
+  it('should loop over object keys', () => {
     var keys = '';
     var vals = 0;
     var obj = {
@@ -20,7 +20,7 @@ describe('utils::forEach', function () {
       r: 3
     };
 
-    forEach(obj, function (v, k) {
+    forEach(obj, (v, k) => {
       keys += k;
       vals += v;
     });
@@ -29,32 +29,32 @@ describe('utils::forEach', function () {
     expect(vals).toEqual(6);
   });
 
-  it('should handle undefined gracefully', function () {
+  it('should handle undefined gracefully', () => {
     var count = 0;
 
-    forEach(undefined, function () {
+    forEach(undefined, () => {
       count++;
     });
 
     expect(count).toEqual(0);
   });
 
-  it('should make an array out of non-array argument', function () {
+  it('should make an array out of non-array argument', () => {
     var count = 0;
 
-    forEach(function () {}, function () {
+    forEach(() => {}, () => {
       count++;
     });
 
     expect(count).toEqual(1);
   });
 
-  it('should handle non object prototype gracefully', function () {
+  it('should handle non object prototype gracefully', () => {
     var count = 0;
     var data = Object.create(null);
     data.foo = 'bar'
 
-    forEach(data, function () {
+    forEach(data, () => {
       count++;
     });
 

--- a/test/specs/utils/isX.spec.js
+++ b/test/specs/utils/isX.spec.js
@@ -1,65 +1,65 @@
 var utils = require('../../../lib/utils');
 var Stream = require('stream');
 
-describe('utils::isX', function () {
-  it('should validate Array', function () {
+describe('utils::isX', () => {
+  it('should validate Array', () => {
     expect(utils.isArray([])).toEqual(true);
     expect(utils.isArray({length: 5})).toEqual(false);
   });
 
-  it('should validate ArrayBuffer', function () {
+  it('should validate ArrayBuffer', () => {
     expect(utils.isArrayBuffer(new ArrayBuffer(2))).toEqual(true);
     expect(utils.isArrayBuffer({})).toEqual(false);
   });
 
-  it('should validate ArrayBufferView', function () {
+  it('should validate ArrayBufferView', () => {
     expect(utils.isArrayBufferView(new DataView(new ArrayBuffer(2)))).toEqual(true);
   });
 
-  it('should validate FormData', function () {
+  it('should validate FormData', () => {
     expect(utils.isFormData(new FormData())).toEqual(true);
   });
 
-  it('should validate Blob', function () {
+  it('should validate Blob', () => {
     expect(utils.isBlob(new Blob())).toEqual(true);
   });
 
-  it('should validate String', function () {
+  it('should validate String', () => {
     expect(utils.isString('')).toEqual(true);
-    expect(utils.isString({toString: function () { return ''; }})).toEqual(false);
+    expect(utils.isString({toString: () => ''})).toEqual(false);
   });
 
-  it('should validate Number', function () {
+  it('should validate Number', () => {
     expect(utils.isNumber(123)).toEqual(true);
     expect(utils.isNumber('123')).toEqual(false);
   });
 
-  it('should validate Undefined', function () {
+  it('should validate Undefined', () => {
     expect(utils.isUndefined()).toEqual(true);
     expect(utils.isUndefined(null)).toEqual(false);
   });
 
-  it('should validate Object', function () {
+  it('should validate Object', () => {
     expect(utils.isObject({})).toEqual(true);
     expect(utils.isObject(null)).toEqual(false);
   });
 
-  it('should validate Date', function () {
+  it('should validate Date', () => {
     expect(utils.isDate(new Date())).toEqual(true);
     expect(utils.isDate(Date.now())).toEqual(false);
   });
 
-  it('should validate Function', function () {
-    expect(utils.isFunction(function () {})).toEqual(true);
+  it('should validate Function', () => {
+    expect(utils.isFunction(() => {})).toEqual(true);
     expect(utils.isFunction('function')).toEqual(false);
   });
 
-  it('should validate Stream', function () {
+  it('should validate Stream', () => {
     expect(utils.isStream(new Stream.Readable())).toEqual(true);
     expect(utils.isStream({ foo: 'bar' })).toEqual(false);
   });
 
-  it('should validate URLSearchParams', function () {
+  it('should validate URLSearchParams', () => {
     expect(utils.isURLSearchParams(new URLSearchParams())).toEqual(true);
     expect(utils.isURLSearchParams('foo=1&bar=2')).toEqual(false);
   });

--- a/test/specs/utils/merge.spec.js
+++ b/test/specs/utils/merge.spec.js
@@ -1,7 +1,7 @@
 var merge = require('../../../lib/utils').merge;
 
-describe('utils::merge', function () {
-  it('should be immutable', function () {
+describe('utils::merge', () => {
+  it('should be immutable', () => {
     var a = {};
     var b = {foo: 123};
     var c = {bar: 456};
@@ -14,7 +14,7 @@ describe('utils::merge', function () {
     expect(typeof c.foo).toEqual('undefined');
   });
   
-  it('should merge properties', function () {
+  it('should merge properties', () => {
     var a = {foo: 123};
     var b = {bar: 456};
     var c = {foo: 789};
@@ -24,7 +24,7 @@ describe('utils::merge', function () {
     expect(d.bar).toEqual(456);
   });
 
-  it('should merge recursively', function () {
+  it('should merge recursively', () => {
     var a = {foo: {bar: 123}};
     var b = {foo: {baz: 456}, bar: {qux: 789}};
     

--- a/test/specs/utils/trim.spec.js
+++ b/test/specs/utils/trim.spec.js
@@ -1,11 +1,11 @@
 var trim = require('../../../lib/utils').trim;
 
-describe('utils::trim', function () {
-  it('should trim spaces', function () {
+describe('utils::trim', () => {
+  it('should trim spaces', () => {
     expect(trim('  foo  ')).toEqual('foo');
   });
 
-  it('should trim tabs', function () {
+  it('should trim tabs', () => {
     expect(trim('\tfoo\t')).toEqual('foo');
   });
 });

--- a/test/specs/xsrf.spec.js
+++ b/test/specs/xsrf.spec.js
@@ -1,80 +1,80 @@
 var cookies = require('../../lib/helpers/cookies');
 
-describe('xsrf', function () {
-  beforeEach(function () {
+describe('xsrf', () => {
+  beforeEach(() => {
     jasmine.Ajax.install();
   });
 
-  afterEach(function () {
+  afterEach(() => {
     document.cookie = axios.defaults.xsrfCookieName + '=;expires=' + new Date(Date.now() - 86400000).toGMTString();
     jasmine.Ajax.uninstall();
   });
 
-  it('should not set xsrf header if cookie is null', function (done) {
+  it('should not set xsrf header if cookie is null', done => {
     axios('/foo');
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       expect(request.requestHeaders[axios.defaults.xsrfHeaderName]).toEqual(undefined);
       done();
     });
   });
 
-  it('should set xsrf header if cookie is set', function (done) {
+  it('should set xsrf header if cookie is set', done => {
     document.cookie = axios.defaults.xsrfCookieName + '=12345';
 
     axios('/foo');
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       expect(request.requestHeaders[axios.defaults.xsrfHeaderName]).toEqual('12345');
       done();
     });
   });
 
-  it('should not set xsrf header if xsrfCookieName is null', function (done) {
+  it('should not set xsrf header if xsrfCookieName is null', done => {
     document.cookie = axios.defaults.xsrfCookieName + '=12345';
 
     axios('/foo', {
       xsrfCookieName: null
     });
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       expect(request.requestHeaders[axios.defaults.xsrfHeaderName]).toEqual(undefined);
       done();
     });
   });
 
-  it('should not read cookies at all if xsrfCookieName is null', function (done) {
+  it('should not read cookies at all if xsrfCookieName is null', done => {
     spyOn(cookies, "read");
 
     axios('/foo', {
       xsrfCookieName: null
     });
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       expect(cookies.read).not.toHaveBeenCalled();
       done();
     });
   });
 
-  it('should not set xsrf header for cross origin', function (done) {
+  it('should not set xsrf header for cross origin', done => {
     document.cookie = axios.defaults.xsrfCookieName + '=12345';
 
     axios('http://example.com/');
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       expect(request.requestHeaders[axios.defaults.xsrfHeaderName]).toEqual(undefined);
       done();
     });
   });
 
-  it('should set xsrf header for cross origin when using withCredentials', function (done) {
+  it('should set xsrf header for cross origin when using withCredentials', done => {
     document.cookie = axios.defaults.xsrfCookieName + '=12345';
 
     axios('http://example.com/', {
       withCredentials: true
     });
 
-    getAjaxRequest().then(function (request) {
+    getAjaxRequest().then(request => {
       expect(request.requestHeaders[axios.defaults.xsrfHeaderName]).toEqual('12345');
       done();
     });

--- a/test/unit/adapters/http.js
+++ b/test/unit/adapters/http.js
@@ -7,9 +7,9 @@ var assert = require('assert');
 var fs = require('fs');
 var server, proxy;
 
-describe('supports http with nodejs', function () {
+describe('supports http with nodejs', () => {
 
-  afterEach(function () {
+  afterEach(() => {
     if (server) {
       server.close();
       server = null;
@@ -26,26 +26,26 @@ describe('supports http with nodejs', function () {
     }
   });
 
-  it('should respect the timeout property', function (done) {
+  it('should respect the timeout property', done => {
 
-    server = http.createServer(function (req, res) {
-      setTimeout(function () {
+    server = http.createServer((req, res) => {
+      setTimeout(() => {
         res.end();
       }, 1000);
-    }).listen(4444, function () {
+    }).listen(4444, () => {
       var success = false, failure = false;
       var error;
 
       axios.get('http://localhost:4444/', {
         timeout: 250
-      }).then(function (res) {
+      }).then(res => {
         success = true;
-      }).catch(function (err) {
+      }).catch(err => {
         error = err;
         failure = true;
       });
 
-      setTimeout(function () {
+      setTimeout(() => {
         assert.equal(success, false, 'request should not succeed');
         assert.equal(failure, true, 'request should fail');
         assert.equal(error.code, 'ECONNABORTED');
@@ -55,28 +55,28 @@ describe('supports http with nodejs', function () {
     });
   });
 
-  it('should allow passing JSON', function (done) {
+  it('should allow passing JSON', done => {
     var data = {
       firstName: 'Fred',
       lastName: 'Flintstone',
       emailAddr: 'fred@example.com'
     };
 
-    server = http.createServer(function (req, res) {
+    server = http.createServer((req, res) => {
       res.setHeader('Content-Type', 'application/json;charset=utf-8');
       res.end(JSON.stringify(data));
-    }).listen(4444, function () {
-      axios.get('http://localhost:4444/').then(function (res) {
+    }).listen(4444, () => {
+      axios.get('http://localhost:4444/').then(res => {
         assert.deepEqual(res.data, data);
         done();
       });
     });
   });
 
-  it('should redirect', function (done) {
+  it('should redirect', done => {
     var str = 'test response';
 
-    server = http.createServer(function (req, res) {
+    server = http.createServer((req, res) => {
       var parsed = url.parse(req.url);
 
       if (parsed.pathname === '/one') {
@@ -86,8 +86,8 @@ describe('supports http with nodejs', function () {
       } else {
         res.end(str);
       }
-    }).listen(4444, function () {
-      axios.get('http://localhost:4444/one').then(function (res) {
+    }).listen(4444, () => {
+      axios.get('http://localhost:4444/one').then(res => {
         assert.equal(res.data, str);
         assert.equal(res.request.path, '/two');
         done();
@@ -95,18 +95,16 @@ describe('supports http with nodejs', function () {
     });
   });
 
-  it('should not redirect', function (done) {
-    server = http.createServer(function (req, res) {
+  it('should not redirect', done => {
+    server = http.createServer((req, res) => {
       res.setHeader('Location', '/foo');
       res.statusCode = 302;
       res.end();
-    }).listen(4444, function () {
+    }).listen(4444, () => {
       axios.get('http://localhost:4444/', {
         maxRedirects: 0,
-        validateStatus: function () {
-          return true;
-        }
-      }).then(function (res) {
+        validateStatus: () => true
+      }).then(res => {
         assert.equal(res.status, 302);
         assert.equal(res.headers['location'], '/foo');
         done();
@@ -114,24 +112,24 @@ describe('supports http with nodejs', function () {
     });
   });
 
-  it('should support max redirects', function (done) {
+  it('should support max redirects', done => {
     var i = 1;
-    server = http.createServer(function (req, res) {
+    server = http.createServer((req, res) => {
       res.setHeader('Location', '/' + i);
       res.statusCode = 302;
       res.end();
       i++;
-    }).listen(4444, function () {
+    }).listen(4444, () => {
       axios.get('http://localhost:4444/', {
         maxRedirects: 3
-      }).catch(function (error) {
+      }).catch(error => {
         done();
       });
     });
   });
 
-  it('should preserve the HTTP verb on redirect', function (done) {
-    server = http.createServer(function (req, res) {
+  it('should preserve the HTTP verb on redirect', done => {
+    server = http.createServer((req, res) => {
       if (req.method.toLowerCase() !== "head") {
         res.statusCode = 400;
         res.end();
@@ -146,31 +144,31 @@ describe('supports http with nodejs', function () {
       } else {
         res.end();
       }
-    }).listen(4444, function () {
-      axios.head('http://localhost:4444/one').then(function (res) {
+    }).listen(4444, () => {
+      axios.head('http://localhost:4444/one').then(res => {
         assert.equal(res.status, 200);
         done();
-      }).catch(function (err) {
+      }).catch(err => {
         done(err);
       });
     });
   });
 
-  it('should support transparent gunzip', function (done) {
+  it('should support transparent gunzip', done => {
     var data = {
       firstName: 'Fred',
       lastName: 'Flintstone',
       emailAddr: 'fred@example.com'
     };
 
-    zlib.gzip(JSON.stringify(data), function (err, zipped) {
+    zlib.gzip(JSON.stringify(data), (err, zipped) => {
 
-      server = http.createServer(function (req, res) {
+      server = http.createServer((req, res) => {
         res.setHeader('Content-Type', 'application/json;charset=utf-8');
         res.setHeader('Content-Encoding', 'gzip');
         res.end(zipped);
-      }).listen(4444, function () {
-        axios.get('http://localhost:4444/').then(function (res) {
+      }).listen(4444, () => {
+        axios.get('http://localhost:4444/').then(res => {
           assert.deepEqual(res.data, data);
           done();
         });
@@ -179,39 +177,39 @@ describe('supports http with nodejs', function () {
     });
   });
 
-  it('should support gunzip error handling', function (done) {
-    server = http.createServer(function (req, res) {
+  it('should support gunzip error handling', done => {
+    server = http.createServer((req, res) => {
       res.setHeader('Content-Type', 'application/json;charset=utf-8');
       res.setHeader('Content-Encoding', 'gzip');
       res.end('invalid response');
-    }).listen(4444, function () {
-      axios.get('http://localhost:4444/').catch(function (error) {
+    }).listen(4444, () => {
+      axios.get('http://localhost:4444/').catch(error => {
         done();
       });
     });
   });
 
-  it('should support UTF8', function (done) {
+  it('should support UTF8', done => {
     var str = Array(100000).join('ж');
 
-    server = http.createServer(function (req, res) {
+    server = http.createServer((req, res) => {
       res.setHeader('Content-Type', 'text/html; charset=UTF-8');
       res.end(str);
-    }).listen(4444, function () {
-      axios.get('http://localhost:4444/').then(function (res) {
+    }).listen(4444, () => {
+      axios.get('http://localhost:4444/').then(res => {
         assert.equal(res.data, str);
         done();
       });
     });
   });
 
-  it('should support basic auth', function (done) {
-    server = http.createServer(function (req, res) {
+  it('should support basic auth', done => {
+    server = http.createServer((req, res) => {
       res.end(req.headers.authorization);
-    }).listen(4444, function () {
+    }).listen(4444, () => {
       var user = 'foo';
       var headers = { Authorization: 'Bearer 1234' };
-      axios.get('http://' + user + '@localhost:4444/', { headers: headers }).then(function (res) {
+      axios.get('http://' + user + '@localhost:4444/', { headers: headers }).then(res => {
         var base64 = Buffer.from(user + ':', 'utf8').toString('base64');
         assert.equal(res.data, 'Basic ' + base64);
         done();
@@ -219,13 +217,13 @@ describe('supports http with nodejs', function () {
     });
   });
 
-  it('should support basic auth with a header', function (done) {
-    server = http.createServer(function (req, res) {
+  it('should support basic auth with a header', done => {
+    server = http.createServer((req, res) => {
       res.end(req.headers.authorization);
-    }).listen(4444, function () {
+    }).listen(4444, () => {
       var auth = { username: 'foo', password: 'bar' };
       var headers = { Authorization: 'Bearer 1234' };
-      axios.get('http://localhost:4444/', { auth: auth, headers: headers }).then(function (res) {
+      axios.get('http://localhost:4444/', { auth: auth, headers: headers }).then(res => {
         var base64 = Buffer.from('foo:bar', 'utf8').toString('base64');
         assert.equal(res.data, 'Basic ' + base64);
         done();
@@ -233,25 +231,25 @@ describe('supports http with nodejs', function () {
     });
   });
 
-  it('should support max content length', function (done) {
+  it('should support max content length', done => {
     var str = Array(100000).join('ж');
 
-    server = http.createServer(function (req, res) {
+    server = http.createServer((req, res) => {
       res.setHeader('Content-Type', 'text/html; charset=UTF-8');
       res.end(str);
-    }).listen(4444, function () {
+    }).listen(4444, () => {
       var success = false, failure = false, error;
 
       axios.get('http://localhost:4444/', {
         maxContentLength: 2000
-      }).then(function (res) {
+      }).then(res => {
         success = true;
-      }).catch(function (err) {
+      }).catch(err => {
         error = err;
         failure = true;
       });
 
-      setTimeout(function () {
+      setTimeout(() => {
         assert.equal(success, false, 'request should not succeed');
         assert.equal(failure, true, 'request should fail');
         assert.equal(error.message, 'maxContentLength size of 2000 exceeded');
@@ -260,42 +258,42 @@ describe('supports http with nodejs', function () {
     });
   });
 
-  it.skip('should support sockets', function (done) {
-    server = net.createServer(function (socket) {
-      socket.on('data', function () {
+  it.skip('should support sockets', done => {
+    server = net.createServer(socket => {
+      socket.on('data', () => {
         socket.end('HTTP/1.1 200 OK\r\n\r\n');
       });
-    }).listen('./test.sock', function () {
+    }).listen('./test.sock', () => {
       axios({
         socketPath: './test.sock',
         url: '/'
       })
-        .then(function (resp) {
+        .then(resp => {
           assert.equal(resp.status, 200);
           assert.equal(resp.statusText, 'OK');
           done();
         })
-        .catch(function (error) {
+        .catch(error => {
           assert.ifError(error);
           done();
         });
     });
   });
 
-  it('should support streams', function (done) {
-    server = http.createServer(function (req, res) {
+  it('should support streams', done => {
+    server = http.createServer((req, res) => {
       req.pipe(res);
-    }).listen(4444, function () {
+    }).listen(4444, () => {
       axios.post('http://localhost:4444/',
         fs.createReadStream(__filename), {
           responseType: 'stream'
-        }).then(function (res) {
+        }).then(res => {
           var stream = res.data;
           var string = '';
-          stream.on('data', function (chunk) {
+          stream.on('data', chunk => {
             string += chunk.toString('utf8');
           });
-          stream.on('end', function () {
+          stream.on('end', () => {
             assert.equal(string, fs.readFileSync(__filename, 'utf8'));
             done();
           });
@@ -303,37 +301,37 @@ describe('supports http with nodejs', function () {
     });
   });
 
-  it('should pass errors for a failed stream', function (done) {
-    server = http.createServer(function (req, res) {
+  it('should pass errors for a failed stream', done => {
+    server = http.createServer((req, res) => {
       req.pipe(res);
-    }).listen(4444, function () {
+    }).listen(4444, () => {
       axios.post('http://localhost:4444/',
         fs.createReadStream('/does/not/exist')
-      ).then(function (res) {
+      ).then(res => {
         assert.fail();
-      }).catch(function (err) {
+      }).catch(err => {
         assert.equal(err.message, 'ENOENT: no such file or directory, open \'/does/not/exist\'');
         done();
       });
     });
   });
 
-  it('should support buffers', function (done) {
+  it('should support buffers', done => {
     var buf = Buffer.alloc(1024, 'x'); // Unsafe buffer < Buffer.poolSize (8192 bytes)
-    server = http.createServer(function (req, res) {
+    server = http.createServer((req, res) => {
       assert.equal(req.headers['content-length'], buf.length.toString());
       req.pipe(res);
-    }).listen(4444, function () {
+    }).listen(4444, () => {
       axios.post('http://localhost:4444/',
         buf, {
           responseType: 'stream'
-        }).then(function (res) {
+        }).then(res => {
           var stream = res.data;
           var string = '';
-          stream.on('data', function (chunk) {
+          stream.on('data', chunk => {
             string += chunk.toString('utf8');
           });
-          stream.on('end', function () {
+          stream.on('end', () => {
             assert.equal(string, buf.toString());
             done();
           });
@@ -341,12 +339,12 @@ describe('supports http with nodejs', function () {
     });
   });
 
-  it('should support HTTP proxies', function (done) {
-    server = http.createServer(function (req, res) {
+  it('should support HTTP proxies', done => {
+    server = http.createServer((req, res) => {
       res.setHeader('Content-Type', 'text/html; charset=UTF-8');
       res.end('12345');
-    }).listen(4444, function () {
-      proxy = http.createServer(function (request, response) {
+    }).listen(4444, () => {
+      proxy = http.createServer((request, response) => {
         var parsed = url.parse(request.url);
         var opts = {
           host: parsed.hostname,
@@ -354,24 +352,24 @@ describe('supports http with nodejs', function () {
           path: parsed.path
         };
 
-        http.get(opts, function (res) {
+        http.get(opts, res => {
           var body = '';
-          res.on('data', function (data) {
+          res.on('data', data => {
             body += data;
           });
-          res.on('end', function () {
+          res.on('end', () => {
             response.setHeader('Content-Type', 'text/html; charset=UTF-8');
             response.end(body + '6789');
           });
         });
 
-      }).listen(4000, function () {
+      }).listen(4000, () => {
         axios.get('http://localhost:4444/', {
           proxy: {
             host: 'localhost',
             port: 4000
           }
-        }).then(function (res) {
+        }).then(res => {
           assert.equal(res.data, '123456789', 'should pass through proxy');
           done();
         });
@@ -379,29 +377,29 @@ describe('supports http with nodejs', function () {
     });
   });
 
-  it('should not pass through disabled proxy', function (done) {
+  it('should not pass through disabled proxy', done => {
     // set the env variable
     process.env.http_proxy = 'http://does-not-exists.example.com:4242/';
 
-    server = http.createServer(function (req, res) {
+    server = http.createServer((req, res) => {
       res.setHeader('Content-Type', 'text/html; charset=UTF-8');
       res.end('123456789');
-    }).listen(4444, function () {
+    }).listen(4444, () => {
       axios.get('http://localhost:4444/', {
         proxy: false
-      }).then(function (res) {
+      }).then(res => {
         assert.equal(res.data, '123456789', 'should not pass through proxy');
         done();
       });
     });
   });
 
-  it('should support proxy set via env var', function (done) {
-    server = http.createServer(function (req, res) {
+  it('should support proxy set via env var', done => {
+    server = http.createServer((req, res) => {
       res.setHeader('Content-Type', 'text/html; charset=UTF-8');
       res.end('4567');
-    }).listen(4444, function () {
-      proxy = http.createServer(function (request, response) {
+    }).listen(4444, () => {
+      proxy = http.createServer((request, response) => {
         var parsed = url.parse(request.url);
         var opts = {
           host: parsed.hostname,
@@ -409,22 +407,22 @@ describe('supports http with nodejs', function () {
           path: parsed.path
         };
 
-        http.get(opts, function (res) {
+        http.get(opts, res => {
           var body = '';
-          res.on('data', function (data) {
+          res.on('data', data => {
             body += data;
           });
-          res.on('end', function () {
+          res.on('end', () => {
             response.setHeader('Content-Type', 'text/html; charset=UTF-8');
             response.end(body + '1234');
           });
         });
 
-      }).listen(4000, function () {
+      }).listen(4000, () => {
         // set the env variable
         process.env.http_proxy = 'http://localhost:4000/';
 
-        axios.get('http://localhost:4444/').then(function (res) {
+        axios.get('http://localhost:4444/').then(res => {
           assert.equal(res.data, '45671234', 'should use proxy set by process.env.http_proxy');
           done();
         });
@@ -432,12 +430,12 @@ describe('supports http with nodejs', function () {
     });
   });
 
-  it('should not use proxy for domains in no_proxy', function (done) {
-    server = http.createServer(function (req, res) {
+  it('should not use proxy for domains in no_proxy', done => {
+    server = http.createServer((req, res) => {
       res.setHeader('Content-Type', 'text/html; charset=UTF-8');
       res.end('4567');
-    }).listen(4444, function () {
-      proxy = http.createServer(function (request, response) {
+    }).listen(4444, () => {
+      proxy = http.createServer((request, response) => {
         var parsed = url.parse(request.url);
         var opts = {
           host: parsed.hostname,
@@ -445,23 +443,23 @@ describe('supports http with nodejs', function () {
           path: parsed.path
         };
 
-        http.get(opts, function (res) {
+        http.get(opts, res => {
           var body = '';
-          res.on('data', function (data) {
+          res.on('data', data => {
             body += data;
           });
-          res.on('end', function () {
+          res.on('end', () => {
             response.setHeader('Content-Type', 'text/html; charset=UTF-8');
             response.end(body + '1234');
           });
         });
 
-      }).listen(4000, function () {
+      }).listen(4000, () => {
         // set the env variable
         process.env.http_proxy = 'http://localhost:4000/';
         process.env.no_proxy = 'foo.com, localhost,bar.net , , quix.co';
 
-        axios.get('http://localhost:4444/').then(function (res) {
+        axios.get('http://localhost:4444/').then(res => {
           assert.equal(res.data, '4567', 'should not use proxy for domains in no_proxy');
           done();
         });
@@ -469,12 +467,12 @@ describe('supports http with nodejs', function () {
     });
   });
 
-  it('should use proxy for domains not in no_proxy', function (done) {
-    server = http.createServer(function (req, res) {
+  it('should use proxy for domains not in no_proxy', done => {
+    server = http.createServer((req, res) => {
       res.setHeader('Content-Type', 'text/html; charset=UTF-8');
       res.end('4567');
-    }).listen(4444, function () {
-      proxy = http.createServer(function (request, response) {
+    }).listen(4444, () => {
+      proxy = http.createServer((request, response) => {
         var parsed = url.parse(request.url);
         var opts = {
           host: parsed.hostname,
@@ -482,23 +480,23 @@ describe('supports http with nodejs', function () {
           path: parsed.path
         };
 
-        http.get(opts, function (res) {
+        http.get(opts, res => {
           var body = '';
-          res.on('data', function (data) {
+          res.on('data', data => {
             body += data;
           });
-          res.on('end', function () {
+          res.on('end', () => {
             response.setHeader('Content-Type', 'text/html; charset=UTF-8');
             response.end(body + '1234');
           });
         });
 
-      }).listen(4000, function () {
+      }).listen(4000, () => {
         // set the env variable
         process.env.http_proxy = 'http://localhost:4000/';
         process.env.no_proxy = 'foo.com, ,bar.net , quix.co';
 
-        axios.get('http://localhost:4444/').then(function (res) {
+        axios.get('http://localhost:4444/').then(res => {
           assert.equal(res.data, '45671234', 'should use proxy for domains not in no_proxy');
           done();
         });
@@ -506,11 +504,11 @@ describe('supports http with nodejs', function () {
     });
   });
 
-  it('should support HTTP proxy auth', function (done) {
-    server = http.createServer(function (req, res) {
+  it('should support HTTP proxy auth', done => {
+    server = http.createServer((req, res) => {
       res.end();
-    }).listen(4444, function () {
-      proxy = http.createServer(function (request, response) {
+    }).listen(4444, () => {
+      proxy = http.createServer((request, response) => {
         var parsed = url.parse(request.url);
         var opts = {
           host: parsed.hostname,
@@ -519,18 +517,18 @@ describe('supports http with nodejs', function () {
         };
         var proxyAuth = request.headers['proxy-authorization'];
 
-        http.get(opts, function (res) {
+        http.get(opts, res => {
           var body = '';
-          res.on('data', function (data) {
+          res.on('data', data => {
             body += data;
           });
-          res.on('end', function () {
+          res.on('end', () => {
             response.setHeader('Content-Type', 'text/html; charset=UTF-8');
             response.end(proxyAuth);
           });
         });
 
-      }).listen(4000, function () {
+      }).listen(4000, () => {
         axios.get('http://localhost:4444/', {
           proxy: {
             host: 'localhost',
@@ -540,7 +538,7 @@ describe('supports http with nodejs', function () {
               password: 'pass'
             }
           }
-        }).then(function (res) {
+        }).then(res => {
           var base64 = Buffer.from('user:pass', 'utf8').toString('base64');
           assert.equal(res.data, 'Basic ' + base64, 'should authenticate to the proxy');
           done();
@@ -549,11 +547,11 @@ describe('supports http with nodejs', function () {
     });
   });
 
-  it('should support proxy auth from env', function (done) {
-    server = http.createServer(function (req, res) {
+  it('should support proxy auth from env', done => {
+    server = http.createServer((req, res) => {
       res.end();
-    }).listen(4444, function () {
-      proxy = http.createServer(function (request, response) {
+    }).listen(4444, () => {
+      proxy = http.createServer((request, response) => {
         var parsed = url.parse(request.url);
         var opts = {
           host: parsed.hostname,
@@ -562,21 +560,21 @@ describe('supports http with nodejs', function () {
         };
         var proxyAuth = request.headers['proxy-authorization'];
 
-        http.get(opts, function (res) {
+        http.get(opts, res => {
           var body = '';
-          res.on('data', function (data) {
+          res.on('data', data => {
             body += data;
           });
-          res.on('end', function () {
+          res.on('end', () => {
             response.setHeader('Content-Type', 'text/html; charset=UTF-8');
             response.end(proxyAuth);
           });
         });
 
-      }).listen(4000, function () {
+      }).listen(4000, () => {
         process.env.http_proxy = 'http://user:pass@localhost:4000/';
 
-        axios.get('http://localhost:4444/').then(function (res) {
+        axios.get('http://localhost:4444/').then(res => {
           var base64 = Buffer.from('user:pass', 'utf8').toString('base64');
           assert.equal(res.data, 'Basic ' + base64, 'should authenticate to the proxy set by process.env.http_proxy');
           done();
@@ -585,11 +583,11 @@ describe('supports http with nodejs', function () {
     });
   });
 
-  it('should support proxy auth with header', function (done) {
-    server = http.createServer(function (req, res) {
+  it('should support proxy auth with header', done => {
+    server = http.createServer((req, res) => {
       res.end();
-    }).listen(4444, function () {
-      proxy = http.createServer(function (request, response) {
+    }).listen(4444, () => {
+      proxy = http.createServer((request, response) => {
         var parsed = url.parse(request.url);
         var opts = {
           host: parsed.hostname,
@@ -598,18 +596,18 @@ describe('supports http with nodejs', function () {
         };
         var proxyAuth = request.headers['proxy-authorization'];
 
-        http.get(opts, function (res) {
+        http.get(opts, res => {
           var body = '';
-          res.on('data', function (data) {
+          res.on('data', data => {
             body += data;
           });
-          res.on('end', function () {
+          res.on('end', () => {
             response.setHeader('Content-Type', 'text/html; charset=UTF-8');
             response.end(proxyAuth);
           });
         });
 
-      }).listen(4000, function () {
+      }).listen(4000, () => {
         axios.get('http://localhost:4444/', {
           proxy: {
             host: 'localhost',
@@ -622,7 +620,7 @@ describe('supports http with nodejs', function () {
           headers: {
             'Proxy-Authorization': 'Basic abc123'
           }
-        }).then(function (res) {
+        }).then(res => {
           var base64 = Buffer.from('user:pass', 'utf8').toString('base64');
           assert.equal(res.data, 'Basic ' + base64, 'should authenticate to the proxy');
           done();
@@ -631,15 +629,15 @@ describe('supports http with nodejs', function () {
     });
   });
 
-  it('should support cancel', function (done) {
+  it('should support cancel', done => {
     var source = axios.CancelToken.source();
-    server = http.createServer(function (req, res) {
+    server = http.createServer((req, res) => {
       // call cancel() when the request has been sent, but a response has not been received
       source.cancel('Operation has been canceled.');
-    }).listen(4444, function () {
+    }).listen(4444, () => {
       axios.get('http://localhost:4444/', {
         cancelToken: source.token
-      }).catch(function (thrown) {
+      }).catch(thrown => {
         assert.ok(thrown instanceof axios.Cancel, 'Promise must be rejected with a Cancel obejct');
         assert.equal(thrown.message, 'Operation has been canceled.');
         done();

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -37,7 +37,7 @@ function generateConfig(name) {
   return config;
 }
 
-['axios', 'axios.min'].forEach(function (key) {
+['axios', 'axios.min'].forEach(key => {
   config[key] = generateConfig(key);
 });
 


### PR DESCRIPTION
Converts traditional function expressions to the new ES6 arrow function syntax. Performs the necessary safety checks to ensure behavior is preserved, e.g., that `this` is not used inside the function.

On my system, all the tests that have been passing before (i.e., on `axios/master`) are still passing.

The commits are fine-grained because they are generated automatically. Feel free to squash them on merge.