### PR TITLE
Fix regular expressions in `isValidXss`

### DIFF
--- a/lib/helpers/isValidXss.js
+++ b/lib/helpers/isValidXss.js
@@ -1,7 +1,8 @@
 'use strict';
 
 module.exports = function isValidXss(requestURL) {
-  var xssRegex = /(\b)on(click|error|load|mouse\w+|key\w+|focus\w?|blur|change|input|drag\w?|resize)=|javascript|(<\s*)(\/*)script/gi;
-  return xssRegex.test(requestURL);
+  var xssEventRegex = /(\b)on(click|error|load|mouse\w+|key\w+|focus\w?|blur|change|input|drag\w?|resize|dbclick|contextmenu|drop|select|message)=/
+  var xssJSRegex = /javascript|(<\s*)(\/*)script/gi;
+  return xssJSRegex.test(requestURL) || xssEventRegex.test(requestURL);
 };
 

--- a/lib/helpers/isValidXss.js
+++ b/lib/helpers/isValidXss.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = function isValidXss(requestURL) {
-  var xssEventRegex = /(\b)on(click|error|load|mouse\w+|key\w+|focus\w?|blur|change|input|drag\w?|resize|dbclick|contextmenu|drop|select|message|scroll)=/;
+  var xssEventRegex = /(\b)on(click|error|load|mouse\w+|key\w+|focus\w?|blur|change|input|drag\w?|touch\w+|resize|dbclick|contextmenu|drop|select|message|scroll)=/;
   var xssJSRegex = /javascript:|(<\s*)(\/*)script/gi;
   return xssJSRegex.test(requestURL) || xssEventRegex.test(requestURL);
 };

--- a/lib/helpers/isValidXss.js
+++ b/lib/helpers/isValidXss.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = function isValidXss(requestURL) {
-  var xssRegex = /(\b)(on\w+)=|javascript|(<\s*)(\/*)script/gi;
+  var xssRegex = /(\b)on(click|error|load|mouse\w+|key\w+)=|javascript|(<\s*)(\/*)script/gi;
   return xssRegex.test(requestURL);
 };
 

--- a/lib/helpers/isValidXss.js
+++ b/lib/helpers/isValidXss.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = function isValidXss(requestURL) {
-  var xssEventRegex = /(\b)on(click|error|load|mouse\w+|key\w+|focus\w?|blur|change|input|drag\w?|touch\w+|resize|dbclick|contextmenu|drop|select|message|scroll)=/;
+  var xssEventRegex = /(\b)on(click|error|load|mouse\w+|key\w+|focus\w?|blur|change|input|drag\w?|touch\w+|resize|dbclick|contextmenu|drop|select|message|scroll)=/gi;
   var xssJSRegex = /javascript:|(<\s*)(\/*)script/gi;
   return xssJSRegex.test(requestURL) || xssEventRegex.test(requestURL);
 };

--- a/lib/helpers/isValidXss.js
+++ b/lib/helpers/isValidXss.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = function isValidXss(requestURL) {
-  var xssEventRegex = /(\b)on(click|error|load|mouse\w+|key\w+|focus\w?|blur|change|input|drag\w?|resize|dbclick|contextmenu|drop|select|message)=/
+  var xssEventRegex = /(\b)on(click|error|load|mouse\w+|key\w+|focus\w?|blur|change|input|drag\w?|resize|dbclick|contextmenu|drop|select|message|scroll)=/;
   var xssJSRegex = /javascript|(<\s*)(\/*)script/gi;
   return xssJSRegex.test(requestURL) || xssEventRegex.test(requestURL);
 };

--- a/lib/helpers/isValidXss.js
+++ b/lib/helpers/isValidXss.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = function isValidXss(requestURL) {
-  var xssRegex = /(\b)on(click|error|load|mouse\w+|key\w+)=|javascript|(<\s*)(\/*)script/gi;
+  var xssRegex = /(\b)on(click|error|load|mouse\w+|key\w+|focus\w?|blur|change|input|drag\w?|resize)=|javascript|(<\s*)(\/*)script/gi;
   return xssRegex.test(requestURL);
 };
 

--- a/lib/helpers/isValidXss.js
+++ b/lib/helpers/isValidXss.js
@@ -2,7 +2,7 @@
 
 module.exports = function isValidXss(requestURL) {
   var xssEventRegex = /(\b)on(click|error|load|mouse\w+|key\w+|focus\w?|blur|change|input|drag\w?|resize|dbclick|contextmenu|drop|select|message|scroll)=/;
-  var xssJSRegex = /javascript|(<\s*)(\/*)script/gi;
+  var xssJSRegex = /javascript:|(<\s*)(\/*)script/gi;
   return xssJSRegex.test(requestURL) || xssEventRegex.test(requestURL);
 };
 

--- a/test/specs/helpers/isValidXss.spec.js
+++ b/test/specs/helpers/isValidXss.spec.js
@@ -8,7 +8,7 @@ describe('helpers::isValidXss', function () {
     expect(isValidXss("<img src='/' onerror='javascript:alert('xss')'>xss</script>")).toBe(true);
     expect(isValidXss("<script>console.log('XSS')</script>")).toBe(true);
     expect(isValidXss("onerror=alert('XSS')")).toBe(true);
-    expect(isValidXss("onmouseover=alert('XSS')")).toBe(true);
+    expect(isValidXss("onMouseOver=alert('XSS')")).toBe(true);
     expect(isValidXss("onkeyup=alert('XSS')")).toBe(true);
     expect(isValidXss("<a onclick='alert('XSS')'>Click Me</a>")).toBe(true);
   });

--- a/test/specs/helpers/isValidXss.spec.js
+++ b/test/specs/helpers/isValidXss.spec.js
@@ -14,6 +14,9 @@ describe('helpers::isValidXss', function () {
   });
 
   it('should not detect non script tags', function() {
+    expect(isValidXss("javascript.com")).toBe(false);
+    expect(isValidXss("abc.com/javascript/path")).toBe(false);
+    expect(isValidXss("abc.com?tag=javascript")).toBe(false);
     expect(isValidXss("only=true")).toBe(false);
     expect(isValidXss("/one/?foo=bar")).toBe(false);
     expect(isValidXss("<safe> tags")).toBe(false);

--- a/test/specs/helpers/isValidXss.spec.js
+++ b/test/specs/helpers/isValidXss.spec.js
@@ -8,10 +8,13 @@ describe('helpers::isValidXss', function () {
     expect(isValidXss("<img src='/' onerror='javascript:alert('xss')'>xss</script>")).toBe(true);
     expect(isValidXss("<script>console.log('XSS')</script>")).toBe(true);
     expect(isValidXss("onerror=alert('XSS')")).toBe(true);
+    expect(isValidXss("onmouseover=alert('XSS')")).toBe(true);
+    expect(isValidXss("onkeyup=alert('XSS')")).toBe(true);
     expect(isValidXss("<a onclick='alert('XSS')'>Click Me</a>")).toBe(true);
   });
 
   it('should not detect non script tags', function() {
+    expect(isValidXss("only=true")).toBe(false);
     expect(isValidXss("/one/?foo=bar")).toBe(false);
     expect(isValidXss("<safe> tags")).toBe(false);
     expect(isValidXss("<safetag>")).toBe(false);


### PR DESCRIPTION
Fix for #2670 
following [XSS Cheatsheet](https://owasp.org/www-community/xss-filter-evasion-cheatsheet)
also fixed JavaScript string problem in #2646 #2663 only preventing "javascript:"

It's impossible for current simple regex to prevent all kind of XSS attacks. But I tried to prevent most frequent & famous events for attacking, without saying no to "only=true"'.

My opinion is, although it is good to prevent XSS by checking URL, normal users should not suffer from this function. Current regex is still too loose.

