### PR TITLE
Fixing building url with hash mark

### DIFF
--- a/lib/helpers/buildURL.js
+++ b/lib/helpers/buildURL.js
@@ -59,6 +59,11 @@ module.exports = function buildURL(url, params, paramsSerializer) {
   }
 
   if (serializedParams) {
+    var hashmarkIndex = url.indexOf('#');
+    if (hashmarkIndex !== -1) {
+      url = url.slice(0, hashmarkIndex);
+    }
+
     url += (url.indexOf('?') === -1 ? '?' : '&') + serializedParams;
   }
 

--- a/test/specs/helpers/buildURL.spec.js
+++ b/test/specs/helpers/buildURL.spec.js
@@ -54,6 +54,12 @@ describe('helpers::buildURL', function () {
     })).toEqual('/foo?query=bar&start=0&length=5');
   });
 
+  it('should correct discard url hash mark', function () {
+    expect(buildURL('/foo?foo=bar#hash', {
+      query: 'baz'
+    })).toEqual('/foo?foo=bar&query=baz');
+  });
+
   it('should use serializer if provided', function () {
     serializer = sinon.stub();
     params = {foo: 'bar'};


### PR DESCRIPTION
This commit fix building url with hash map (fragment identifier) when parameters are present: they must not be added after `#`, because client cut everything after `#`