### PR TITLE
Add the missing `responseEncoding` typing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -56,6 +56,7 @@ export interface AxiosRequestConfig {
   adapter?: AxiosAdapter;
   auth?: AxiosBasicCredentials;
   responseType?: ResponseType;
+  responseEncoding?: string;
   xsrfCookieName?: string;
   xsrfHeaderName?: string;
   onUploadProgress?: (progressEvent: any) => void;


### PR DESCRIPTION
The `responseEncoding` which is used in the HTTP adapter was not added to the `AxiosRequestConfig`

it's mentioned here: https://github.com/axios/axios/blob/7df84a7ff7c2d33b0f210608a489db7b5fc0df37/README.md#L335
and used here: https://github.com/axios/axios/blob/03e6f4bf4c1eced613cf60d59ef50b0e18b31907/lib/adapters/http.js#L232
