### PR TITLE
Adding TS generic to AxiosError to allow specifying the response format

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -76,11 +76,11 @@ export interface AxiosResponse<T = any>  {
   request?: any;
 }
 
-export interface AxiosError extends Error {
+export interface AxiosError<T = any> extends Error {
   config: AxiosRequestConfig;
   code?: string;
   request?: any;
-  response?: AxiosResponse;
+  response?: AxiosResponse<T>;
   isAxiosError: boolean;
 }
 


### PR DESCRIPTION
This adds a generic to the `AxiosError` type and allows usage like this:

```ts
const getServerErrorMessage = (axiosError: AxiosError<{ errors: string[] }>) =>
  axiosError.response.data.errors[0];
```