### PR TITLE
fix:Merge array error becomes object

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -250,8 +250,8 @@ function forEach(obj, fn) {
  */
 function merge(/* obj1, obj2, obj3, ... */) {
   var result;
-  function assignValue(val, key , obj) {
-    result = result || (isArray(obj) ? [] : {})
+  function assignValue(val, key, obj) {
+    result = result || (isArray(obj) ? [] : {});
 
     if (typeof result[key] === 'object' && typeof val === 'object') {
       result[key] = merge(result[key], val);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -249,8 +249,10 @@ function forEach(obj, fn) {
  * @returns {Object} Result of all merge properties
  */
 function merge(/* obj1, obj2, obj3, ... */) {
-  var result = {};
-  function assignValue(val, key) {
+  var result;
+  function assignValue(val, key , obj) {
+    result = result || (isArray(obj) ? [] : {})
+
     if (typeof result[key] === 'object' && typeof val === 'object') {
       result[key] = merge(result[key], val);
     } else {


### PR DESCRIPTION
merge({
    data:{
        filters:[{
            name:'1'
        }]
    }
},{
    data:{
        filters:[{
            name:'b'
        }]
    }
})

----- 
error merge to : { data: { filters: { '0': [Object] } } }
----
The correct answer should be： {"data":{"filters":[{"name":"b"}]}}
