### PR TITLE
Don't remove Content-Encoding header

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -189,9 +189,6 @@ module.exports = function httpAdapter(config) {
       case 'deflate':
         // add the unzipper to the body stream processing pipeline
         stream = (res.statusCode === 204) ? stream : stream.pipe(zlib.createUnzip());
-
-        // remove the content-encoding in order to not confuse downstream operations
-        delete res.headers['content-encoding'];
         break;
       }
 


### PR DESCRIPTION
[This](https://github.com/axios/axios/pull/149) commit  brought automatic body decode based on `Content-Encoding` header. The motivation was: `This is done by the browser automatically`. That PR also removes `Content-Encoding` header after decode with the following motivation: `// remove the content-encoding in order to not confuse downstream operations`.

But header removal creates new confusions:
1. `Content-Length` header will stay untoched and will be equal to X, while decoded body will be >X. So `Content-Length` != length(data). And it's confusing, because you can't understand the reason of this. The only clue is `Content-Encoding`, which was removed.
2. Browser automatically decodes body, but leaves `Content-Encoding` untoched (fetch API, XMLHttpRequest). I don't know why author didn't strictly mimicked browser behavior.

How I found it:
I was creating some kind of proxy which modifies response a bit and sends it in original encoding.
