### PR TITLE
updating spelling and adding link to docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ Please update the tests to reflect your code changes. Pull requests will not be 
 
 ### Documentation
 
-Please update the docs accordingly so that there are no discrepencies between the API and the documentation.
+Please update the [docs](README.md) accordingly so that there are no discrepancies between the API and the documentation.
 
 ### Developing
 


### PR DESCRIPTION
Corrected spelling mistake and added a link to the general docs from the 'contributing' readme.
old:

![image](https://user-images.githubusercontent.com/25258332/59151973-82230400-89f0-11e9-9ad3-36594526146d.png)

corrected:
![image](https://user-images.githubusercontent.com/25258332/59151997-e645c800-89f0-11e9-89dd-6ace3a41d682.png)
