### PR TITLE
Fixing crash in XHR when setting user-agent header

### DIFF
--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -112,8 +112,10 @@ module.exports = function xhrAdapter(config) {
     // Add headers to the request
     if ('setRequestHeader' in request) {
       utils.forEach(requestHeaders, function setRequestHeader(val, key) {
-        if (typeof requestData === 'undefined' && key.toLowerCase() === 'content-type') {
-          // Remove Content-Type if data is undefined
+        if ((typeof requestData === 'undefined' && key.toLowerCase() === 'content-type') || key.toLowerCase() === 'user-agent') {
+          // Remove header if
+          // - It's Content-Type and data is undefined
+          // - It's User-Agent (browsers don't allow XHR to set user-agent header)
           delete requestHeaders[key];
         } else {
           // Otherwise add header to the request

--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -112,11 +112,15 @@ module.exports = function xhrAdapter(config) {
     // Add headers to the request
     if ('setRequestHeader' in request) {
       utils.forEach(requestHeaders, function setRequestHeader(val, key) {
-        if ((typeof requestData === 'undefined' && key.toLowerCase() === 'content-type') || key.toLowerCase() === 'user-agent') {
-          // Remove header if
-          // - It's Content-Type and data is undefined
-          // - It's User-Agent (browsers don't allow XHR to set user-agent header)
+        if (typeof requestData === 'undefined' && key.toLowerCase() === 'content-type') {
+          // Remove Content-Type if data is undefined
           delete requestHeaders[key];
+        } else if (key.toLowerCase() === 'user-agent') {
+          try {
+            request.setRequestHeader(key, val);
+          } catch (_) {
+            // Don't crash when some browsers don't allow setting user-agent header
+          }
         } else {
           // Otherwise add header to the request
           request.setRequestHeader(key, val);


### PR DESCRIPTION
Fixes https://github.com/axios/axios/issues/1231

### Context

Axios is a cross-runtime request library, it works out of the box in both Node.js and Browsers. Therefore consumers of the library don't add any extra checks around the runtime themselves, hoping axios would handle the differences for them.

Among the consumers of axios is the Google official API client [`googleapis`](https://www.npmjs.com/package/googleapis). It uses axios for it's http requests but also sets `user-agent` header. While the request works in Node.js, it fails in browsers because they disallow setting a custom User-Agent header.

### The Solution

This PR is a backward compatible way of fixing above scenario. Backward compatible as-in, the above mentioned scenario would've failed in browsers and wouldn't have worked so there's no way anybody could be depending on user-agent behavior of this library in browsers. Furthermore `user-agent` is a non-important header, in my testing requests behave the same on googleapis regardless of user agent payload.