### PR TITLE
Fixing ignore set withCredentials false

### DIFF
--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -125,7 +125,7 @@ module.exports = function xhrAdapter(config) {
     // Add withCredentials to request if needed. Explicit to set a true or false
     if (typeof config.withCredentials !== 'undefined') {
       request.withCredentials = !!config.withCredentials;
-    }    
+    }
     // Add responseType to request if needed
     if (config.responseType) {
       try {

--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -122,12 +122,11 @@ module.exports = function xhrAdapter(config) {
       });
     }
 
-    // Add withCredentials to request if needed
-    // Explicit to set a true or false 
+    // Add withCredentials to request if needed. Explicit to set a true or false 
     if (typeof config.withCredentials !== 'undefined') {
       request.withCredentials = !!config.withCredentials;
     }
-
+    
     // Add responseType to request if needed
     if (config.responseType) {
       try {

--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -123,10 +123,10 @@ module.exports = function xhrAdapter(config) {
     }
 
     // Add withCredentials to request if needed
-    if(typeof config.withCredentials!='undefined'){
+    // Explicit to set a true or false 
+    if (typeof config.withCredentials !== 'undefined') {
       request.withCredentials = !!config.withCredentials;
     }
-    
 
     // Add responseType to request if needed
     if (config.responseType) {

--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -122,11 +122,10 @@ module.exports = function xhrAdapter(config) {
       });
     }
 
-    // Add withCredentials to request if needed. Explicit to set a true or false 
+    // Add withCredentials to request if needed. Explicit to set a true or false
     if (typeof config.withCredentials !== 'undefined') {
       request.withCredentials = !!config.withCredentials;
-    }
-    
+    }    
     // Add responseType to request if needed
     if (config.responseType) {
       try {

--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -123,9 +123,10 @@ module.exports = function xhrAdapter(config) {
     }
 
     // Add withCredentials to request if needed
-    if (config.withCredentials) {
-      request.withCredentials = true;
+    if(typeof config.withCredentials!='undefined'){
+      request.withCredentials = !!config.withCredentials;
     }
+    
 
     // Add responseType to request if needed
     if (config.responseType) {


### PR DESCRIPTION
Explicit  to set a true or false setting.
if (typeof config.withCredentials !== 'undefined') {
      request.withCredentials = !!config.withCredentials;
 }