### PR TITLE
makes axios error generic to use axios response

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -76,11 +76,11 @@ export interface AxiosResponse<T = any>  {
   request?: any;
 }
 
-export interface AxiosError extends Error {
+export interface AxiosError<T = any> extends Error {
   config: AxiosRequestConfig;
   code?: string;
   request?: any;
-  response?: AxiosResponse;
+  response?: AxiosResponse<T>;
 }
 
 export interface AxiosPromise<T = any> extends Promise<AxiosResponse<T>> {


### PR DESCRIPTION
Regarding [#1730](https://github.com/axios/axios/issues/1730) 


Adjusts `index.d.ts` so that it takes type argument which is passed on to AxiosResponse.

```
export interface AxiosError<T = any> extends Error {
  config: AxiosRequestConfig;
  code?: string;
  request?: any;
  response?: AxiosResponse<T>;
}
```