### PR TITLE
Clarify in README that default timeout is 0 (no timeout)

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ These are the available config options for making requests. Only the `url` is re
 
   // `timeout` specifies the number of milliseconds before the request times out.
   // If the request takes longer than `timeout`, the request will be aborted.
-  timeout: 1000,
+  timeout: 1000, // default is `0` (no timeout)
 
   // `withCredentials` indicates whether or not cross-site Access-Control requests
   // should be made using credentials


### PR DESCRIPTION
I didn't make a GitHub issue since this is such a simple documentation update.

When I Cmd-F to find "timeout" in the README (i.e. GitHub home page for Axios), I see `timeout: 1000`, but the default is actually `0` (no timeout). Similar to how other configs have their `// default` listed in a comment, I added a comment to specify that even though the example says timeout is `1000`, the default is `0` (no timeout).

This caused confusion in my project with an unreliable API. I couldn't find the source of a queue that was blocking too much, and after a few hours I realized that the Axios timeout is actually `0`, not `1000`.