### PR TITLE
fix: URL encoding on values

### DIFF
--- a/lib/helpers/buildURL.js
+++ b/lib/helpers/buildURL.js
@@ -2,7 +2,7 @@
 
 var utils = require('./../utils');
 
-function encode(val) {
+function encodeKey(val) {
   return encodeURIComponent(val).
     replace(/%40/gi, '@').
     replace(/%3A/gi, ':').
@@ -51,7 +51,7 @@ module.exports = function buildURL(url, params, paramsSerializer) {
         } else if (utils.isObject(v)) {
           v = JSON.stringify(v);
         }
-        parts.push(encode(key) + '=' + encode(v));
+        parts.push(encodeKey(key) + '=' + encodeURIComponent(v));
       });
     });
 

--- a/test/specs/helpers/buildURL.spec.js
+++ b/test/specs/helpers/buildURL.spec.js
@@ -17,7 +17,7 @@ describe('helpers::buildURL', function () {
       foo: {
         bar: 'baz'
       }
-    })).toEqual('/foo?foo=' + encodeURI('{"bar":"baz"}'));
+    })).toEqual('/foo?foo=' + encodeURIComponent('{"bar":"baz"}'));
   });
 
   it('should support date params', function () {
@@ -25,7 +25,7 @@ describe('helpers::buildURL', function () {
 
     expect(buildURL('/foo', {
       date: date
-    })).toEqual('/foo?date=' + date.toISOString());
+    })).toEqual('/foo?date=' + encodeURIComponent(date.toISOString()));
   });
 
   it('should support array params', function () {
@@ -34,10 +34,10 @@ describe('helpers::buildURL', function () {
     })).toEqual('/foo?foo[]=bar&foo[]=baz');
   });
 
-  it('should support special char params', function () {
+  it('should support special char params on keys', function () {
     expect(buildURL('/foo', {
-      foo: '@:$, '
-    })).toEqual('/foo?foo=@:$,+');
+      '@:$, ': '@:$, '
+    })).toEqual('/foo?@:$,+=%40%3A%24%2C%20');
   });
 
   it('should support existing params', function () {


### PR DESCRIPTION
Fixes #678 #1111 #1644 #1727.

I see some people having the same problem and having to use a custom `paramsSerializer` to handle it. Maybe I'm wrong, but I believe the reason for the `encode()` function (which I'm renaming here to `encodeKey()`) to "unescape" certain characters after the call to `encodeURIComponent` is so that things like `?foo[0]=bar&foo[1]=baz` work properly, but this should only happen on the keys, not the values.