### PR TITLE
Update response interceptor docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,9 +492,11 @@ axios.interceptors.request.use(function (config) {
 
 // Add a response interceptor
 axios.interceptors.response.use(function (response) {
+    // Any status code that lie within the range of 2xx cause this function to trigger
     // Do something with response data
     return response;
   }, function (error) {
+    // Any status codes that falls outside the range of 2xx cause this function to trigger
     // Do something with response error
     return Promise.reject(error);
   });


### PR DESCRIPTION
The documentation for response interceptor seems lacking of the description when the two functions are executed. 

Adding documentation which describes it will certainly be helpful.