### PR TITLE
fix issue #2567 Rewrite the 'utils.deepMerge()' method

### DIFF
--- a/lib/core/mergeConfig.js
+++ b/lib/core/mergeConfig.js
@@ -33,11 +33,11 @@ module.exports = function mergeConfig(config1, config2) {
 
   utils.forEach(mergeDeepPropertiesKeys, function mergeDeepProperties(prop) {
     if (utils.isObject(config2[prop])) {
-      config[prop] = utils.deepMerge(config1[prop], config2[prop]);
+      config[prop] = utils.deepMerge({}, config1[prop], config2[prop]);
     } else if (typeof config2[prop] !== 'undefined') {
       config[prop] = config2[prop];
     } else if (utils.isObject(config1[prop])) {
-      config[prop] = utils.deepMerge(config1[prop]);
+      config[prop] = utils.deepMerge({}, config1[prop]);
     } else if (typeof config1[prop] !== 'undefined') {
       config[prop] = config1[prop];
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -106,6 +106,16 @@ function isObject(val) {
 }
 
 /**
+ * Determine if a value is an Object
+ *
+ * @param {Object} val The value to test
+ * @returns {boolean} True if value is an Object, otherwise false
+ */
+function isPlainObject(val) {
+  return toString.call(val) === '[object Object]';
+}
+
+/**
  * Determine if a value is a Date
  *
  * @param {Object} val The value to test
@@ -282,22 +292,36 @@ function merge(/* obj1, obj2, obj3, ... */) {
  * @param {Object} obj1 Object to merge
  * @returns {Object} Result of all merge properties
  */
-function deepMerge(/* obj1, obj2, obj3, ... */) {
-  var result = {};
-  function assignValue(val, key) {
-    if (typeof result[key] === 'object' && typeof val === 'object') {
-      result[key] = deepMerge(result[key], val);
-    } else if (typeof val === 'object') {
-      result[key] = deepMerge({}, val);
-    } else {
-      result[key] = val;
-    }
+function deepMerge() {
+  var target = arguments[0] || {};
+  var length = arguments.length;
+  var i = 1;
+  // eslint-disable-next-line one-var
+  var src, clone, copyIsArray;
+
+  if (typeof target !== 'object') {
+    target = {};
   }
 
-  for (var i = 0, l = arguments.length; i < l; i++) {
+  function assignValue(val, key) {
+    src = target[key];
+    if (isPlainObject(val) || (copyIsArray = isArray(val))) {
+      if (copyIsArray) {
+        copyIsArray = false;
+        clone = src && isArray(src) ? src : [];
+      } else {
+        clone = src && isPlainObject(src) ? src : {};
+      }
+      target[key] = deepMerge(clone, val);
+    } else if (!isUndefined(val)) {
+      target[key] = val;
+    }
+  }
+  for (; i < length; i++) {
     forEach(arguments[i], assignValue);
   }
-  return result;
+
+  return target;
 }
 
 /**
@@ -328,6 +352,7 @@ module.exports = {
   isString: isString,
   isNumber: isNumber,
   isObject: isObject,
+  isPlainObject: isPlainObject,
   isUndefined: isUndefined,
   isDate: isDate,
   isFile: isFile,

--- a/test/specs/utils/deepMerge.spec.js
+++ b/test/specs/utils/deepMerge.spec.js
@@ -6,7 +6,7 @@ describe('utils::deepMerge', function () {
     var b = {foo: 123};
     var c = {bar: 456};
 
-    deepMerge(a, b, c);
+    deepMerge({}, a, b, c);
 
     expect(typeof a.foo).toEqual('undefined');
     expect(typeof a.bar).toEqual('undefined');
@@ -18,7 +18,7 @@ describe('utils::deepMerge', function () {
     var a = {foo: 123};
     var b = {bar: 456};
     var c = {foo: 789};
-    var d = deepMerge(a, b, c);
+    var d = deepMerge({}, a, b, c);
 
     expect(d.foo).toEqual(789);
     expect(d.bar).toEqual(456);
@@ -28,7 +28,7 @@ describe('utils::deepMerge', function () {
     var a = {foo: {bar: 123}};
     var b = {foo: {baz: 456}, bar: {qux: 789}};
 
-    expect(deepMerge(a, b)).toEqual({
+    expect(deepMerge({}, a, b)).toEqual({
       foo: {
         bar: 123,
         baz: 456
@@ -42,7 +42,7 @@ describe('utils::deepMerge', function () {
   it('should remove all references from nested objects', function () {
     var a = {foo: {bar: 123}};
     var b = {};
-    var d = deepMerge(a, b);
+    var d = deepMerge({}, a, b);
 
     expect(d).toEqual({
       foo: {
@@ -53,14 +53,26 @@ describe('utils::deepMerge', function () {
     expect(d.foo).not.toBe(a.foo);
   });
 
+  it('Should not change the data type', function() {
+    var a = {foo: {bar:123}, hnd: [444, 555, 666]};
+    var b = {foo: {baz: 456}, hnd: [222]};
+    var d = deepMerge({}, a, b);
+    expect(d).toEqual({
+      foo: {bar: 123, baz: 456},
+      hnd: [222, 555, 666]
+    });
+    expect(d.foo).not.toBe(a.foo);
+    expect(d.hnd).not.toBe(a.hnd);
+  });
+
   it('handles null and undefined arguments', function () {
     expect(deepMerge(undefined, undefined)).toEqual({});
     expect(deepMerge(undefined, {foo: 123})).toEqual({foo: 123});
-    expect(deepMerge({foo: 123}, undefined)).toEqual({foo: 123});
+    expect(deepMerge({}, {foo: 123}, undefined)).toEqual({foo: 123});
 
     expect(deepMerge(null, null)).toEqual({});
     expect(deepMerge(null, {foo: 123})).toEqual({foo: 123});
-    expect(deepMerge({foo: 123}, null)).toEqual({foo: 123});
+    expect(deepMerge({}, {foo: 123}, null)).toEqual({foo: 123});
   });
 });
 


### PR DESCRIPTION
### Changes：

1. Rewrite the 'utils.deepMerge()' method, this method should not change the data type.

2. Fixes #2567  