### PR TITLE
remove License badge from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 [![npm downloads](https://img.shields.io/npm/dm/axios.svg?style=flat-square)](http://npm-stat.com/charts.html?package=axios)
 [![gitter chat](https://img.shields.io/gitter/room/mzabriskie/axios.svg?style=flat-square)](https://gitter.im/mzabriskie/axios)
 [![code helpers](https://www.codetriage.com/axios/axios/badges/users.svg)](https://www.codetriage.com/axios/axios)
-![license: MIT](https://img.shields.io/badge/License-MIT-blue.svg)
 
 Promise based HTTP client for the browser and node.js
 


### PR DESCRIPTION
<!-- Click "Preview" for a more readable version -->

Describe your pull request here.
Remove License badge in README.md as GitHub repository already shows on its bar.