### PR TITLE
Added support for empty Buffer on requests with data

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -39,7 +39,10 @@ module.exports = function httpAdapter(config) {
 
     if (data && !utils.isStream(data)) {
       if (Buffer.isBuffer(data)) {
-        // Nothing to do...
+        // if Buffer is empty, transform to string or else request will hang
+        if(data.length === 0) {
+          data = data.toString();
+        }
       } else if (utils.isArrayBuffer(data)) {
         data = Buffer.from(new Uint8Array(data));
       } else if (utils.isString(data)) {

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -40,7 +40,7 @@ module.exports = function httpAdapter(config) {
     if (data && !utils.isStream(data)) {
       if (Buffer.isBuffer(data)) {
         // if Buffer is empty, transform to string or else request will hang
-        if(data.length === 0) {
+        if (data.length === 0) {
           data = data.toString();
         }
       } else if (utils.isArrayBuffer(data)) {

--- a/test/unit/adapters/http.js
+++ b/test/unit/adapters/http.js
@@ -543,6 +543,20 @@ describe('supports http with nodejs', function () {
       });
     });
   });
+
+  it('should not hang on empty buffer', function(done) {
+    server = http.createServer(function (req, res) {
+      res.writeHead(200, {'Content-Type': 'text/plain'});
+      res.end('success');
+    }).listen(4444, function () {
+      axios.post('http://localhost:4444/', Buffer.from('')).then(function(res) {
+        assert.equal(res.config.data, Buffer.from('').toString());
+        assert.equal(res.config.headers['Content-Type'], 'application/x-www-form-urlencoded');
+        assert.equal(res.data, 'success');
+        done();
+      });
+    });
+  });
 });
 
 


### PR DESCRIPTION
# What was the problem?
As described in this issue https://github.com/axios/axios/issues/1701, axios would hang when passing an empty buffer.

# How was the problem fixed?
By converting the empty Buffer (```data.length === 0```) into a string (```data.toString()```).