### PR TITLE
add AxiosError to AxiosInterceptorManager use onRejected

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -120,7 +120,7 @@ export interface CancelTokenSource {
 }
 
 export interface AxiosInterceptorManager<V> {
-  use(onFulfilled?: (value: V) => V | Promise<V>, onRejected?: (error: any) => any): number;
+  use(onFulfilled?: (value: V) => V | Promise<V>, onRejected?: (error: AxiosError) => any): number;
   eject(id: number): void;
 }
 


### PR DESCRIPTION
This adds AxiosError type to onRejected callback so we won't have to write this

![image](https://user-images.githubusercontent.com/20615964/71516025-dffb3880-28bb-11ea-8c2b-50a2d2a7b164.png)
