### PR TITLE
Fixing .eslintrc without extension

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,4 @@
-{
+module.exports = {
   "globals": {
     "console": true,
     "module": true,


### PR DESCRIPTION
### Summary
.eslintrc without extension is deprecated (https://eslint.org/docs/user-guide/configuring#configuration-file-formats).

Fix #1788 

### Changes
* Change the content of .eslintrc to be a js module (module.exports)
* Add .js extension to .eslintrc
