### PR TITLE
fix: fix ignore set withCredentials false

### DIFF
--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -129,8 +129,8 @@ module.exports = function xhrAdapter(config) {
     }
 
     // Add withCredentials to request if needed
-    if (config.withCredentials) {
-      request.withCredentials = true;
+    if (!utils.isUndefined(config.withCredentials)) {
+      request.withCredentials = !!config.withCredentials;
     }
 
     // Add responseType to request if needed


### PR DESCRIPTION
Same issue as https://github.com/axios/axios/issues/1837

When i  use `React-native`, which sets the default value of withCredentials as true.

I try to set `withCredentials: false` , and `axios` will ignore the `withCredentials` config