### PR TITLE
feat: type axios-error

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -76,11 +76,11 @@ export interface AxiosResponse<T = any>  {
   request?: any;
 }
 
-export interface AxiosError extends Error {
+export interface AxiosError<T = any> extends Error {
   config: AxiosRequestConfig;
   code?: string;
   request?: any;
-  response?: AxiosResponse;
+  response?: AxiosResponse<T>;
   isAxiosError: boolean;
 }
 


### PR DESCRIPTION
**Summary:**

Turn `AxiosError` into a generic, this allows typing of the returned response.