### PR TITLE
fix issue #2235: add custom `btoa` in the environment which does not support it

### DIFF
--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -7,6 +7,7 @@ var buildFullPath = require('../core/buildFullPath');
 var parseHeaders = require('./../helpers/parseHeaders');
 var isURLSameOrigin = require('./../helpers/isURLSameOrigin');
 var createError = require('../core/createError');
+var btoa = (!utils.isUndefined(window) && window.btoa && utils.isFunction(window.btoa) && window.btoa.bind(window)) || require('./../helpers/btoa');
 
 module.exports = function xhrAdapter(config) {
   return new Promise(function dispatchXhrRequest(resolve, reject) {

--- a/lib/helpers/btoa.js
+++ b/lib/helpers/btoa.js
@@ -1,0 +1,36 @@
+'use strict';
+
+// btoa polyfill form https://github.com/davidchambers/Base64.js
+
+var chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=';
+
+function E(message) {
+  this.message = message;
+}
+E.prototype = new Error;
+E.prototype.code = 5;
+E.prototype.name = 'InvalidCharacterError';
+
+function btoa(input) {
+  var str = String(input);
+  var output = '';
+  for (
+    // initialize result and counter
+    var block, charCode, idx = 0, map = chars;
+    // if the next str index does not exist:
+    //   change the mapping table to "="
+    //   check if d has no fractional digits
+    str.charAt(idx | 0) || (map = '=', idx % 1);
+    // "8 - idx % 1 * 8" generates the sequence 2, 4, 6, 8
+    output += map.charAt(63 & block >> 8 - idx % 1 * 8)
+  ) {
+    charCode = str.charCodeAt(idx += 3 / 4);
+    if (charCode > 0xFF) {
+      throw new E('String contains an invalid character');
+    }
+    block = block << 8 | charCode;
+  }
+  return output;
+}
+
+module.exports = btoa;

--- a/test/specs/__helpers.js
+++ b/test/specs/__helpers.js
@@ -90,3 +90,6 @@ setupBasicAuthTest = function setupBasicAuthTest() {
     });
   });
 };
+
+// Is this an old version of IE that lacks standard objects like DataView, ArrayBuffer, FormData, etc.
+isOldIE = /MSIE (8|9)\.0/.test(navigator.userAgent);

--- a/test/specs/helpers/basicAuthWithPolyfill.spec.js
+++ b/test/specs/helpers/basicAuthWithPolyfill.spec.js
@@ -1,0 +1,18 @@
+var window_btoa;
+
+describe('basicAuth with btoa polyfill', function() {
+  beforeAll(function() {
+    window_btoa = window.btoa;
+    window.btoa = undefined;
+  });
+
+  afterAll(function() {
+    window.btoa = window_btoa;
+    window_btoa = undefined;
+  });
+  it('should not have native window.btoa', function(){
+    expect(window.btoa).toEqual(undefined);
+  });
+
+  setupBasicAuthTest();
+});

--- a/test/specs/helpers/btoa.spec.js
+++ b/test/specs/helpers/btoa.spec.js
@@ -1,0 +1,27 @@
+var __btoa = require('./../../../lib/helpers/btoa');
+
+describe('btoa polyfill', function () {
+  it('should behave the same as native window.btoa', function () {
+    // btoa doesn't exist in IE8/9 
+    // https://developer.mozilla.org/zh-CN/docs/Web/API/WindowBase64/btoa
+    if (isOldIE && typeof Int8Array === 'undefined') {
+      return;
+    }
+
+    var data = 'Hello:world';
+    expect(__btoa(data)).toEqual(window.btoa(data));
+  });
+
+  it('should throw an error if char is out of range 0xFF', function () {
+    var err;
+    var data = 'I ♡ Axios!';
+
+    try {
+      __btoa(data);
+    } catch (e) {
+      err = e;
+    }
+
+    validateInvalidCharacterError(err);
+  });
+});


### PR DESCRIPTION
### Changes:
- add custom `btoa` function for some special environment like `expo app` which does not support it
- Fix for #2235 