### PR TITLE
Adding responseEncoding to AxiosRequestConfig typescript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -53,6 +53,7 @@ export interface AxiosRequestConfig {
   adapter?: AxiosAdapter;
   auth?: AxiosBasicCredentials;
   responseType?: ResponseType;
+  responseEncoding?: string;
   xsrfCookieName?: string;
   xsrfHeaderName?: string;
   onUploadProgress?: (progressEvent: any) => void;


### PR DESCRIPTION
Fixes #1866 

* Added ``responseEncoding`` option to the ``AxiosRequestConfig`` interface in the Typescript definitions.

