### PR TITLE
Fix CI build failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   },
   "typings": "./index.d.ts",
   "dependencies": {
-    "follow-redirects": "^1.4.1"
+    "follow-redirects": "1.5.10"
   },
   "bundlesize": [
     {


### PR DESCRIPTION
### Changes

1. Error message: "Should support max redirects."

2. Reason:  `follow-redirects` installed `version-1.9.0`.
```
https://github.com/axios/axios/blob/master/package.json#L76
```
3. Related PR #1816 
