### PR TITLE
Adding feature to support axios sub-instances

### DIFF
--- a/lib/axios.js
+++ b/lib/axios.js
@@ -22,6 +22,11 @@ function createInstance(defaultConfig) {
   // Copy context to instance
   utils.extend(instance, context);
 
+  // Factory for creating new instances
+  instance.create = function create(instanceConfig) {
+    return createInstance(mergeConfig(context.defaults, instanceConfig));
+  };
+
   return instance;
 }
 
@@ -30,11 +35,6 @@ var axios = createInstance(defaults);
 
 // Expose Axios class to allow class inheritance
 axios.Axios = Axios;
-
-// Factory for creating new instances
-axios.create = function create(instanceConfig) {
-  return createInstance(mergeConfig(axios.defaults, instanceConfig));
-};
 
 // Expose Cancel & CancelToken
 axios.Cancel = require('./cancel/Cancel');

--- a/test/specs/api.spec.js
+++ b/test/specs/api.spec.js
@@ -61,4 +61,8 @@ describe('instance api', function () {
     expect(typeof instance.interceptors.request).toEqual('object');
     expect(typeof instance.interceptors.response).toEqual('object');
   });
+
+  it('should have factory method', function () {
+    expect(typeof instance.create).toEqual('function');
+  });
 });

--- a/test/specs/instance.spec.js
+++ b/test/specs/instance.spec.js
@@ -13,7 +13,6 @@ describe('instance', function () {
     for (var prop in axios) {
       if ([
         'Axios',
-        'create',
         'Cancel',
         'CancelToken',
         'isCancel',
@@ -96,5 +95,34 @@ describe('instance', function () {
         done();
       }, 100);
     });
+  });
+
+  it('should support nested instances', function () {
+    var url1 = 'https://api.example1.com';
+    var url2 = 'https://api.example2.com';
+    var url3 = 'https://api.example3.com';
+
+    var instance = axios.create({
+      baseURL: url1,
+      timeout: 500
+    });
+    var instanceNested1 = instance.create({
+      timeout: 1000
+    });
+    var instanceNested2 = instance.create({
+      baseURL: url2
+    });
+    var instanceNestedNested = instanceNested2.create({
+      baseURL: url3
+    });
+
+    expect(instance.defaults.baseURL).toEqual(url1);
+    expect(instance.defaults.timeout).toEqual(500);
+    expect(instanceNested1.defaults.baseURL).toEqual(url1);
+    expect(instanceNested1.defaults.timeout).toEqual(1000);
+    expect(instanceNested2.defaults.baseURL).toEqual(url2);
+    expect(instanceNested2.defaults.timeout).toEqual(500);
+    expect(instanceNestedNested.defaults.baseURL).toEqual(url3);
+    expect(instanceNestedNested.defaults.timeout).toEqual(500);
   });
 });


### PR DESCRIPTION
Fixes https://github.com/axios/axios/issues/1170.

Before this change, calling `axios.create().create()` would result with the error:

```
TypeError: axios.create(...).create is not a function
```

After this change, all is well.  Axios instances now can be sub-instanced indefinitely.