### PR TITLE
Fixing issue 2195

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -15,13 +15,12 @@ function setContentTypeIfUnset(headers, value) {
 
 function getDefaultAdapter() {
   var adapter;
-  // Only Node.JS has a process variable that is of [[Class]] process
-  if (typeof process !== 'undefined' && Object.prototype.toString.call(process) === '[object process]') {
-    // For node use HTTP adapter
-    adapter = require('./adapters/http');
-  } else if (typeof XMLHttpRequest !== 'undefined') {
+  if (typeof XMLHttpRequest !== 'undefined') {
     // For browsers use XHR adapter
     adapter = require('./adapters/xhr');
+  } else if (typeof process !== 'undefined' && Object.prototype.toString.call(process) === '[object process]') {
+    // For node use HTTP adapter
+    adapter = require('./adapters/http');
   }
   return adapter;
 }


### PR DESCRIPTION
Fixes #2195 

The order of the if/else blocks matters when running tests mocking XHR. Changing the order allows this to continue working in node and browsers, but also allows for unit tests to properly connect over the correct protocol.
