### PR TITLE
Fix moxios by not forcing adapters to resolve baseURL

### DIFF
--- a/lib/adapters/README.md
+++ b/lib/adapters/README.md
@@ -7,7 +7,7 @@ The modules under `adapters/` are modules that handle dispatching a request and 
 ```js
 var settle = require('./../core/settle');
 
-module.exports = function myAdapter(config) {
+module.exports = function myAdapter(config, rawConfig) {
   // At this point:
   //  - config has been merged with defaults
   //  - request transformers have already run
@@ -24,6 +24,7 @@ module.exports = function myAdapter(config) {
       statusText: request.statusText,
       headers: responseHeaders,
       config: config,
+      rawConfig: rawConfig,
       request: request
     };
 

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -45,7 +45,8 @@ module.exports = function httpAdapter(config, rawConfig) {
       } else {
         return reject(createError(
           'Data after transformation must be a string, an ArrayBuffer, a Buffer, or a Stream',
-          config
+          config,
+          rawConfig
         ));
       }
 
@@ -202,6 +203,7 @@ module.exports = function httpAdapter(config, rawConfig) {
         statusText: res.statusMessage,
         headers: res.headers,
         config: config,
+        rawConfig: rawConfig,
         request: lastRequest
       };
 
@@ -217,13 +219,13 @@ module.exports = function httpAdapter(config, rawConfig) {
           if (config.maxContentLength > -1 && Buffer.concat(responseBuffer).length > config.maxContentLength) {
             stream.destroy();
             reject(createError('maxContentLength size of ' + config.maxContentLength + ' exceeded',
-              config, null, lastRequest));
+              config, rawConfig, null, lastRequest));
           }
         });
 
         stream.on('error', function handleStreamError(err) {
           if (req.aborted) return;
-          reject(enhanceError(err, config, null, lastRequest));
+          reject(enhanceError(err, config, rawConfig, null, lastRequest));
         });
 
         stream.on('end', function handleStreamEnd() {
@@ -241,7 +243,7 @@ module.exports = function httpAdapter(config, rawConfig) {
     // Handle errors
     req.on('error', function handleRequestError(err) {
       if (req.aborted && err.code !== 'ERR_FR_TOO_MANY_REDIRECTS') return;
-      reject(enhanceError(err, config, null, req));
+      reject(enhanceError(err, config, rawConfig, null, req));
     });
 
     // Handle request timeout
@@ -253,7 +255,7 @@ module.exports = function httpAdapter(config, rawConfig) {
       // ClientRequest.setTimeout will be fired on the specify milliseconds, and can make sure that abort() will be fired after connect.
       req.setTimeout(config.timeout, function handleRequestTimeout() {
         req.abort();
-        reject(createError('timeout of ' + config.timeout + 'ms exceeded', config, 'ECONNABORTED', req));
+        reject(createError('timeout of ' + config.timeout + 'ms exceeded', config, rawConfig, 'ECONNABORTED', req));
       });
     }
 
@@ -270,7 +272,7 @@ module.exports = function httpAdapter(config, rawConfig) {
     // Send the request
     if (utils.isStream(data)) {
       data.on('error', function handleStreamError(err) {
-        reject(enhanceError(err, config, null, req));
+        reject(enhanceError(err, config, rawConfig, null, req));
       }).pipe(req);
     } else {
       req.end(data);

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -17,7 +17,7 @@ var enhanceError = require('../core/enhanceError');
 var isHttps = /https:?/;
 
 /*eslint consistent-return:0*/
-module.exports = function httpAdapter(config) {
+module.exports = function httpAdapter(config, rawConfig) {
   return new Promise(function dispatchHttpRequest(resolvePromise, rejectPromise) {
     var resolve = function resolve(value) {
       resolvePromise(value);

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -2,7 +2,6 @@
 
 var utils = require('./../utils');
 var settle = require('./../core/settle');
-var buildFullPath = require('../core/buildFullPath');
 var buildURL = require('./../helpers/buildURL');
 var http = require('http');
 var https = require('https');
@@ -63,8 +62,7 @@ module.exports = function httpAdapter(config, rawConfig) {
     }
 
     // Parse url
-    var fullPath = buildFullPath(config.baseURL, config.url);
-    var parsed = url.parse(fullPath);
+    var parsed = url.parse(config.url);
     var protocol = parsed.protocol || 'http:';
 
     if (!auth && parsed.auth) {

--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -3,7 +3,6 @@
 var utils = require('./../utils');
 var settle = require('./../core/settle');
 var buildURL = require('./../helpers/buildURL');
-var buildFullPath = require('../core/buildFullPath');
 var parseHeaders = require('./../helpers/parseHeaders');
 var isURLSameOrigin = require('./../helpers/isURLSameOrigin');
 var createError = require('../core/createError');
@@ -26,8 +25,7 @@ module.exports = function xhrAdapter(config, rawConfig) {
       requestHeaders.Authorization = 'Basic ' + btoa(username + ':' + password);
     }
 
-    var fullPath = buildFullPath(config.baseURL, config.url);
-    request.open(config.method.toUpperCase(), buildURL(fullPath, config.params, config.paramsSerializer), true);
+    request.open(config.method.toUpperCase(), buildURL(config.url, config.params, config.paramsSerializer), true);
 
     // Set the request timeout in MS
     request.timeout = config.timeout;
@@ -107,7 +105,7 @@ module.exports = function xhrAdapter(config, rawConfig) {
       var cookies = require('./../helpers/cookies');
 
       // Add xsrf header
-      var xsrfValue = (config.withCredentials || isURLSameOrigin(fullPath)) && config.xsrfCookieName ?
+      var xsrfValue = (config.withCredentials || isURLSameOrigin(config.url)) && config.xsrfCookieName ?
         cookies.read(config.xsrfCookieName) :
         undefined;
 

--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -55,6 +55,7 @@ module.exports = function xhrAdapter(config, rawConfig) {
         statusText: request.statusText,
         headers: responseHeaders,
         config: config,
+        rawConfig: rawConfig,
         request: request
       };
 
@@ -70,7 +71,7 @@ module.exports = function xhrAdapter(config, rawConfig) {
         return;
       }
 
-      reject(createError('Request aborted', config, 'ECONNABORTED', request));
+      reject(createError('Request aborted', config, rawConfig, 'ECONNABORTED', request));
 
       // Clean up request
       request = null;
@@ -80,7 +81,7 @@ module.exports = function xhrAdapter(config, rawConfig) {
     request.onerror = function handleError() {
       // Real errors are hidden from us by the browser
       // onerror should only fire if it's a network error
-      reject(createError('Network Error', config, null, request));
+      reject(createError('Network Error', config, rawConfig, null, request));
 
       // Clean up request
       request = null;
@@ -92,7 +93,7 @@ module.exports = function xhrAdapter(config, rawConfig) {
       if (config.timeoutErrorMessage) {
         timeoutErrorMessage = config.timeoutErrorMessage;
       }
-      reject(createError(timeoutErrorMessage, config, 'ECONNABORTED',
+      reject(createError(timeoutErrorMessage, config, rawConfig, 'ECONNABORTED',
         request));
 
       // Clean up request

--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -8,7 +8,7 @@ var parseHeaders = require('./../helpers/parseHeaders');
 var isURLSameOrigin = require('./../helpers/isURLSameOrigin');
 var createError = require('../core/createError');
 
-module.exports = function xhrAdapter(config) {
+module.exports = function xhrAdapter(config, rawConfig) {
   return new Promise(function dispatchXhrRequest(resolve, reject) {
     var requestData = config.data;
     var requestHeaders = config.headers;

--- a/lib/core/Axios.js
+++ b/lib/core/Axios.js
@@ -24,17 +24,17 @@ function Axios(instanceConfig) {
  *
  * @param {Object} config The config specific for this request (merged with this.defaults)
  */
-Axios.prototype.request = function request(config) {
+Axios.prototype.request = function request(rawConfig) {
   /*eslint no-param-reassign:0*/
   // Allow for axios('example/url'[, config]) a la fetch API
-  if (typeof config === 'string') {
-    config = arguments[1] || {};
-    config.url = arguments[0];
+  if (typeof rawConfig === 'string') {
+    rawConfig = arguments[1] || {};
+    rawConfig.url = arguments[0];
   } else {
-    config = config || {};
+    rawConfig = rawConfig || {};
   }
 
-  config = mergeConfig(this.defaults, config);
+  var config = mergeConfig(this.defaults, rawConfig);
 
   // Set config.method
   if (config.method) {
@@ -53,7 +53,9 @@ Axios.prototype.request = function request(config) {
   });
 
   middlewareRegistry.push({
-    fulfilled: dispatchRequest
+    fulfilled: function(reqConfig) {
+      return dispatchRequest(reqConfig, rawConfig);
+    }
   });
 
   this.interceptors.response.forEach(function(interceptor) {

--- a/lib/core/Axios.js
+++ b/lib/core/Axios.js
@@ -45,21 +45,27 @@ Axios.prototype.request = function request(config) {
     config.method = 'get';
   }
 
-  // Hook up interceptors middleware
-  var chain = [dispatchRequest, undefined];
+  // Collect interceptors middleware
+  var middlewareRegistry = [];
+
+  this.interceptors.request.forEach(function(interceptor) {
+    middlewareRegistry.push(interceptor);
+  });
+
+  middlewareRegistry.push({
+    fulfilled: dispatchRequest
+  });
+
+  this.interceptors.response.forEach(function(interceptor) {
+    middlewareRegistry.push(interceptor);
+  });
+
+  // Hook up middleware
   var promise = Promise.resolve(config);
 
-  this.interceptors.request.forEach(function unshiftRequestInterceptors(interceptor) {
-    chain.unshift(interceptor.fulfilled, interceptor.rejected);
+  utils.forEach(middlewareRegistry, function(middleware) {
+    promise = promise.then(middleware.fulfilled, middleware.rejected);
   });
-
-  this.interceptors.response.forEach(function pushResponseInterceptors(interceptor) {
-    chain.push(interceptor.fulfilled, interceptor.rejected);
-  });
-
-  while (chain.length) {
-    promise = promise.then(chain.shift(), chain.shift());
-  }
 
   return promise;
 };

--- a/lib/core/createError.js
+++ b/lib/core/createError.js
@@ -7,12 +7,13 @@ var enhanceError = require('./enhanceError');
  *
  * @param {string} message The error message.
  * @param {Object} config The config.
+ * @param {Object} rawConfig The config that the user originally specified.
  * @param {string} [code] The error code (for example, 'ECONNABORTED').
  * @param {Object} [request] The request.
  * @param {Object} [response] The response.
  * @returns {Error} The created error.
  */
-module.exports = function createError(message, config, code, request, response) {
+module.exports = function createError(message, config, rawConfig, code, request, response) {
   var error = new Error(message);
-  return enhanceError(error, config, code, request, response);
+  return enhanceError(error, config, rawConfig, code, request, response);
 };

--- a/lib/core/dispatchRequest.js
+++ b/lib/core/dispatchRequest.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var utils = require('./../utils');
+var buildFullPath = require('./buildFullPath');
 var transformData = require('./transformData');
 var isCancel = require('../cancel/isCancel');
 var defaults = require('../defaults');
@@ -23,6 +24,9 @@ function throwIfCancellationRequested(config) {
  */
 module.exports = function dispatchRequest(config, rawConfig) {
   throwIfCancellationRequested(config);
+
+  // Support baseURL config
+  config.url = buildFullPath(config.baseURL, config.url);
 
   // Ensure headers exist
   config.headers = config.headers || {};

--- a/lib/core/dispatchRequest.js
+++ b/lib/core/dispatchRequest.js
@@ -18,9 +18,10 @@ function throwIfCancellationRequested(config) {
  * Dispatch a request to the server using the configured adapter.
  *
  * @param {object} config The config that is to be used for the request
+ * @param {object} rawConfig The config initially specified for the request
  * @returns {Promise} The Promise to be fulfilled
  */
-module.exports = function dispatchRequest(config) {
+module.exports = function dispatchRequest(config, rawConfig) {
   throwIfCancellationRequested(config);
 
   // Ensure headers exist
@@ -49,7 +50,7 @@ module.exports = function dispatchRequest(config) {
 
   var adapter = config.adapter || defaults.adapter;
 
-  return adapter(config).then(function onAdapterResolution(response) {
+  return adapter(config, rawConfig).then(function onAdapterResolution(response) {
     throwIfCancellationRequested(config);
 
     // Transform response data

--- a/lib/core/enhanceError.js
+++ b/lib/core/enhanceError.js
@@ -5,13 +5,15 @@
  *
  * @param {Error} error The error to update.
  * @param {Object} config The config.
+ * @param {Object} rawConfig The config that the user originally specified.
  * @param {string} [code] The error code (for example, 'ECONNABORTED').
  * @param {Object} [request] The request.
  * @param {Object} [response] The response.
  * @returns {Error} The error.
  */
-module.exports = function enhanceError(error, config, code, request, response) {
+module.exports = function enhanceError(error, config, rawConfig, code, request, response) {
   error.config = config;
+  error.rawConfig = rawConfig;
   if (code) {
     error.code = code;
   }
@@ -35,6 +37,7 @@ module.exports = function enhanceError(error, config, code, request, response) {
       stack: this.stack,
       // Axios
       config: this.config,
+      rawConfig: this.rawConfig,
       code: this.code
     };
   };

--- a/lib/core/mergeConfig.js
+++ b/lib/core/mergeConfig.js
@@ -6,6 +6,8 @@ var utils = require('../utils');
  * Config-specific merge-function which creates a new config-object
  * by merging two configuration objects together.
  *
+ * Should not modify either config1 nor config2.
+ *
  * @param {Object} config1
  * @param {Object} config2
  * @returns {Object} New object resulting from merging config2 to config1

--- a/lib/core/settle.js
+++ b/lib/core/settle.js
@@ -17,6 +17,7 @@ module.exports = function settle(resolve, reject, response) {
     reject(createError(
       'Request failed with status code ' + response.status,
       response.config,
+      response.rawConfig,
       null,
       response.request,
       response

--- a/test/specs/core/createError.spec.js
+++ b/test/specs/core/createError.spec.js
@@ -4,10 +4,11 @@ describe('core::createError', function() {
   it('should create an Error with message, config, code, request, response and isAxiosError', function() {
     var request = { path: '/foo' };
     var response = { status: 200, data: { foo: 'bar' } };
-    var error = createError('Boom!', { foo: 'bar' }, 'ESOMETHING', request, response);
+    var error = createError('Boom!', { foo: 'bar' }, { foo: 'bar2' }, 'ESOMETHING', request, response);
     expect(error instanceof Error).toBe(true);
     expect(error.message).toBe('Boom!');
     expect(error.config).toEqual({ foo: 'bar' });
+    expect(error.rawConfig).toEqual({ foo: 'bar2' });
     expect(error.code).toBe('ESOMETHING');
     expect(error.request).toBe(request);
     expect(error.response).toBe(response);
@@ -18,10 +19,11 @@ describe('core::createError', function() {
     //    TypeError: Converting circular structure to JSON
     var request = { path: '/foo' };
     var response = { status: 200, data: { foo: 'bar' } };
-    var error = createError('Boom!', { foo: 'bar' }, 'ESOMETHING', request, response);
+    var error = createError('Boom!', { foo: 'bar' }, { foo: 'bar2' }, 'ESOMETHING', request, response);
     var json = error.toJSON();
     expect(json.message).toBe('Boom!');
     expect(json.config).toEqual({ foo: 'bar' });
+    expect(json.rawConfig).toEqual({ foo: 'bar2' });
     expect(json.code).toBe('ESOMETHING');
     expect(json.request).toBe(undefined);
     expect(json.response).toBe(undefined);

--- a/test/specs/core/enhanceError.spec.js
+++ b/test/specs/core/enhanceError.spec.js
@@ -6,8 +6,9 @@ describe('core::enhanceError', function() {
     var request = { path: '/foo' };
     var response = { status: 200, data: { foo: 'bar' } };
 
-    enhanceError(error, { foo: 'bar' }, 'ESOMETHING', request, response);
+    enhanceError(error, { foo: 'bar' }, { foo: 'bar2' }, 'ESOMETHING', request, response);
     expect(error.config).toEqual({ foo: 'bar' });
+    expect(error.rawConfig).toEqual({ foo: 'bar2' });
     expect(error.code).toBe('ESOMETHING');
     expect(error.request).toBe(request);
     expect(error.response).toBe(response);
@@ -16,6 +17,6 @@ describe('core::enhanceError', function() {
 
   it('should return error', function() {
     var error = new Error('Boom!');
-    expect(enhanceError(error, { foo: 'bar' }, 'ESOMETHING')).toBe(error);
+    expect(enhanceError(error, { foo: 'bar' }, { foo: 'bar2' }, 'ESOMETHING')).toBe(error);
   });
 });

--- a/test/specs/core/settle.spec.js
+++ b/test/specs/core/settle.spec.js
@@ -58,6 +58,9 @@ describe('core::settle', function() {
           return false;
         }
       },
+      rawConfig: {
+        url: req.path,
+      },
       request: req
     };
     settle(resolve, reject, response);
@@ -67,6 +70,7 @@ describe('core::settle', function() {
     expect(reason instanceof Error).toBe(true);
     expect(reason.message).toBe('Request failed with status code 500');
     expect(reason.config).toBe(response.config);
+    expect(reason.rawConfig).toBe(response.rawConfig);
     expect(reason.request).toBe(req);
     expect(reason.response).toBe(response);
   });

--- a/test/specs/requests.spec.js
+++ b/test/specs/requests.spec.js
@@ -264,8 +264,7 @@ describe('requests', function () {
 
       setTimeout(function () {
         expect(e.config.baseURL).toBe('/api');
-        // FIXME: this should be /api/foo (#2650)
-        expect(e.config.url).toBe('/foo');
+        expect(e.config.url).toBe('/api/foo');
         expect(e.config.method).toBe('get');
 
         expect(e.rawConfig).toEqual({

--- a/test/specs/requests.spec.js
+++ b/test/specs/requests.spec.js
@@ -245,13 +245,14 @@ describe('requests', function () {
     });
   });
 
-  it('should not modify the config url with relative baseURL', function (done) {
-    var config;
+  it('should set rawConfig in the error', function (done) {
+    var e;
 
-    axios.get('/foo', {
-        baseURL: '/api'
+    axios.request('/foo', {
+      baseURL: '/api',
+      method: 'GET',
     }).catch(function (error) {
-        config = error.config;
+        e = error;
     });
 
     getAjaxRequest().then(function (request) {
@@ -262,8 +263,16 @@ describe('requests', function () {
       });
 
       setTimeout(function () {
-        expect(config.baseURL).toEqual('/api');
-        expect(config.url).toEqual('/foo');
+        expect(e.config.baseURL).toBe('/api');
+        // FIXME: this should be /api/foo (#2650)
+        expect(e.config.url).toBe('/foo');
+        expect(e.config.method).toBe('get');
+
+        expect(e.rawConfig).toEqual({
+          baseURL: '/api',
+          url: '/foo',
+          method: 'GET',
+        });
         done();
       }, 100);
     });

--- a/test/unit/adapters/http.js
+++ b/test/unit/adapters/http.js
@@ -658,7 +658,7 @@ describe('supports http with nodejs', function () {
         baseURL: 'http://localhost:4444/',
       }).then(function (res) {
         assert.equal(res.config.baseURL, 'http://localhost:4444/');
-        assert.equal(res.config.url, '/foo');
+        assert.equal(res.config.url, 'http://localhost:4444/foo');
         done();
       });
     });


### PR DESCRIPTION
Fixes #2650 

Adapters should not have to care about `baseURL`; everything should be fully resolved by the point it gets to the adapter. The original PR (#2391) broke moxios tests that used `baseURL` in the production code, but stubbed requests using full URLs.

This PR should maintain the behavior the first PR set out to fix (namely, that the config URL is not modified) while allowing adapters to have the same behavior as before the first PR. In general, I recommend not modifying the config at all in `dispatchRequest`, but this fix should suffice for the issue above