### PR TITLE
Adding reverseInterceptorsOrder method

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ The available instance methods are listed below. The specified config will be me
 ##### axios#put(url[, data[, config]])
 ##### axios#patch(url[, data[, config]])
 ##### axios#getUri([config])
+##### axios#reverseInterceptorsOrder()
 
 ## Request Config
 

--- a/lib/core/Axios.js
+++ b/lib/core/Axios.js
@@ -61,6 +61,10 @@ Axios.prototype.getUri = function getUri(config) {
   return buildURL(config.url, config.params, config.paramsSerializer).replace(/^\?/, '');
 };
 
+Axios.prototype.reverseInterceptorsOrder = function reverseInterceptorsOrder() {
+  this.interceptors.request.handlers.reverse();
+};
+
 // Provide aliases for supported request methods
 utils.forEach(['delete', 'get', 'head', 'options'], function forEachMethodNoData(method) {
   /*eslint func-names:0*/


### PR DESCRIPTION
#### What
In regards to #1663 .

Basically just added a method that reverses the request interceptors with the `.reverse()` javascript function. Also added the method to the docs.

#### Why
The reason I did it this way is because I did not want to change the internals of axios (risking to break existing applications that make use of the interceptors in the order that they are now). 
