### PR TITLE
Do not limit the return type in interceptor

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -116,7 +116,7 @@ export interface CancelTokenSource {
 }
 
 export interface AxiosInterceptorManager<V> {
-  use(onFulfilled?: (value: V) => V | Promise<V>, onRejected?: (error: any) => any): number;
+  use(onFulfilled?: (value: V) => any | Promise<any>, onRejected?: (error: any) => any): number;
   eject(id: number): void;
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -115,8 +115,8 @@ export interface CancelTokenSource {
   cancel: Canceler;
 }
 
-export interface AxiosInterceptorManager<V> {
-  use(onFulfilled?: (value: V) => any | Promise<any>, onRejected?: (error: any) => any): number;
+export interface AxiosInterceptorManager<V, T = any> {
+  use(onFulfilled?: (value: V) => T | Promise<T>, onRejected?: (error: any) => any): number;
   eject(id: number): void;
 }
 
@@ -124,9 +124,9 @@ export interface AxiosInstance {
   (config: AxiosRequestConfig): AxiosPromise;
   (url: string, config?: AxiosRequestConfig): AxiosPromise;
   defaults: AxiosRequestConfig;
-  interceptors: {
-    request: AxiosInterceptorManager<AxiosRequestConfig>;
-    response: AxiosInterceptorManager<AxiosResponse>;
+  interceptors<P = any, Q = any>: {
+    request: AxiosInterceptorManager<AxiosRequestConfig, Q>;
+    response: AxiosInterceptorManager<AxiosResponse, S>;
   };
   getUri(config?: AxiosRequestConfig): string;
   request<T = any, R = AxiosResponse<T>> (config: AxiosRequestConfig): Promise<R>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -124,9 +124,9 @@ export interface AxiosInstance {
   (config: AxiosRequestConfig): AxiosPromise;
   (url: string, config?: AxiosRequestConfig): AxiosPromise;
   defaults: AxiosRequestConfig;
-  interceptors<P = any, Q = any>: {
-    request: AxiosInterceptorManager<AxiosRequestConfig, Q>;
-    response: AxiosInterceptorManager<AxiosResponse, S>;
+  interceptors: {
+    request: AxiosInterceptorManager<AxiosRequestConfig>;
+    response: AxiosInterceptorManager<AxiosResponse>;
   };
   getUri(config?: AxiosRequestConfig): string;
   request<T = any, R = AxiosResponse<T>> (config: AxiosRequestConfig): Promise<R>;


### PR DESCRIPTION
Limiting the return type in the interceptor may not be ideal.
Consumer should be free to transform the incoming data to whatever data format they like.

There is only 2 LOCs so the issue step is skipped.😝