### PR TITLE
Adding connectTimeout setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,9 +281,17 @@ These are the available config options for making requests. Only the `url` is re
     firstName: 'Fred'
   },
 
-  // `timeout` specifies the number of milliseconds before the request times out.
-  // If the request takes longer than `timeout`, the request will be aborted.
+  // If the request takes longer than `timeout` milliseconds to complete,
+  // the request will be aborted. Default 0 means no timeout.
   timeout: 1000,
+
+  // If the server takes longer than `connectTimeout` milliseconds to accept the tcp socket,
+  // the request will be aborted. By setting a low `connectTimeout` but a high `timeout`,
+  // the requests will fail quickly if the server is not reachable or down, but
+  // if the server responds, the request is allowed to take a long time to complete.
+  // Default 0 means no timeout.
+  // connectTimeout is only available in node.js.
+  connectTimeout: 1000,
 
   // `withCredentials` indicates whether or not cross-site Access-Control requests
   // should be made using credentials

--- a/index.d.ts
+++ b/index.d.ts
@@ -49,6 +49,7 @@ export interface AxiosRequestConfig {
   paramsSerializer?: (params: any) => string;
   data?: any;
   timeout?: number;
+  connectTimeout?: number;
   withCredentials?: boolean;
   adapter?: AxiosAdapter;
   auth?: AxiosBasicCredentials;

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -19,12 +19,15 @@ var isHttps = /https:?/;
 module.exports = function httpAdapter(config) {
   return new Promise(function dispatchHttpRequest(resolvePromise, rejectPromise) {
     var timer;
+    var socketConnectTimeout;
     var resolve = function resolve(value) {
       clearTimeout(timer);
+      clearTimeout(socketConnectTimeout);
       resolvePromise(value);
     };
     var reject = function reject(value) {
       clearTimeout(timer);
+      clearTimeout(socketConnectTimeout);
       rejectPromise(value);
     };
     var data = config.data;
@@ -250,6 +253,25 @@ module.exports = function httpAdapter(config) {
         req.abort();
         reject(createError('timeout of ' + config.timeout + 'ms exceeded', config, 'ECONNABORTED', req));
       }, config.timeout);
+    }
+
+    // Handle socket connect timeout
+    if (config.connectTimeout) {
+      socketConnectTimeout = setTimeout( function handleConnectTimeout() {
+        req.abort();
+        reject(createError('connectTimeout of ' + config.connectTimeout + 'ms exceeded', config, 'ECONNABORTED', req));
+      }, config.connectTimeout);
+
+      req.on('socket', function socketEvent(socket) {
+        // Clear timeout if socket is already connected (keep-alive)
+        if (socket.connecting) {
+          socket.once('connect', function socketConnectEvent() {
+            clearTimeout(socketConnectTimeout);
+          });
+        } else {
+          clearTimeout(socketConnectTimeout);
+        }
+      });
     }
 
     if (config.cancelToken) {

--- a/lib/core/mergeConfig.js
+++ b/lib/core/mergeConfig.js
@@ -35,7 +35,7 @@ module.exports = function mergeConfig(config1, config2) {
 
   utils.forEach([
     'baseURL', 'transformRequest', 'transformResponse', 'paramsSerializer',
-    'timeout', 'withCredentials', 'adapter', 'responseType', 'xsrfCookieName',
+    'timeout', 'connectTimeout', 'withCredentials', 'adapter', 'responseType', 'xsrfCookieName',
     'xsrfHeaderName', 'onUploadProgress', 'onDownloadProgress', 'maxContentLength',
     'validateStatus', 'maxRedirects', 'httpAgent', 'httpsAgent', 'cancelToken',
     'socketPath'

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -66,10 +66,17 @@ var defaults = {
   }],
 
   /**
-   * A timeout in milliseconds to abort a request. If set to 0 (default) a
-   * timeout is not created.
+   * Abort the request if it hasn't completed in this many milliseconds.
+   * If set to 0 (default) a timeout is not created.
    */
   timeout: 0,
+
+  /**
+   * Abort the request if the tcp-connection to the server has not been established
+   * within this many milliseconds.
+   * If set to 0 (default), a timeout is not created.
+   */
+  connectTimeout: 0,
 
   xsrfCookieName: 'XSRF-TOKEN',
   xsrfHeaderName: 'X-XSRF-TOKEN',


### PR DESCRIPTION
I want to use axios to connect to an http-server that is available via several different servers with different url:s. If one of the servers does not respond, I want to try another server instead. To get fast failovers, I want to set a low timeout for the request.

But the server sometimes takes a long time to respond (when I am making a complex query). To give the server time to generate the response, I have to set a high timeout.

What I really want to do is set a low connectTimeout, so that if the server has not accepted the tcp connection within this timeout, the request is aborted, but a high timeout to give the server time to generate the response.

Resolves #1739 