### PR TITLE
Add `getUri` signature to TypeScript definition.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -127,6 +127,7 @@ export interface AxiosInstance {
     request: AxiosInterceptorManager<AxiosRequestConfig>;
     response: AxiosInterceptorManager<AxiosResponse>;
   };
+  getUri(config: AxiosRequestConfig): string;
   request<T = any, R = AxiosResponse<T>> (config: AxiosRequestConfig): Promise<R>;
   get<T = any, R = AxiosResponse<T>>(url: string, config?: AxiosRequestConfig): Promise<R>;
   delete<T = any, R = AxiosResponse<T>>(url: string, config?: AxiosRequestConfig): Promise<R>;


### PR DESCRIPTION
This is in support of #1624.  It adds a definition for the `getUri` feature added by @delirius325 to the base axios type.