### PR TITLE
upadating README: example for CommonJS autocomplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,15 @@ Using cdn:
 
 ## Example
 
+### note: CommonJS usage
+In order to gain the TypeScript typings (for intellisense / autocomplete) while using CommonJS imports with `require()` use the following approach:
+
+```js
+const axios = require('axios').default;
+
+// axios.<method> will now provide autocomplete and parameter typings
+```
+
 Performing a `GET` request
 
 ```js


### PR DESCRIPTION
closes #2226. add note and example on how to gain typings / autocomplete / intellisense when using CommonJS, `require()`, import syntax
