### PR TITLE
Fixing indexOf[throws] error on null url.

### DIFF
--- a/lib/core/Axios.js
+++ b/lib/core/Axios.js
@@ -58,7 +58,7 @@ Axios.prototype.request = function request(config) {
 
 Axios.prototype.getUri = function getUri(config) {
   config = mergeConfig(this.defaults, config);
-  return buildURL(config.url, config.params, config.paramsSerializer).replace(/^\?/, '');
+  return buildURL(config.url, config.params, config.paramsSerializer);
 };
 
 // Provide aliases for supported request methods

--- a/lib/helpers/buildURL.js
+++ b/lib/helpers/buildURL.js
@@ -57,6 +57,9 @@ module.exports = function buildURL(url, params, paramsSerializer) {
 
     serializedParams = parts.join('&');
   }
+  if (!utils.isString(url)) {
+    return serializedParams;
+  }
 
   if (serializedParams) {
     var hashmarkIndex = url.indexOf('#');
@@ -67,5 +70,5 @@ module.exports = function buildURL(url, params, paramsSerializer) {
     url += (url.indexOf('?') === -1 ? '?' : '&') + serializedParams;
   }
 
-  return url;
+  return url.replace(/^\?/, '');
 };

--- a/test/specs/helpers/buildURL.spec.js
+++ b/test/specs/helpers/buildURL.spec.js
@@ -72,4 +72,8 @@ describe('helpers::buildURL', function () {
   it('should support URLSearchParams', function () {
     expect(buildURL('/foo', new URLSearchParams('bar=baz'))).toEqual('/foo?bar=baz');
   });
+
+  it('should return serialized/unserialized params if url is null', function () {
+    expect(buildURL(null, new URLSearchParams('foo=bar'))).toEqual('foo=bar');
+  });
 });


### PR DESCRIPTION
```
const instance = axios.create({
    baseURL: 'https://some-domain.com/api/',
    timeout: 1000,
    headers: {'X-Custom-Header': 'foobar'},
  });

instance.getUri({params: {name: 'asd'}}) // throws TypeError
```

With this PR, It addresses the null/undefined url to the getUri method by simply returning serialized/unserialized params.

Also ,
```
.replace(/^\?/, ''); 
``` 
is moved inside the buildURL method so that it does not operate on undefined/null url which could be the case if params ```config.params``` evaluates to false and ```config.url``` is not set to string.

Thank you.

