### PR TITLE
Storing uploaded files in 'examples/upload'.

### DIFF
--- a/examples/upload/server.js
+++ b/examples/upload/server.js
@@ -1,13 +1,17 @@
+var formidable = require('formidable');
+var fs = require('fs');
 module.exports = function (req, res) {
-  var data = '';
+  var form = new formidable.IncomingForm();
+    form.parse(req, function (err, fields, files) {
+      var tmpfile = files.file.path;
+      var file = __dirname + '/files/' + files.file.name;
+      fs.copyFile(tmpfile, file, function (err) {
+        if (err) throw err;
+        fs.unlinkSync(tmpfile);
 
-  req.on('data', function (chunk) {
-    data += chunk;
-  });
-
-  req.on('end', function () {
-    console.log('File uploaded');
-    res.writeHead(200);
-    res.end();
-  });
+        console.log(`file uploaded at ${file}`);
+        res.write(`'${files.file.name}' file uploaded`);
+        res.end();
+      });
+ });
 };

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "bundlesize": "^0.17.0",
     "coveralls": "^3.0.0",
     "es6-promise": "^4.2.4",
+    "formidable": "^1.2.1",
     "grunt": "^1.0.2",
     "grunt-banner": "^0.6.0",
     "grunt-cli": "^1.2.0",


### PR DESCRIPTION
Uploaded files for 'examples/upload' will be saved at 'examples/upload/files'.
File name will be displayed in the browser, and file path will be displayed in the console.