### PR TITLE
Fix issue #2239: Add a condition to check if status is a function

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,9 +354,8 @@ These are the available config options for making requests. Only the `url` is re
   maxContentLength: 2000,
 
   // `validateStatus` defines whether to resolve or reject the promise for a given
-  // HTTP response status code. If `validateStatus` returns `true` (or is set to `null`
-  // or `undefined`), the promise will be resolved; otherwise, the promise will be
-  // rejected.
+  // HTTP response status code. If `validateStatus` returns `true` (or is set to `null`), 
+  // the promise will be resolved; otherwise, the promise will be rejected.
   validateStatus: function (status) {
     return status >= 200 && status < 300; // default
   },

--- a/lib/core/settle.js
+++ b/lib/core/settle.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var createError = require('./createError');
-
+var utils = require('./../utils');
 /**
  * Resolve or reject a Promise based on response status.
  *
@@ -11,7 +11,7 @@ var createError = require('./createError');
  */
 module.exports = function settle(resolve, reject, response) {
   var validateStatus = response.config.validateStatus;
-  if (!validateStatus || validateStatus(response.status)) {
+  if (validateStatus === null || (utils.isFunction(validateStatus) && validateStatus(response.status))) {
     resolve(response);
   } else {
     reject(createError(

--- a/test/specs/core/settle.spec.js
+++ b/test/specs/core/settle.spec.js
@@ -22,15 +22,39 @@ describe('core::settle', function() {
     expect(reject).not.toHaveBeenCalled();
   });
 
-  it('should resolve promise if validateStatus is not set', function() {
+  it('should resolve promise if validateStatus set null', function() {
     var response = {
       status: 500,
       config: {
+        validateStatus: null
       }
     };
     settle(resolve, reject, response);
     expect(resolve).toHaveBeenCalledWith(response);
     expect(reject).not.toHaveBeenCalled();
+  });
+
+  it('should reject promise if validateStatus is not set', function() {
+    var req = {
+      path: '/foo'
+    };
+    var response = {
+      status: 500,
+      config: {
+      },
+      request: req
+    };
+    settle(resolve, reject, response);
+    expect(resolve).not.toHaveBeenCalled();
+    expect(reject).toHaveBeenCalled();
+    var reason = reject.calls.first().args[0];
+    expect(reason instanceof Error).toBe(true);
+    expect(reason.config).toBe(response.config);
+    expect(reason.request).toBe(req);
+    expect(reason.response).toBe(response);
+    expect(reason.isAxiosError).toBe(true);
+    expect(typeof reason.toJSON).toEqual('function');
+    expect(reason.toJSON().message).toBe('Request failed with status code 500');
   });
 
   it('should resolve promise if validateStatus returns true', function() {
@@ -65,10 +89,12 @@ describe('core::settle', function() {
     expect(reject).toHaveBeenCalled();
     var reason = reject.calls.first().args[0];
     expect(reason instanceof Error).toBe(true);
-    expect(reason.message).toBe('Request failed with status code 500');
     expect(reason.config).toBe(response.config);
     expect(reason.request).toBe(req);
     expect(reason.response).toBe(response);
+    expect(reason.isAxiosError).toBe(true);
+    expect(typeof reason.toJSON).toEqual('function');
+    expect(reason.toJSON().message).toBe('Request failed with status code 500');
   });
 
   it('should pass status to validateStatus', function() {

--- a/test/specs/requests.spec.js
+++ b/test/specs/requests.spec.js
@@ -119,10 +119,12 @@ describe('requests', function () {
         expect(rejectSpy).toHaveBeenCalled();
         var reason = rejectSpy.calls.first().args[0];
         expect(reason instanceof Error).toBe(true);
-        expect(reason.message).toBe('Request failed with status code 500');
         expect(reason.config.method).toBe('get');
         expect(reason.config.url).toBe('/foo');
         expect(reason.response.status).toBe(500);
+        expect(reason.isAxiosError).toBe(true);
+        expect(typeof reason.toJSON).toEqual('function');
+        expect(reason.toJSON().message).toBe('Request failed with status code 500');
 
         done();
       });


### PR DESCRIPTION
### PR Description

1. As required,  `validateStatus` should be config to be `null` or  `function` ,

2. If `validateStatus` returns `true` (or is set to `null` ), the promise will be resolved; otherwise, the promise will be rejected 

3. fixes #2239 
