### PR TITLE
Improve typings: set isAxiosError to true

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -81,7 +81,7 @@ export interface AxiosError extends Error {
   code?: string;
   request?: any;
   response?: AxiosResponse;
-  isAxiosError: boolean;
+  isAxiosError: true;
 }
 
 export interface AxiosPromise<T = any> extends Promise<AxiosResponse<T>> {


### PR DESCRIPTION
Restrict typings since `isAxiosError` is always set to true. This allows discriminating between axios errors and non-axios errors.