### PR TITLE
Using Node 10 on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - node
+  - "11"
 email:
   on_failure: change
   on_success: never

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "11"
+  - "10"
 email:
   on_failure: change
   on_success: never


### PR DESCRIPTION
Temporarily downgrades NodeJS because a nested dependency (`bundlesize@0.17.1 > brotli-size@0.0.1 > iltorb@1.3.10`) does not support Node 12. This can probably be reverted once https://github.com/siddharthkp/bundlesize/pull/299 is merged. Alternatively, a package-lock.json or npm-shrinkwrap.json can be used to upgrade `brotli-size` to 0.1.0.