### PR TITLE
Remove 'includes' API, fix CI build failure

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -26,7 +26,8 @@ function isArray(val) {
  * @returns {boolean} True if value is a Buffer, otherwise false
  */
 function isBuffer(val) {
-  return ![undefined, null].includes(val) && val.constructor === Buffer;
+  if (val === null || val === void 0 || val.constructor === null || val.constructor === void 0 )  return false;
+  return typeof val.constructor.isBuffer === 'function' && val.constructor.isBuffer(val);
 }
 
 /**

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -18,6 +18,15 @@ function isArray(val) {
   return toString.call(val) === '[object Array]';
 }
 
+/**
+ * Determine if a value is undefined
+ *
+ * @param {Object} val The value to test
+ * @returns {boolean} True if the value is undefined, otherwise false
+ */
+function isUndefined(val) {
+  return typeof val === 'undefined';
+}
 
 /**
  * Determine if a value is a Buffer
@@ -26,7 +35,7 @@ function isArray(val) {
  * @returns {boolean} True if value is a Buffer, otherwise false
  */
 function isBuffer(val) {
-  if (val === null || val === void 0 || val.constructor === null || val.constructor === void 0 )  return false;
+  if (val === null || isUndefined(val) || val.constructor === null ||  isUndefined(val.constructor))  return false;
   return typeof val.constructor.isBuffer === 'function' && val.constructor.isBuffer(val);
 }
 
@@ -84,16 +93,6 @@ function isString(val) {
  */
 function isNumber(val) {
   return typeof val === 'number';
-}
-
-/**
- * Determine if a value is undefined
- *
- * @param {Object} val The value to test
- * @returns {boolean} True if the value is undefined, otherwise false
- */
-function isUndefined(val) {
-  return typeof val === 'undefined';
 }
 
 /**

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -35,8 +35,8 @@ function isUndefined(val) {
  * @returns {boolean} True if value is a Buffer, otherwise false
  */
 function isBuffer(val) {
-  if (val === null || isUndefined(val) || val.constructor === null ||  isUndefined(val.constructor))  return false;
-  return typeof val.constructor.isBuffer === 'function' && val.constructor.isBuffer(val);
+  return val !== null && !isUndefined(val) && val.constructor !== null && !isUndefined(val.constructor)
+    && typeof val.constructor.isBuffer === 'function' && val.constructor.isBuffer(val);
 }
 
 /**


### PR DESCRIPTION
### Changes:

1. Error message: "Object doesn't support property or method 'includes' to equal."

2. Reason: 'includes' belongs to the API of `ES7`, `ie11` does not support it.

    https://github.com/axios/axios/blob/master/lib/utils.js#L29

3. Related PR #1816