### PR TITLE
add native allSettled method for axios from Promise

### DIFF
--- a/lib/axios.js
+++ b/lib/axios.js
@@ -41,10 +41,15 @@ axios.Cancel = require('./cancel/Cancel');
 axios.CancelToken = require('./cancel/CancelToken');
 axios.isCancel = require('./cancel/isCancel');
 
-// Expose all/spread
+// Expose all/spread/allSettled
 axios.all = function all(promises) {
   return Promise.all(promises);
 };
+
+axios.allSettled = function allSettled(promises){
+  return Promise.allSettled(promises);
+};
+
 axios.spread = require('./helpers/spread');
 
 module.exports = axios;


### PR DESCRIPTION
Sometimes we need to deal with serveral concurrent requests util they are all done,there is one way we can use with axios:
```js
// Use Promise.allSettled,notice that allSettled is not supported by axios natively
Promise.allSettled([
  axios.get('/sample-get'),
  axios.post('/sample-post')
]).then((result) => {
  // `result` should contain an array of either http responses or errors
})
```
But it is an unappealing way to implement it.So I extend the method of axios by addding allSettled method to it.
```js
axios.allSettled = function allSettled(promises){
  return Promise.allSettled(promises);
};
```
Therefore,I can use axios like
```js
axios.allSettled([
   promise1,promise2
]).then((result) => {
  // `result` should contain an array of either http responses or errors
})
```
It is a better pratice from my point of view.


