### PR TITLE
Prevent subdomains of domains in NO_PROXY from getting proxied

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -118,8 +118,7 @@ module.exports = function httpAdapter(config) {
               return true;
             }
             if (proxyElement[0] === '.' &&
-                parsed.hostname.substr(parsed.hostname.length - proxyElement.length) === proxyElement &&
-                proxyElement.match(/\./g).length === parsed.hostname.match(/\./g).length) {
+                parsed.hostname.substr(parsed.hostname.length - proxyElement.length) === proxyElement) {
               return true;
             }
 


### PR DESCRIPTION
Currently, the behaviour for parsing the `no_proxy` env variable is to check that that hostname ends with the `no_proxy` listed element, and that the element contains the same number of `.`s as the hostname.

This is kind of cumbersome because it forces you to list every possible subdomain of a domain you want not to go through a proxy. For example, if you want any requests to `*.foo.com` not to go through a proxy, you would have to have something like this:
`set NO_PROXY=bar.foo.com, baz.qux.foo.com, quuz.foo.com`

I think it would make more sense for
`set NO_PROXY=.foo.com`
to also cover all subdomains of `foo.com` as well.

Let me know what you guys think!



P.S I found this impossible to work this into the existing tests as they spawn servers on localhost, and I can't create subdomains on localhost without changing `/etc/hosts`. Open to suggestions of this