### PR TITLE
Adding option useGlobalInterceptors

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -65,6 +65,7 @@ export interface AxiosRequestConfig {
   httpsAgent?: any;
   proxy?: AxiosProxyConfig | false;
   cancelToken?: CancelToken;
+  useGlobalInterceptors?: boolean,
 }
 
 export interface AxiosResponse<T = any>  {

--- a/lib/axios.js
+++ b/lib/axios.js
@@ -12,8 +12,8 @@ var defaults = require('./defaults');
  * @param {Object} defaultConfig The default config for the instance
  * @return {Axios} A new instance of Axios
  */
-function createInstance(defaultConfig) {
-  var context = new Axios(defaultConfig);
+function createInstance(defaultConfig, axiosGlobal) {
+  var context = new Axios(defaultConfig, axiosGlobal);
   var instance = bind(Axios.prototype.request, context);
 
   // Copy axios.prototype to instance
@@ -33,7 +33,7 @@ axios.Axios = Axios;
 
 // Factory for creating new instances
 axios.create = function create(instanceConfig) {
-  return createInstance(mergeConfig(axios.defaults, instanceConfig));
+  return createInstance(mergeConfig(axios.defaults, instanceConfig), axios);
 };
 
 // Expose Cancel & CancelToken

--- a/lib/core/Axios.js
+++ b/lib/core/Axios.js
@@ -11,8 +11,9 @@ var mergeConfig = require('./mergeConfig');
  *
  * @param {Object} instanceConfig The default config for the instance
  */
-function Axios(instanceConfig) {
+function Axios(instanceConfig, axiosGlobal) {
   this.defaults = instanceConfig;
+  this.axiosGlobal = axiosGlobal;
   this.interceptors = {
     request: new InterceptorManager(),
     response: new InterceptorManager()
@@ -40,6 +41,16 @@ Axios.prototype.request = function request(config) {
   // Hook up interceptors middleware
   var chain = [dispatchRequest, undefined];
   var promise = Promise.resolve(config);
+
+  if (config.useGlobalInterceptors && this.axiosGlobal) {
+    this.axiosGlobal.interceptors.request.forEach(function unshiftRequestInterceptorsGlobal(interceptor) {
+      chain.unshift(interceptor.fulfilled, interceptor.rejected);
+    });
+
+    this.axiosGlobal.interceptors.response.forEach(function pushResponseInterceptorsGlobal(interceptor) {
+      chain.push(interceptor.fulfilled, interceptor.rejected);
+    });
+  }
 
   this.interceptors.request.forEach(function unshiftRequestInterceptors(interceptor) {
     chain.unshift(interceptor.fulfilled, interceptor.rejected);

--- a/lib/core/Axios.js
+++ b/lib/core/Axios.js
@@ -42,6 +42,14 @@ Axios.prototype.request = function request(config) {
   var chain = [dispatchRequest, undefined];
   var promise = Promise.resolve(config);
 
+  this.interceptors.request.forEach(function unshiftRequestInterceptors(interceptor) {
+    chain.unshift(interceptor.fulfilled, interceptor.rejected);
+  });
+
+  this.interceptors.response.forEach(function pushResponseInterceptors(interceptor) {
+    chain.push(interceptor.fulfilled, interceptor.rejected);
+  });
+
   if (config.useGlobalInterceptors && this.axiosGlobal) {
     this.axiosGlobal.interceptors.request.forEach(function unshiftRequestInterceptorsGlobal(interceptor) {
       chain.unshift(interceptor.fulfilled, interceptor.rejected);
@@ -51,14 +59,6 @@ Axios.prototype.request = function request(config) {
       chain.push(interceptor.fulfilled, interceptor.rejected);
     });
   }
-
-  this.interceptors.request.forEach(function unshiftRequestInterceptors(interceptor) {
-    chain.unshift(interceptor.fulfilled, interceptor.rejected);
-  });
-
-  this.interceptors.response.forEach(function pushResponseInterceptors(interceptor) {
-    chain.push(interceptor.fulfilled, interceptor.rejected);
-  });
 
   while (chain.length) {
     promise = promise.then(chain.shift(), chain.shift());

--- a/lib/core/mergeConfig.js
+++ b/lib/core/mergeConfig.js
@@ -38,7 +38,7 @@ module.exports = function mergeConfig(config1, config2) {
     'timeout', 'withCredentials', 'adapter', 'responseType', 'xsrfCookieName',
     'xsrfHeaderName', 'onUploadProgress', 'onDownloadProgress', 'maxContentLength',
     'validateStatus', 'maxRedirects', 'httpAgent', 'httpsAgent', 'cancelToken',
-    'socketPath'
+    'socketPath', 'useGlobalInterceptors'
   ], function defaultToConfig2(prop) {
     if (typeof config2[prop] !== 'undefined') {
       config[prop] = config2[prop];

--- a/test/specs/instance.spec.js
+++ b/test/specs/instance.spec.js
@@ -19,7 +19,8 @@ describe('instance', function () {
         'isCancel',
         'all',
         'spread',
-        'default'].indexOf(prop) > -1) {
+        'default',
+        'axiosGlobal'].indexOf(prop) > -1) {
         continue;
       }
       expect(typeof instance[prop]).toBe(typeof axios[prop]);

--- a/test/typescript/axios.ts
+++ b/test/typescript/axios.ts
@@ -40,7 +40,8 @@ const config: AxiosRequestConfig = {
     host: '127.0.0.1',
     port: 9000
   },
-  cancelToken: new axios.CancelToken((cancel: Canceler) => {})
+  cancelToken: new axios.CancelToken((cancel: Canceler) => {}),
+  useGlobalInterceptors: false,
 };
 
 const handleResponse = (response: AxiosResponse) => {
@@ -231,6 +232,7 @@ instance1.defaults.baseURL = 'https://api.example.com/';
 instance1.defaults.headers.common['Authorization'] = 'token';
 instance1.defaults.headers.post['X-FOO'] = 'bar';
 instance1.defaults.timeout = 2500;
+instance1.defaults.useGlobalInterceptors = false;
 
 // Interceptors
 

--- a/test/unit/adapters/http.js
+++ b/test/unit/adapters/http.js
@@ -646,6 +646,26 @@ describe('supports http with nodejs', function () {
       });
     });
   });
+
+  it('should support useGlobalInterceptors option', function(done) {
+    server = http.createServer(function(req, res) {
+      res.setHeader('Content-Type', 'application/json;charset=utf-8');
+      res.end(JSON.stringify({}));
+    }).listen(4444, function() {
+      var isCall = false
+      var interceptId = axios.interceptors.request.use(function (config) {
+        isCall = true
+        return config;
+      });
+      var axiosInstance = axios.create({ useGlobalInterceptors: true })
+
+      axiosInstance.get('http://localhost:4444/').then(function(res) {
+        axios.interceptors.request.eject(interceptId)
+        assert.ok(isCall, 'interceptors is not work');
+        done();
+      });
+    });
+  });
 });
 
 


### PR DESCRIPTION
# Description
I implement `useGlobalInterceptors` option for axios instance can be use interceptors of global axios.

```javascript
import axios from 'axios';

// axiosInstance must have this interceptors
axios.interceptors.request.use((config) => {
  console.log(config);
  return config;
}, (error) => {
  console.log(error);
  return Promise.reject(error);
});

const axiosInstance = axios.create({ useGlobalInterceptors: true });
axiosInstance.get(URL)
  .then(() => { /* ... */ })
  .catch(() => { /* ... */ })
```