### PR TITLE
Fixing request.responseText missing error

### DIFF
--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -46,7 +46,9 @@ module.exports = function xhrAdapter(config) {
 
       // Prepare the response
       var responseHeaders = 'getAllResponseHeaders' in request ? parseHeaders(request.getAllResponseHeaders()) : null;
-      var responseData = !config.responseType || config.responseType === 'text' ? request.responseText : request.response;
+      var responseData = (!config.responseType || config.responseType === 'text') && (Object.keys(request).indexOf('responseText') >= 0)
+        ? request.responseText
+        : request.response;
       var response = {
         data: responseData,
         status: request.status,


### PR DESCRIPTION
There are some cases where sites wrongly pass a responseType but not a responseText.

In those cases I found the response in request.response.

I did not create an issue because it's an edge case that I think it is quite rare, and in code it translates in an reinforcement of a check in a ternary operator.

Thank you for your time and effort, this library is great!
