### PR TITLE
Allow PROPFIND to submit data

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -91,7 +91,7 @@ utils.forEach(['delete', 'get', 'head'], function forEachMethodNoData(method) {
   defaults.headers[method] = {};
 });
 
-utils.forEach(['post', 'put', 'patch'], function forEachMethodWithData(method) {
+utils.forEach(['post', 'put', 'patch', 'propfind'], function forEachMethodWithData(method) {
   defaults.headers[method] = utils.merge(DEFAULT_CONTENT_TYPE);
 });
 


### PR DESCRIPTION
Addresses #2270 where a PROPFIND |(for CalDAV / WebDAV) request would be stripped of its data prior to making the request.

Example request:

```
    const options = {
        method: 'PROPFIND',
        url: 'https://caldav.icloud.com/',
        auth: {
            username: 'XXX',
            password: 'ZZZ'
        },
        responseType: 'document',
        data: "<propfind xmlns='DAV:'><prop><current-user-principal/></prop></propfind>"
    }
    return axios(options as any).then((response) => {
        ...
    }).catch(error => {
        ...
    })    
```