### PR TITLE
Make redirection from HTTP to HTTPS work

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -85,6 +85,10 @@ module.exports = function httpAdapter(config) {
       method: config.method.toUpperCase(),
       headers: headers,
       agent: agent,
+      agents: {
+        httpsAgent: config.httpsAgent,
+        httpAgent: config.httpAgent
+      },
       auth: auth
     };
 


### PR DESCRIPTION
When calling an HTTP resource redirecting to a HTTPS one with a keepAlive agent. We get the following error:
```
TypeError [ERR_INVALID_PROTOCOL]: Protocol "https:" not supported. Expected "http:"
    at new ClientRequest (_http_client.js:119:11)
    at Object.request (https.js:281:10)
    at RedirectableRequest._performRequest (/Users/jthomassey/projects/ecom-shop-web/node_modules/follow-redirects/index.js:169:24)
    at RedirectableRequest._processResponse (/Users/jthomassey/projects/ecom-shop-web/node_modules/follow-redirects/index.js:260:10)
    at ClientRequest.RedirectableRequest._onNativeResponse (/Users/jthomassey/projects/ecom-shop-web/node_modules/follow-redirects/index.js:50:10)
    at Object.onceWrapper (events.js:277:13)
    at ClientRequest.emit (events.js:189:13)
    at HTTPParser.parserOnIncomingClient [as onIncoming] (_http_client.js:556:21)
    at HTTPParser.parserOnHeadersComplete (_http_common.js:109:17)
    at Socket.socketOnData (_http_client.js:442:20)
```

This can be tested here : 
```
const http = require('http');
const https = require('https');
const axios = require('axios');

axios.get('http://www.photobox.fr', { httpAgent: http.Agent({ keepAlive:true }), httpsAgent: https.Agent({ keepAlive:true }) })
  .then(response => {
    console.log(response);
    console.log(response.headers);
  })
  .catch(error => {
    console.log(error);
  });
```

Axios delegate the redirection to the follow-redirect package which accept an option `agents` for both http and https agent see : https://github.com/follow-redirects/follow-redirects#per-request-options