### PR TITLE
Axios create url bug

### DIFF
--- a/lib/core/mergeConfig.js
+++ b/lib/core/mergeConfig.js
@@ -34,7 +34,7 @@ module.exports = function mergeConfig(config1, config2) {
   });
 
   utils.forEach([
-    'baseURL','url', 'transformRequest', 'transformResponse', 'paramsSerializer',
+    'baseURL', 'url', 'transformRequest', 'transformResponse', 'paramsSerializer',
     'timeout', 'withCredentials', 'adapter', 'responseType', 'xsrfCookieName',
     'xsrfHeaderName', 'onUploadProgress', 'onDownloadProgress', 'maxContentLength',
     'validateStatus', 'maxRedirects', 'httpAgent', 'httpsAgent', 'cancelToken',

--- a/lib/core/mergeConfig.js
+++ b/lib/core/mergeConfig.js
@@ -34,7 +34,7 @@ module.exports = function mergeConfig(config1, config2) {
   });
 
   utils.forEach([
-    'baseURL', 'transformRequest', 'transformResponse', 'paramsSerializer',
+    'baseURL','url', 'transformRequest', 'transformResponse', 'paramsSerializer',
     'timeout', 'withCredentials', 'adapter', 'responseType', 'xsrfCookieName',
     'xsrfHeaderName', 'onUploadProgress', 'onDownloadProgress', 'maxContentLength',
     'validateStatus', 'maxRedirects', 'httpAgent', 'httpsAgent', 'cancelToken',

--- a/test/specs/core/mergeConfig.spec.js
+++ b/test/specs/core/mergeConfig.spec.js
@@ -32,13 +32,11 @@ describe('core::mergeConfig', function() {
 
   it('should not inherit request options', function() {
     var localDefaults = {
-      url: '__sample url__',
       method: '__sample method__',
       params: '__sample params__',
       data: { foo: true }
     };
     var merged = mergeConfig(localDefaults, {});
-    expect(merged.url).toEqual(undefined);
     expect(merged.method).toEqual(undefined);
     expect(merged.params).toEqual(undefined);
     expect(merged.data).toEqual(undefined);

--- a/test/specs/instance.spec.js
+++ b/test/specs/instance.spec.js
@@ -37,6 +37,19 @@ describe('instance', function () {
     });
   });
 
+  it('should make an http request with url instead of baseURL', function () {
+    var instance = axios.create({
+      url: 'https://api.example.com'
+    });
+
+    instance('/foo');
+
+    getAjaxRequest().then(function (request) {
+      expect(request.url).toBe('/foo');
+      done();
+    });
+  });
+
   it('should make an http request', function (done) {
     var instance = axios.create();
 


### PR DESCRIPTION
When using the request() method on an instance, the request would be successful even if the instance's config has **url** specified, but not **baseUrl**.