### PR TITLE
Adding setTimeout based timeout fallback for browsers without timeout support

### DIFF
--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -11,6 +11,7 @@ module.exports = function xhrAdapter(config) {
   return new Promise(function dispatchXhrRequest(resolve, reject) {
     var requestData = config.data;
     var requestHeaders = config.headers;
+    var fallbackTimeout;
 
     if (utils.isFormData(requestData)) {
       delete requestHeaders['Content-Type']; // Let the browser set it
@@ -27,8 +28,18 @@ module.exports = function xhrAdapter(config) {
 
     request.open(config.method.toUpperCase(), buildURL(config.url, config.params, config.paramsSerializer), true);
 
-    // Set the request timeout in MS
-    request.timeout = config.timeout;
+    if (typeof request.timeout !== 'undefined') {
+      // Set the request timeout in MS
+      request.timeout = config.timeout;
+    } else {
+      // Fallback for browsers without support for XmlHttpRequest.timeout
+      if (config.timeout) {
+        fallbackTimeout = setTimeout(function fallbackTimeoutCallback() {
+          request.abort();
+          reject(createError('timeout of ' + config.timeout + 'ms exceeded', config, 'ECONNABORTED', request));
+        }, config.timeout);
+      }
+    }
 
     // Listen for ready state
     request.onreadystatechange = function handleLoad() {
@@ -57,6 +68,7 @@ module.exports = function xhrAdapter(config) {
       };
 
       settle(resolve, reject, response);
+      clearTimeout(fallbackTimeout);
 
       // Clean up request
       request = null;


### PR DESCRIPTION
This pull request tries to address #2301. When the browser doesn't have support for XHR's timeout feature, Axios will internally create a setTimeout and relay on it to abort the request if config.timeout is reached.

**Note**: Despite the contributing guide specifies to create tests for every new feature, I couldn't find any place where I can do so. At least, running the existing ones seems nothing is broken with the change but in any case, I will be happy to implement tests if someone point me out in the right direction.