### PR TITLE
Fix merging of params

### DIFF
--- a/lib/core/enhanceError.js
+++ b/lib/core/enhanceError.js
@@ -20,7 +20,7 @@ module.exports = function enhanceError(error, config, code, request, response) {
   error.response = response;
   error.isAxiosError = true;
 
-  error.toJSON = function() {
+  error.toJSON = function toJSON() {
     return {
       // Standard
       message: this.message,

--- a/lib/core/mergeConfig.js
+++ b/lib/core/mergeConfig.js
@@ -15,8 +15,8 @@ module.exports = function mergeConfig(config1, config2) {
   config2 = config2 || {};
   var config = {};
 
-  var valueFromConfig2Keys = ['url', 'method', 'params', 'data'];
-  var mergeDeepPropertiesKeys = ['headers', 'auth', 'proxy'];
+  var valueFromConfig2Keys = ['url', 'method', 'data'];
+  var mergeDeepPropertiesKeys = ['headers', 'auth', 'proxy', 'params'];
   var defaultToConfig2Keys = [
     'baseURL', 'url', 'transformRequest', 'transformResponse', 'paramsSerializer',
     'timeout', 'withCredentials', 'adapter', 'responseType', 'xsrfCookieName',

--- a/test/specs/core/mergeConfig.spec.js
+++ b/test/specs/core/mergeConfig.spec.js
@@ -40,23 +40,20 @@ describe('core::mergeConfig', function() {
     expect(merged.data).toEqual(undefined);
   });
 
-  it('should merge auth, headers, params, proxy with defaults', function() {
-    expect(mergeConfig({ auth: { user: 'foo' } }, { auth: { pass: 'test' } })).toEqual({
-      auth: { user: 'foo', pass: 'test' }
+  ['auth', 'headers', 'params', 'proxy'].forEach(key => {
+    it(`should set new config for ${key} without default`, function() {
+      expect(mergeConfig({ [key]: undefined }, { [key]: { user: 'foo', pass: 'test' } })).toEqual({
+        [key]: { user: 'foo', pass: 'test' }
+      });
     });
-    expect(mergeConfig({ headers: { user: 'foo' } }, { headers: { pass: 'test' } })).toEqual({
-      headers: { user: 'foo', pass: 'test' }
-    });
-    expect(mergeConfig({ params: { user: 'foo' } }, { params: { pass: 'test' } })).toEqual({
-      params: { user: 'foo', pass: 'test' }
-    });
-    expect(mergeConfig({ proxy: { user: 'foo' } }, { proxy: { pass: 'test' } })).toEqual({
-      proxy: { user: 'foo', pass: 'test' }
-    });
-  });
 
-  it('should overwrite auth, headers, params, proxy with a non-object value', function() {
-    ['auth', 'headers', 'params', 'proxy'].forEach(key => {
+    it(`should merge ${key} with defaults`, function() {
+      expect(mergeConfig({ [key]: { user: 'foo', pass: 'bar' } }, { [key]: { pass: 'test' } })).toEqual({
+        [key]: { user: 'foo', pass: 'test' }
+      });
+    });
+
+    it(`should overwrite default ${key} with a non-object value`, function() {
       [false, null].forEach(value => {
         expect(mergeConfig({ [key]: { user: 'foo', pass: 'test' } }, { [key]: value })).toEqual({
           [key]: value

--- a/test/specs/core/mergeConfig.spec.js
+++ b/test/specs/core/mergeConfig.spec.js
@@ -33,30 +33,40 @@ describe('core::mergeConfig', function() {
   it('should not inherit request options', function() {
     var localDefaults = {
       method: '__sample method__',
-      params: '__sample params__',
       data: { foo: true }
     };
     var merged = mergeConfig(localDefaults, {});
     expect(merged.method).toEqual(undefined);
-    expect(merged.params).toEqual(undefined);
     expect(merged.data).toEqual(undefined);
   });
 
-  it('should merge auth, headers, proxy with defaults', function() {
-    expect(mergeConfig({ auth: undefined }, { auth: { user: 'foo', pass: 'test' } })).toEqual({
+  it('should merge auth, headers, params, proxy with defaults', function() {
+    expect(mergeConfig({ auth: { user: 'foo' } }, { auth: { pass: 'test' } })).toEqual({
       auth: { user: 'foo', pass: 'test' }
     });
-    expect(mergeConfig({ auth: { user: 'foo', pass: 'test' } }, { auth: { pass: 'foobar' } })).toEqual({
-      auth: { user: 'foo', pass: 'foobar' }
+    expect(mergeConfig({ headers: { user: 'foo' } }, { headers: { pass: 'test' } })).toEqual({
+      headers: { user: 'foo', pass: 'test' }
+    });
+    expect(mergeConfig({ params: { user: 'foo' } }, { params: { pass: 'test' } })).toEqual({
+      params: { user: 'foo', pass: 'test' }
+    });
+    expect(mergeConfig({ proxy: { user: 'foo' } }, { proxy: { pass: 'test' } })).toEqual({
+      proxy: { user: 'foo', pass: 'test' }
     });
   });
 
-  it('should overwrite auth, headers, proxy with a non-object value', function() {
+  it('should overwrite auth, headers, params, proxy with a non-object value', function() {
     expect(mergeConfig({ auth: { user: 'foo', pass: 'test' } }, { auth: false })).toEqual({
       auth: false
     });
-    expect(mergeConfig({ auth: { user: 'foo', pass: 'test' } }, { auth: null })).toEqual({
-      auth: null
+    expect(mergeConfig({ headers: { user: 'foo', pass: 'test' } }, { headers: null })).toEqual({
+      headers: null
+    });
+    expect(mergeConfig({ params: { user: 'foo', pass: 'test' } }, { params: null })).toEqual({
+      params: null
+    });
+    expect(mergeConfig({ proxy: { user: 'foo', pass: 'test' } }, { proxy: null })).toEqual({
+      proxy: null
     });
   });
 

--- a/test/specs/core/mergeConfig.spec.js
+++ b/test/specs/core/mergeConfig.spec.js
@@ -54,7 +54,7 @@ describe('core::mergeConfig', function() {
     });
 
     it(`should overwrite default ${key} with a non-object value`, function() {
-      [false, null].forEach(value => {
+      [false, null, 123].forEach(value => {
         expect(mergeConfig({ [key]: { user: 'foo', pass: 'test' } }, { [key]: value })).toEqual({
           [key]: value
         });

--- a/test/specs/core/mergeConfig.spec.js
+++ b/test/specs/core/mergeConfig.spec.js
@@ -56,17 +56,12 @@ describe('core::mergeConfig', function() {
   });
 
   it('should overwrite auth, headers, params, proxy with a non-object value', function() {
-    expect(mergeConfig({ auth: { user: 'foo', pass: 'test' } }, { auth: false })).toEqual({
-      auth: false
-    });
-    expect(mergeConfig({ headers: { user: 'foo', pass: 'test' } }, { headers: null })).toEqual({
-      headers: null
-    });
-    expect(mergeConfig({ params: { user: 'foo', pass: 'test' } }, { params: null })).toEqual({
-      params: null
-    });
-    expect(mergeConfig({ proxy: { user: 'foo', pass: 'test' } }, { proxy: null })).toEqual({
-      proxy: null
+    ['auth', 'headers', 'params', 'proxy'].forEach(key => {
+      [false, null].forEach(value => {
+        expect(mergeConfig({ [key]: { user: 'foo', pass: 'test' } }, { [key]: value })).toEqual({
+          [key]: value
+        });
+      });
     });
   });
 


### PR DESCRIPTION
Move `'params'` to the `mergeDeepPropertiesKeys` array, so that the specific parameters for the request get merged with the defaults, rather than overwriting them. This allows e.g. setting authentication params for a specific API in a central location, and matches the description in the README that _"The specified config will be merged with the instance config."_

Also the existing merging tests repeated the same case twice and didn't actually cover the described behaviour, so I've fixed that.

Fixes #2190 and various linked issues, supersedes #2196.
