### PR TITLE
Fixing proxy type in AxiosRequestConfig

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -63,7 +63,7 @@ export interface AxiosRequestConfig {
   socketPath?: string | null;
   httpAgent?: any;
   httpsAgent?: any;
-  proxy?: AxiosProxyConfig | false;
+  proxy?: AxiosProxyConfig | boolean;
   cancelToken?: CancelToken;
 }
 


### PR DESCRIPTION
Hi,
In index.d.ts, AxiosRequestConfig interface, the type 'proxy?: AxiosProxyConfig | false;' is incorrect.
false is a value not a type. The type is boolean.
Best Regards