### PR TITLE
Adding support for no_proxy env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,7 +353,11 @@ These are the available config options for making requests. Only the `url` is re
   httpAgent: new http.Agent({ keepAlive: true }),
   httpsAgent: new https.Agent({ keepAlive: true }),
 
-  // 'proxy' defines the hostname and port of the proxy server
+  // 'proxy' defines the hostname and port of the proxy server.
+  // You can also define your proxy using the conventional `http_proxy` and
+  // `https_proxy` environment variables. If you are using environment variables
+  // for your proxy configuration, you can also define a `no_proxy` environment
+  // variable as a comma-separated list of domains that should not be proxied.
   // Use `false` to disable proxies, ignoring environment variables.
   // `auth` indicates that HTTP Basic auth should be used to connect to the proxy, and
   // supplies credentials.

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -102,17 +102,45 @@ module.exports = function httpAdapter(config) {
       var proxyUrl = process.env[proxyEnv] || process.env[proxyEnv.toUpperCase()];
       if (proxyUrl) {
         var parsedProxyUrl = url.parse(proxyUrl);
-        proxy = {
-          host: parsedProxyUrl.hostname,
-          port: parsedProxyUrl.port
-        };
+        var noProxyEnv = process.env.no_proxy || process.env.NO_PROXY;
+        var shouldProxy = true;
 
-        if (parsedProxyUrl.auth) {
-          var proxyUrlAuth = parsedProxyUrl.auth.split(':');
-          proxy.auth = {
-            username: proxyUrlAuth[0],
-            password: proxyUrlAuth[1]
+        if (noProxyEnv) {
+          var noProxy = noProxyEnv.split(',').map(function trim(s) {
+            return s.trim();
+          });
+
+          shouldProxy = !noProxy.some(function proxyMatch(proxyElement) {
+            if (!proxyElement) {
+              return false;
+            }
+            if (proxyElement === '*') {
+              return true;
+            }
+            if (proxyElement[0] === '.' &&
+                parsed.hostname.substr(parsed.hostname.length - proxyElement.length) === proxyElement &&
+                proxyElement.match(/\./g).length === parsed.hostname.match(/\./g).length) {
+              return true;
+            }
+
+            return parsed.hostname === proxyElement;
+          });
+        }
+
+
+        if (shouldProxy) {
+          proxy = {
+            host: parsedProxyUrl.hostname,
+            port: parsedProxyUrl.port
           };
+
+          if (parsedProxyUrl.auth) {
+            var proxyUrlAuth = parsedProxyUrl.auth.split(':');
+            proxy.auth = {
+              username: proxyUrlAuth[0],
+              password: proxyUrlAuth[1]
+            };
+          }
         }
       }
     }

--- a/test/unit/adapters/http.js
+++ b/test/unit/adapters/http.js
@@ -21,6 +21,9 @@ describe('supports http with nodejs', function () {
     if (process.env.http_proxy) {
       delete process.env.http_proxy;
     }
+    if (process.env.no_proxy) {
+      delete process.env.no_proxy;
+    }
   });
 
   it('should respect the timeout property', function (done) {
@@ -397,6 +400,80 @@ describe('supports http with nodejs', function () {
 
         axios.get('http://localhost:4444/').then(function (res) {
           assert.equal(res.data, '45671234', 'should use proxy set by process.env.http_proxy');
+          done();
+        });
+      });
+    });
+  });
+
+  it('should not use proxy for domains in no_proxy', function (done) {
+    server = http.createServer(function (req, res) {
+      res.setHeader('Content-Type', 'text/html; charset=UTF-8');
+      res.end('4567');
+    }).listen(4444, function () {
+      proxy = http.createServer(function (request, response) {
+        var parsed = url.parse(request.url);
+        var opts = {
+          host: parsed.hostname,
+          port: parsed.port,
+          path: parsed.path
+        };
+
+        http.get(opts, function (res) {
+          var body = '';
+          res.on('data', function (data) {
+            body += data;
+          });
+          res.on('end', function () {
+            response.setHeader('Content-Type', 'text/html; charset=UTF-8');
+            response.end(body + '1234');
+          });
+        });
+
+      }).listen(4000, function () {
+        // set the env variable
+        process.env.http_proxy = 'http://localhost:4000/';
+        process.env.no_proxy = 'foo.com, localhost,bar.net , , quix.co';
+
+        axios.get('http://localhost:4444/').then(function (res) {
+          assert.equal(res.data, '4567', 'should not use proxy for domains in no_proxy');
+          done();
+        });
+      });
+    });
+  });
+
+  it('should use proxy for domains not in no_proxy', function (done) {
+    server = http.createServer(function (req, res) {
+      res.setHeader('Content-Type', 'text/html; charset=UTF-8');
+      res.end('4567');
+    }).listen(4444, function () {
+      proxy = http.createServer(function (request, response) {
+        var parsed = url.parse(request.url);
+        var opts = {
+          host: parsed.hostname,
+          port: parsed.port,
+          path: parsed.path
+        };
+
+        http.get(opts, function (res) {
+          var body = '';
+          res.on('data', function (data) {
+            body += data;
+          });
+          res.on('end', function () {
+            response.setHeader('Content-Type', 'text/html; charset=UTF-8');
+            response.end(body + '1234');
+          });
+        });
+
+      }).listen(4000, function () {
+        // set the env variable
+        process.env.http_proxy = 'http://localhost:4000/';
+        process.env.no_proxy = 'foo.com, ,bar.net , quix.co';
+
+        axios.get('http://localhost:4444/').then(function (res) {
+          assert.equal(res.data, '45671234', 'should use proxy for domains not in no_proxy');
           done();
         });
       });


### PR DESCRIPTION
This commit adds support for the `no_proxy` env variable ([Issue #434](https://github.com/axios/axios/issues/434) and [on umbrella issue for 1.0.0](https://github.com/axios/axios/issues/1333)). It looks like there's [an open PR #565](https://github.com/axios/axios/pull/565), however it has conflicts, adds an unnecessary dependency, and was created in 2016 and hasn't been merged yet. At the company where I work, we are behind a proxy and are having to work around this lack of functionality, and it seems like several people are in a similar situation, so it'd be nice to have this feature. 🙂