### PR TITLE
Default params serialisation violates RFC 3986 less.

### DIFF
--- a/lib/helpers/buildURL.js
+++ b/lib/helpers/buildURL.js
@@ -8,9 +8,7 @@ function encode(val) {
     replace(/%3A/gi, ':').
     replace(/%24/g, '$').
     replace(/%2C/gi, ',').
-    replace(/%20/g, '+').
-    replace(/%5B/gi, '[').
-    replace(/%5D/gi, ']');
+    replace(/%20/g, '+');
 }
 
 /**

--- a/test/specs/helpers/buildURL.spec.js
+++ b/test/specs/helpers/buildURL.spec.js
@@ -31,7 +31,7 @@ describe('helpers::buildURL', function () {
   it('should support array params', function () {
     expect(buildURL('/foo', {
       foo: ['bar', 'baz']
-    })).toEqual('/foo?foo[]=bar&foo[]=baz');
+    })).toEqual('/foo?foo%5B%5D=bar&foo%5B%5D=baz');
   });
 
   it('should support special char params', function () {


### PR DESCRIPTION
Fixes #1727.

Does so in the "standards compliant weenie" fashion, by making axios' default behaviour violate RFC 3986 less.

I appreciate that including `[` and `]` characters raw in the query portion of a request URL is a near-universal practice, but it is a clear and wilful violation of URI syntax. This makes axios' default behaviour brittle in the face of an environment were popular server implementations are getting more pedantic. And here we are with axios out-of-the-box generating requests that Tomcat out-of-the-box rejects as syntactically invalid.