### PR TITLE
Added getUri method

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ The available instance methods are listed below. The specified config will be me
 ##### axios#post(url[, data[, config]])
 ##### axios#put(url[, data[, config]])
 ##### axios#patch(url[, data[, config]])
+##### axios#getUri([config])
 
 ## Request Config
 

--- a/lib/core/Axios.js
+++ b/lib/core/Axios.js
@@ -2,7 +2,6 @@
 
 var utils = require('./../utils');
 var buildURL = require('../helpers/buildURL');
-var url = require('url');
 var InterceptorManager = require('./InterceptorManager');
 var dispatchRequest = require('./dispatchRequest');
 var mergeConfig = require('./mergeConfig');
@@ -59,8 +58,7 @@ Axios.prototype.request = function request(config) {
 
 Axios.prototype.getUri = function getUri(config) {
   config = mergeConfig(this.defaults, config);
-  var parsed = url.parse(config.url);
-  return buildURL(parsed.path, config.params, config.paramsSerializer).replace(/^\?/, '');
+  return buildURL(config.url, config.params, config.paramsSerializer).replace(/^\?/, '');
 };
 
 // Provide aliases for supported request methods

--- a/lib/core/Axios.js
+++ b/lib/core/Axios.js
@@ -1,6 +1,8 @@
 'use strict';
 
 var utils = require('./../utils');
+var buildURL = require('../helpers/buildURL');
+var url = require('url');
 var InterceptorManager = require('./InterceptorManager');
 var dispatchRequest = require('./dispatchRequest');
 var mergeConfig = require('./mergeConfig');
@@ -53,6 +55,12 @@ Axios.prototype.request = function request(config) {
   }
 
   return promise;
+};
+
+Axios.prototype.getUri = function getUri(config) {
+  config = mergeConfig(this.defaults, config);
+  var parsed = url.parse(config.url);
+  return buildURL(parsed.path, config.params, config.paramsSerializer).replace(/^\?/, '');
 };
 
 // Provide aliases for supported request methods


### PR DESCRIPTION
This is a new feature to get the built URI of an axios instance. It's been added in regards to this issue https://github.com/axios/axios/issues/1624 , I thought the use-case was interesting and I didn't think it was a good idea to include this feature in a third-party module. 

This code 
```javascript
const axios = require('axios');
const fakeConfig = {
  method: 'post',
  url: '/user/12345',
  data: {
    firstName: 'Fred',
    lastName: 'Flintstone'
  },
  params: {
    idClient: 1,
    idTest: 2,
    testString: 'thisIsATest'
  }
}
console.log(axios.getUri(fakeConfig));
```
Outputs
```bash
/user/12345?idClient=1&idTest=2&testString=thisIsATest
```