### PR TITLE
Disable Content-Type header

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -12,8 +12,9 @@ function setContentTypeIfUnset(headers, value) {
     headers['Content-Type'] = value;
   }
 
-  if (!utils.isUndefined(headers) && !headers['Content-Type'])
+  if (!utils.isUndefined(headers) && !headers['Content-Type']) {
     delete headers['Content-Type'];
+  }
 }
 
 function getDefaultAdapter() {

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -11,6 +11,9 @@ function setContentTypeIfUnset(headers, value) {
   if (!utils.isUndefined(headers) && utils.isUndefined(headers['Content-Type'])) {
     headers['Content-Type'] = value;
   }
+
+  if (!utils.isUndefined(headers) && !headers['Content-Type'])
+    delete headers['Content-Type'];
 }
 
 function getDefaultAdapter() {


### PR DESCRIPTION
If you want to send a post request without headers, you need to create an instance without headers by default:
```
const instance = axios.create();
instance.defaults.headers.common = {};
instance.defaults.headers.post = {};
```

But then you will have a header 'Content-Type': 'application/x-www-form-urlencoded;charset=utf-8'. To disable this header, you need to pass 'content-type': false to the headers:
```
instance({
        method: 'post',
        url: `${baseURL}/auth`,
        data: {
          uid,
        },
        headers: {
          'content-type': false,
        },
      });
```

That's all :)