### PR TITLE
Fixing #2482 Can not override Content-Type on Headers when send GET requests

### DIFF
--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -118,8 +118,12 @@ module.exports = function xhrAdapter(config) {
     // Add headers to the request
     if ('setRequestHeader' in request) {
       utils.forEach(requestHeaders, function setRequestHeader(val, key) {
-        if (typeof requestData === 'undefined' && key.toLowerCase() === 'content-type') {
-          // Remove Content-Type if data is undefined
+        if (key.toLowerCase() === 'content-type' &&
+          ((typeof requestData === 'undefined' && config.method.toLowerCase === 'post') ||
+            (typeof config.params === 'undefined' && config.method.toLowerCase === 'get'))
+        ) {
+          // Remove Content-Type if data is undefined when method is POST
+          // or params is undefined when method is GET
           delete requestHeaders[key];
         } else {
           // Otherwise add header to the request

--- a/test/specs/headers.spec.js
+++ b/test/specs/headers.spec.js
@@ -78,6 +78,15 @@ describe('headers', function () {
     });
   });
 
+  it('should remove content-type if params is empty when method is GET', function (done) {
+    axios.get('/foo');
+
+    getAjaxRequest().then(function (request) {
+      testHeaderValue(request.requestHeaders, 'Content-Type', undefined);
+      done();
+    });
+  });
+
   it('should preserve content-type if data is false', function (done) {
     axios.post('/foo', false);
 


### PR DESCRIPTION

See #2482
