### PR TITLE
Fixing set `config.method` after mergeConfig for Axios.prototype.request

### DIFF
--- a/lib/core/Axios.js
+++ b/lib/core/Axios.js
@@ -35,7 +35,15 @@ Axios.prototype.request = function request(config) {
   }
 
   config = mergeConfig(this.defaults, config);
-  config.method = config.method ? config.method.toLowerCase() : 'get';
+
+  // Set config.method
+  if (config.method) {
+    config.method = config.method.toLowerCase();
+  } else if (this.defaults.method) {
+    config.method = this.defaults.method.toLowerCase();
+  } else {
+    config.method = 'get';
+  }
 
   // Hook up interceptors middleware
   var chain = [dispatchRequest, undefined];


### PR DESCRIPTION
Inside **Axios.prototype.request** function

It's forced to set `config.method `to  `GET` after `mergeConfig` if `config.method` exists 
which makes the `defaults.method` not effective.

```javascript
// Set default options
const instance = axios.create({ method: 'post', /* options */ })

// use instance.request() or instance()
instance({ url })            
instance.request({ url })     
```  

HTTP method should be POST above.


