### PR TITLE
Add toJSON property to AxiosError type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -82,6 +82,7 @@ export interface AxiosError<T = any> extends Error {
   request?: any;
   response?: AxiosResponse<T>;
   isAxiosError: boolean;
+  toJSON: () => object;
 }
 
 export interface AxiosPromise<T = any> extends Promise<AxiosResponse<T>> {


### PR DESCRIPTION
I noticed the error object has a `toJSON` method but when I tried to use it in my typescript code it complained it didn't exist, even though I was using the `AxiosError` type.
