### PR TITLE
support message-body in get requests

### DIFF
--- a/lib/core/Axios.js
+++ b/lib/core/Axios.js
@@ -62,7 +62,7 @@ Axios.prototype.getUri = function getUri(config) {
 };
 
 // Provide aliases for supported request methods
-utils.forEach(['delete', 'get', 'head', 'options'], function forEachMethodNoData(method) {
+utils.forEach(['delete', 'head', 'options'], function forEachMethodNoData(method) {
   /*eslint func-names:0*/
   Axios.prototype[method] = function(url, config) {
     return this.request(utils.merge(config || {}, {
@@ -72,7 +72,7 @@ utils.forEach(['delete', 'get', 'head', 'options'], function forEachMethodNoData
   };
 });
 
-utils.forEach(['post', 'put', 'patch'], function forEachMethodWithData(method) {
+utils.forEach(['get', 'post', 'put', 'patch'], function forEachMethodWithData(method) {
   /*eslint func-names:0*/
   Axios.prototype[method] = function(url, data, config) {
     return this.request(utils.merge(config || {}, {

--- a/lib/core/Axios.js
+++ b/lib/core/Axios.js
@@ -72,7 +72,18 @@ utils.forEach(['delete', 'head', 'options'], function forEachMethodNoData(method
   };
 });
 
-utils.forEach(['get', 'post', 'put', 'patch'], function forEachMethodWithData(method) {
+utils.forEach(['get'], function forEachMethodWithOptionalData(method) {
+  /*eslint func-names:0*/
+  Axios.prototype[method] = function(url, config, data) {
+    return this.request(utils.merge(config || {}, {
+      method: method,
+      url: url,
+      data: data
+    }));
+  };
+});
+
+utils.forEach(['post', 'put', 'patch'], function forEachMethodWithData(method) {
   /*eslint func-names:0*/
   Axios.prototype[method] = function(url, data, config) {
     return this.request(utils.merge(config || {}, {


### PR DESCRIPTION
rfc7231 does not forbit sending payload with GET-Requests. In several cases this is needed because of the size-restriction on GET-Parameters.

fixes #787
