### PR TITLE
Fixing Mocha tests.

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   },
   "typings": "./index.d.ts",
   "dependencies": {
-    "follow-redirects": "^1.4.1",
+    "follow-redirects": "1.5.10",
     "is-buffer": "^2.0.2"
   },
   "bundlesize": [


### PR DESCRIPTION
TLDR: Fixes #1953

Versions 1.6.0 and 1.6.1 of [follow-redirects](https://github.com/follow-redirects/follow-redirects/releases) break Mocha test `should support max redirects`. The PR updates dependency version to the last compatible one.