### PR TITLE
ci: test Node.js 6, 8, 10 and 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: node_js
 node_js:
   - node
+  - 10
+  - 8
+  - 6
 email:
   on_failure: change
   on_success: never


### PR DESCRIPTION
We should test against all current LTS branches to make sure that axios works there.
