### PR TITLE
fix(Accept): Normalize accept header in request config

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -30,6 +30,7 @@ var defaults = {
   adapter: getDefaultAdapter(),
 
   transformRequest: [function transformRequest(data, headers) {
+    normalizeHeaderName(headers, 'Accept');
     normalizeHeaderName(headers, 'Content-Type');
     if (utils.isFormData(data) ||
       utils.isArrayBuffer(data) ||


### PR DESCRIPTION
Overriding the accept header is case sensitive wrt the defaults object.

Example:

```js
axios.get('/foo', {
	headers: { accept: 'text/html' }
});
```

Expected behavior:
```
GET /foo HTTP/1.1
[..]
Accept: text/html
[..]
```

Actual behavior:
```
GET /foo HTTP/1.1
[..]
Accept: application/json, text/plain, */*, text/html
[..]
```
Whereas
```js
axios.get('/foo', {
	headers: { Accept: 'text/html' }
});
```
Works as expected.

## Solution
Normalize the header before merging into the final headers object, just like we do for `Content-Type`.