### PR TITLE
Preserve HTTP method when following redirect

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -83,7 +83,7 @@ module.exports = function httpAdapter(config) {
 
     var options = {
       path: buildURL(parsed.path, config.params, config.paramsSerializer).replace(/^\?/, ''),
-      method: config.method,
+      method: config.method.toUpperCase(),
       headers: headers,
       agent: agent,
       auth: auth

--- a/test/unit/adapters/http.js
+++ b/test/unit/adapters/http.js
@@ -130,6 +130,32 @@ describe('supports http with nodejs', function () {
     });
   });
 
+  it('should preserve the HTTP verb on redirect', function (done) {
+    server = http.createServer(function (req, res) {
+      if (req.method.toLowerCase() !== "head") {
+        res.statusCode = 400;
+        res.end();
+        return;
+      }
+
+      var parsed = url.parse(req.url);
+      if (parsed.pathname === '/one') {
+        res.setHeader('Location', '/two');
+        res.statusCode = 302;
+        res.end();
+      } else {
+        res.end();
+      }
+    }).listen(4444, function () {
+      axios.head('http://localhost:4444/one').then(function (res) {
+        assert.equal(res.status, 200);
+        done();
+      }).catch(function (err) {
+        done(err);
+      });
+    });
+  });
+
   it('should support transparent gunzip', function (done) {
     var data = {
       firstName: 'Fred',


### PR DESCRIPTION
Resolves #1158

This modifies http.js to uppercase the HTTP method, similar to xhr.js, before passing the request off to the transport. This causes follow-redirects to preserve the HTTP method when automatically making a request to the next URL.

@axe312ger