### PR TITLE
Fix `params` merging

### DIFF
--- a/lib/core/mergeConfig.js
+++ b/lib/core/mergeConfig.js
@@ -15,8 +15,8 @@ module.exports = function mergeConfig(config1, config2) {
   config2 = config2 || {};
   var config = {};
 
-  var valueFromConfig2Keys = ['url', 'method', 'params', 'data'];
-  var mergeDeepPropertiesKeys = ['headers', 'auth', 'proxy'];
+  var valueFromConfig2Keys = ['url', 'method', 'data'];
+  var mergeDeepPropertiesKeys = ['headers', 'auth', 'params', 'proxy'];
   var defaultToConfig2Keys = [
     'baseURL', 'url', 'transformRequest', 'transformResponse', 'paramsSerializer',
     'timeout', 'withCredentials', 'adapter', 'responseType', 'xsrfCookieName',


### PR DESCRIPTION
Fixes bug introduced in 0.19.0 where request params are not being merged correctly with default instance params. See bug #2190 for more information

According to the documentation:

> The available instance methods are listed below. The specified config will be merged with the instance config.

Tests were failing because of the change to merge params, so hopefully my update to the tests is _correct_ … and passes