### PR TITLE
Fixing IE11/Edge doesn't respect responseType, so do it manually

### DIFF
--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -5,6 +5,7 @@ var settle = require('./../core/settle');
 var buildURL = require('./../helpers/buildURL');
 var parseHeaders = require('./../helpers/parseHeaders');
 var isURLSameOrigin = require('./../helpers/isURLSameOrigin');
+var parseJSON = require('./../helpers/parseJSON');
 var createError = require('../core/createError');
 
 module.exports = function xhrAdapter(config) {
@@ -47,6 +48,8 @@ module.exports = function xhrAdapter(config) {
       // Prepare the response
       var responseHeaders = 'getAllResponseHeaders' in request ? parseHeaders(request.getAllResponseHeaders()) : null;
       var responseData = !config.responseType || config.responseType === 'text' ? request.responseText : request.response;
+      // In IE11 request.response always returns string although responseType is given "json"
+      responseData = config.responseType === 'json' && typeof responseData === 'string' ? parseJSON(responseData) : responseData;
       var response = {
         data: responseData,
         status: request.status,

--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -48,7 +48,7 @@ module.exports = function xhrAdapter(config) {
       // Prepare the response
       var responseHeaders = 'getAllResponseHeaders' in request ? parseHeaders(request.getAllResponseHeaders()) : null;
       var responseData = !config.responseType || config.responseType === 'text' ? request.responseText : request.response;
-      // In IE11 request.response always returns string although responseType is given "json"
+      // In IE11/Edge request.response always returns string although responseType is given "json"
       responseData = config.responseType === 'json' && typeof responseData === 'string' ? parseJSON(responseData) : responseData;
       var response = {
         data: responseData,

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -2,6 +2,7 @@
 
 var utils = require('./utils');
 var normalizeHeaderName = require('./helpers/normalizeHeaderName');
+var parseJSON = require('./helpers/parseJSON');
 
 var DEFAULT_CONTENT_TYPE = {
   'Content-Type': 'application/x-www-form-urlencoded'
@@ -55,15 +56,7 @@ var defaults = {
     return data;
   }],
 
-  transformResponse: [function transformResponse(data) {
-    /*eslint no-param-reassign:0*/
-    if (typeof data === 'string') {
-      try {
-        data = JSON.parse(data);
-      } catch (e) { /* Ignore */ }
-    }
-    return data;
-  }],
+  transformResponse: [parseJSON],
 
   /**
    * A timeout in milliseconds to abort a request. If set to 0 (default) a

--- a/lib/helpers/parseJSON.js
+++ b/lib/helpers/parseJSON.js
@@ -1,0 +1,11 @@
+'use strict';
+
+module.exports = function parseJSON(data) {
+  /*eslint no-param-reassign:0*/
+  if (typeof data === 'string') {
+    try {
+      data = JSON.parse(data);
+    } catch (e) { /* Ignore */ }
+  }
+  return data;
+};


### PR DESCRIPTION
## Failing case

```
axios({
  url: 'example.com',
  responseType: 'json',
  transformResponse: [
    data => {
      console.log(data.message.field);  // ERROR
    }
  ]
})
```

While running the above case in IE 11, an error will be thrown at the line marked.

Because:

1. `defaults.transformResponse` gets overrided
2. IE 11 ignores `XHR.responseType` and `XHR.response` will always give out `string`

## How does this PR do

Whenever we find `responseType` is set to `json` and response type is `string`,
try to `JSON.parse` it.
