### PR TITLE
Fix the  number length exceeds 16 in return value, resulting the prec…

### DIFF
--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -49,6 +49,8 @@ module.exports = function xhrAdapter(config) {
       // Prepare the response
       var responseHeaders = 'getAllResponseHeaders' in request ? parseHeaders(request.getAllResponseHeaders()) : null;
       var responseData = !config.responseType || config.responseType === 'text' ? request.responseText : request.response;
+      var reg = /:\s?(\d{16,})/g; //the number length exceeds 16
+      responseData = responseData.replace(reg, ':"$1"'); //replace to string
       var response = {
         data: responseData,
         status: request.status,

--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -49,8 +49,10 @@ module.exports = function xhrAdapter(config) {
       // Prepare the response
       var responseHeaders = 'getAllResponseHeaders' in request ? parseHeaders(request.getAllResponseHeaders()) : null;
       var responseData = !config.responseType || config.responseType === 'text' ? request.responseText : request.response;
-      var reg = /:\s?(\d{16,})/g; //the number length exceeds 16
-      responseData = responseData.replace(reg, ':"$1"'); //replace to string
+      // The number length exceeds 16
+      var reg = /:\s?(\d{16,})/g;
+      // Replace to string
+      responseData = responseData.replace(reg, ':"$1"');
       var response = {
         data: responseData,
         status: request.status,


### PR DESCRIPTION
Fix the  number length exceeds 16 in return value, resulting the precision is lost in js

<!-- Click "Preview" for a more readable version -->

#### Instructions
Sometimes, the "orderNumber" or "userCode" returned by the backend is a pure number and may be longer than 16. This will result in the loss of the precision of the string received by the front end, which will cause some unnecessary trouble.
Perhaps, this problem should be solved by the backend, returning a string type "orderNumber", but in most cases the backend is more complicated to change or they are not willing to modify. So I added this string of code to solve this problem.

```javascript
// Prepare the response
var responseHeaders = 'getAllResponseHeaders' in request ? parseHeaders(request.getAllResponseHeaders()) : null;
var responseData = !config.responseType || config.responseType === 'text' ? request.responseText : request.response;
// The number length exceeds 16
var reg = /:\s?(\d{16,})/g;
// Replace to string
responseData = responseData.replace(reg, ':"$1"');
```
