### PR TITLE
Updating README.md - Log errors always to stderr

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ axios.get('/user?ID=12345')
   })
   .catch(function (error) {
     // handle error
-    console.log(error);
+    console.error(error);
   })
   .then(function () {
     // always executed
@@ -80,7 +80,7 @@ axios.get('/user', {
     console.log(response);
   })
   .catch(function (error) {
-    console.log(error);
+    console.error(error);
   })
   .then(function () {
     // always executed
@@ -111,7 +111,7 @@ axios.post('/user', {
     console.log(response);
   })
   .catch(function (error) {
-    console.log(error);
+    console.error(error);
   });
 ```
 
@@ -513,17 +513,17 @@ axios.get('/user/12345')
     if (error.response) {
       // The request was made and the server responded with a status code
       // that falls out of the range of 2xx
-      console.log(error.response.data);
-      console.log(error.response.status);
-      console.log(error.response.headers);
+      console.error(error.response.data);
+      console.error(error.response.status);
+      console.error(error.response.headers);
     } else if (error.request) {
       // The request was made but no response was received
       // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
       // http.ClientRequest in node.js
-      console.log(error.request);
+      console.error(error.request);
     } else {
       // Something happened in setting up the request that triggered an Error
-      console.log('Error', error.message);
+      console.error('Error', error.message);
     }
     console.log(error.config);
   });


### PR DESCRIPTION
Errors should always be logged to stderr. This PR uses `console.error` consistently to log errors in the axios examples.