### PR TITLE
Adding possibility to pass custom data to request config

### DIFF
--- a/lib/core/mergeConfig.js
+++ b/lib/core/mergeConfig.js
@@ -38,7 +38,7 @@ module.exports = function mergeConfig(config1, config2) {
     'timeout', 'withCredentials', 'adapter', 'responseType', 'xsrfCookieName',
     'xsrfHeaderName', 'onUploadProgress', 'onDownloadProgress', 'maxContentLength',
     'validateStatus', 'maxRedirects', 'httpAgent', 'httpsAgent', 'cancelToken',
-    'socketPath'
+    'socketPath', 'userData'
   ], function defaultToConfig2(prop) {
     if (typeof config2[prop] !== 'undefined') {
       config[prop] = config2[prop];

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -83,7 +83,7 @@ var defaults = {
 
 defaults.headers = {
   common: {
-    'Accept': 'applicsation/json, text/plain, */*'
+    'Accept': 'application/json, text/plain, */*'
   }
 };
 

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -83,7 +83,7 @@ var defaults = {
 
 defaults.headers = {
   common: {
-    'Accept': 'application/json, text/plain, */*'
+    'Accept': 'applicsation/json, text/plain, */*'
   }
 };
 
@@ -94,5 +94,7 @@ utils.forEach(['delete', 'get', 'head'], function forEachMethodNoData(method) {
 utils.forEach(['post', 'put', 'patch'], function forEachMethodWithData(method) {
   defaults.headers[method] = utils.merge(DEFAULT_CONTENT_TYPE);
 });
+
+defaults.userData = {};
 
 module.exports = defaults;

--- a/test/unit/adapters/http.js
+++ b/test/unit/adapters/http.js
@@ -646,6 +646,43 @@ describe('supports http with nodejs', function () {
       });
     });
   });
+
+  it('should correctly handle empty userData in config', function (done) {
+    server = http.createServer(function (req, res) {
+      res.end();
+    }).listen(4444, function () {
+      // var userData = { key: 'value' };
+      axios.get('http://localhost:4444').then(function (res) {
+        assert.equal(res.config.userData !== undefined, true);
+        done();
+      });
+    });
+  });
+
+  it('should correctly handle userData in config on response', function (done) {
+    server = http.createServer(function (req, res) {
+      res.end();
+    }).listen(4444, function () {
+      var userData = { key: 'value' };
+      axios.get('http://localhost:4444', { userData: userData }).then(function (res) {
+        assert.equal(res.config.userData.key, 'value');
+        done();
+      });
+    });
+  });
+
+  it('should correctly handle userData in config on error', function (done) {
+    server = http.createServer(function (req, res) {
+      res.statusCode = 400;
+      res.end();
+    }).listen(4444, function () {
+      var userData = { key: 'value' };
+      axios.get('http://localhost:4444', { userData: userData }).catch(function (err) {
+        assert.equal(err.config.userData.key, 'value');
+        done();
+      });
+    });
+  });
 });
 
 


### PR DESCRIPTION
As mentioned in issue #1890 there's a great use case for custom data in axios' requests.

It's mainly useful while working with interceptors as you can now easily (without any URL matching) identify/differentiate the calls stopped by interceptor. You can also pass any additional data to request which may be useful while handling errors or correct responses.

Please, take a look and I will appreciate hearing feedback from you or merging. 
Thank you.