### PR TITLE
Allow uppercase methods in typings.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -21,14 +21,14 @@ export interface AxiosProxyConfig {
   protocol?: string;
 }
 
-export type Method = 
-  | 'get' 
-  | 'delete' 
-  | 'head' 
-  | 'options' 
-  | 'post' 
-  | 'put' 
-  | 'patch'
+export type Method =
+  | 'get' | 'GET'
+  | 'delete' | 'DELETE'
+  | 'head' | 'HEAD'
+  | 'options' | 'OPTIONS'
+  | 'post' | 'POST'
+  | 'put' | 'PUT'
+  | 'patch' | 'PATCH'
 
 export type ResponseType = 
   | 'arraybuffer' 


### PR DESCRIPTION
The current typings shipping with Axios type `method` as a string accepting both upper and lowercase method names. This change ensures that when the new typings ship they will be backwards compatible.