### PR TITLE
fix the description of maxContentLength in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ These are the available config options for making requests. Only the `url` is re
     // Do whatever you want with the native progress event
   },
 
-  // `maxContentLength` defines the max size of the http response content in bytes allowed
+  // `maxContentLength` defines the max size of the http request content in bytes allowed
   maxContentLength: 2000,
 
   // `validateStatus` defines whether to resolve or reject the promise for a given


### PR DESCRIPTION
I see `maxContentLength` option is passed to `maxBodyLength` option in [follow-redirects](https://github.com/olalonde/follow-redirects), which describes itself as
> sets the maximum size of the request body

The explanation for maxContentLength in this document should also be `request` instead of `response`.