### PR TITLE
Add 'custom' config for special case

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,11 @@ These are the available config options for making requests. Only the `url` is re
   data: {
     firstName: 'Fred'
   },
+  
+  // `custom`, add cutom config for special case, such as interceptor and etc
+  custom: {
+    foo: 'bar'
+  },
 
   // `timeout` specifies the number of milliseconds before the request times out.
   // If the request takes longer than `timeout`, the request will be aborted.

--- a/lib/core/mergeConfig.js
+++ b/lib/core/mergeConfig.js
@@ -15,7 +15,7 @@ module.exports = function mergeConfig(config1, config2) {
   config2 = config2 || {};
   var config = {};
 
-  utils.forEach(['url', 'method', 'params', 'data'], function valueFromConfig2(prop) {
+  utils.forEach(['url', 'method', 'params', 'data', 'custom'], function valueFromConfig2(prop) {
     if (typeof config2[prop] !== 'undefined') {
       config[prop] = config2[prop];
     }

--- a/test/specs/core/mergeConfig.spec.js
+++ b/test/specs/core/mergeConfig.spec.js
@@ -21,13 +21,15 @@ describe('core::mergeConfig', function() {
       url: '__sample url__',
       method: '__sample method__',
       params: '__sample params__',
-      data: { foo: true }
+      data: { foo: true },
+	  custom: { showProgress: true, showError: true }
     };
     var merged = mergeConfig(defaults, config);
     expect(merged.url).toEqual(config.url);
     expect(merged.method).toEqual(config.method);
     expect(merged.params).toEqual(config.params);
     expect(merged.data).toEqual(config.data);
+	expect(merged.custom).toEqual(config.custom);
   });
 
   it('should not inherit request options', function() {
@@ -35,13 +37,15 @@ describe('core::mergeConfig', function() {
       url: '__sample url__',
       method: '__sample method__',
       params: '__sample params__',
-      data: { foo: true }
+      data: { foo: true },
+	  custom: { showProgress: true, showError: true }
     };
     var merged = mergeConfig(localDefaults, {});
     expect(merged.url).toEqual(undefined);
     expect(merged.method).toEqual(undefined);
     expect(merged.params).toEqual(undefined);
     expect(merged.data).toEqual(undefined);
+	expect(merged.custom).toEqual(undefined);
   });
 
   it('should merge auth, headers, proxy with defaults', function() {


### PR DESCRIPTION
Add `custom` config for special case.

since v0.19.0,  axios use `/lib/core/mergeConfig.js` for merging config, and the config's properties are fixed, they must be in 'url', 'method', 'params', 'data','headers', 'auth', 'proxy','baseURL', 'transformRequest', 'transformResponse', 'paramsSerializer', 'timeout', 'withCredentials', 'adapter', 'responseType', 'xsrfCookieName',  'xsrfHeaderName', 'onUploadProgress', 'onDownloadProgress', 'maxContentLength', 'validateStatus', 'maxRedirects', 'httpAgent', 'httpsAgent', 'cancelToken', 'socketPath'.

in the previous version, we use custom config for identifying special action in interceptor.

for example (In Browser):

___Custom Request Interceptor___
```javascript
import uiService from '../../../ui-service'

export default [
  config => {
   // using the custom config the judge show progress or not
    if (config.custom.showProgress !== false) {
      config.custom.showProgress = true
      uiService.progress.start()
    }

    if (config.custom.showError !== false) {
      config.custom.showError = true
    }

    config.headers['X-Requested-With'] = 'XMLHttpRequest' // setup xhr flag
    config.withCredentials = true
    return config
  },
  error => {
    // using the custom config the judge remove progress
    if (error && error.config && error.config.custom && error.config.custom.showProgress) {
      uiService.progress.done()
    }
   // using the custom config the judge show toastr or not
    if (error && error.config && error.config.custom && error.config.custom.showError) {
      uiService.showToastr('Request Error')
    }
    return Promise.reject(error)
  }
]
```
___Custom Response Interceptor___
```javascript
import uiService from '../../../ui-service'

export default [
  response => {
    if (response && response.config && response.config.custom && response.config.custom.showProgress) {
      uiService.progress.done()
    }
    return response.data
  },
  error => {
    // progesss
    if (error && error.config && error.config.showProgress) {
      uiService.progress.done()
    }

    let err = {
      status: 500,
      errcode: '',
      message: (error.response && error.response.data && error.response.data.message) || error.message || 'Unknown Error',
      stack: error.stack || ''
    }

    if (error && error.config && error.config.custom && error.config.custom.showError) {
      if (error.message === 'Network Error') {
        err.message = 'Network Error'
      }
      uiService.showToastr(err.message)
    }

    if (error.response && error.response.data) {
      err.errcode = error.response.data.status
      err.message = error.response.data.message
    }
    return Promise.reject(err)
  }
]
```
The default behavior for interceptor is diplay progress bar, we can disable it by passed config
```javascript
let updateUser = () => {
  return createRequest(req)
    .get('/xxxxxx', {
      params: {
        guid,
        type
      },
      custom: {
        showProgress: false
      }
    })
}
```

The PR add a custom config in config for this case