### PR TITLE
Adding form-data support

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ These are the available config options for making requests. Only the `url` is re
   // When no `transformRequest` is set, must be of one of the following types:
   // - string, plain object, ArrayBuffer, ArrayBufferView, URLSearchParams
   // - Browser only: FormData, File, Blob
-  // - Node only: Stream, Buffer
+  // - Node only: Stream, Buffer, form-data (https://www.npmjs.com/package/form-data)
   data: {
     firstName: 'Fred'
   },

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -35,22 +35,28 @@ module.exports = function httpAdapter(config) {
       headers['User-Agent'] = 'axios/' + pkg.version;
     }
 
-    if (data && !utils.isStream(data)) {
-      if (Buffer.isBuffer(data)) {
-        // Nothing to do...
-      } else if (utils.isArrayBuffer(data)) {
-        data = Buffer.from(new Uint8Array(data));
-      } else if (utils.isString(data)) {
-        data = Buffer.from(data, 'utf-8');
-      } else {
-        return reject(createError(
-          'Data after transformation must be a string, an ArrayBuffer, a Buffer, or a Stream',
-          config
-        ));
+    if (data) {
+      if (utils.isFunction(data.getHeaders)) {
+        headers = utils.merge(data.getHeaders(), headers);
       }
 
-      // Add Content-Length header if data exists
-      headers['Content-Length'] = data.length;
+      if (!utils.isStream(data)) {
+        if (Buffer.isBuffer(data)) {
+          // Nothing to do...
+        } else if (utils.isArrayBuffer(data)) {
+          data = Buffer.from(new Uint8Array(data));
+        } else if (utils.isString(data)) {
+          data = Buffer.from(data, 'utf-8');
+        } else {
+          return reject(createError(
+            'Data after transformation must be a string, an ArrayBuffer, a Buffer, or a Stream',
+            config
+          ));
+        }
+
+        // Add Content-Length header if data exists
+        headers['Content-Length'] = data.length;
+      }
     }
 
     // HTTP basic authentication


### PR DESCRIPTION
This adds support for the form-data package.

It was already possible to submit form-data using this package, as it inherits a stream. This commit extends this support by setting the correct header automatically, without adding dependencies.

Closes #789