### PR TITLE
Adding method usePromise for allowing replace Promise used by axios

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -18,7 +18,7 @@ var isHttps = /https:?/;
 
 /*eslint consistent-return:0*/
 module.exports = function httpAdapter(config) {
-  return new Promise(function dispatchHttpRequest(resolvePromise, rejectPromise) {
+  return new utils.Promise(function dispatchHttpRequest(resolvePromise, rejectPromise) {
     var resolve = function resolve(value) {
       resolvePromise(value);
     };

--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -9,7 +9,7 @@ var isURLSameOrigin = require('./../helpers/isURLSameOrigin');
 var createError = require('../core/createError');
 
 module.exports = function xhrAdapter(config) {
-  return new Promise(function dispatchXhrRequest(resolve, reject) {
+  return new utils.Promise(function dispatchXhrRequest(resolve, reject) {
     var requestData = config.data;
     var requestHeaders = config.headers;
 

--- a/lib/axios.js
+++ b/lib/axios.js
@@ -41,9 +41,12 @@ axios.Cancel = require('./cancel/Cancel');
 axios.CancelToken = require('./cancel/CancelToken');
 axios.isCancel = require('./cancel/isCancel');
 
+// Expose usePromise
+axios.usePromise = utils.usePromise;
+
 // Expose all/spread
 axios.all = function all(promises) {
-  return Promise.all(promises);
+  return utils.Promise.all(promises);
 };
 axios.spread = require('./helpers/spread');
 

--- a/lib/cancel/CancelToken.js
+++ b/lib/cancel/CancelToken.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var utils = require('../utils');
 var Cancel = require('./Cancel');
 
 /**
@@ -14,7 +15,7 @@ function CancelToken(executor) {
   }
 
   var resolvePromise;
-  this.promise = new Promise(function promiseExecutor(resolve) {
+  this.promise = new utils.Promise(function promiseExecutor(resolve) {
     resolvePromise = resolve;
   });
 

--- a/lib/core/Axios.js
+++ b/lib/core/Axios.js
@@ -47,7 +47,7 @@ Axios.prototype.request = function request(config) {
 
   // Hook up interceptors middleware
   var chain = [dispatchRequest, undefined];
-  var promise = Promise.resolve(config);
+  var promise = utils.Promise.resolve(config);
 
   this.interceptors.request.forEach(function unshiftRequestInterceptors(interceptor) {
     chain.unshift(interceptor.fulfilled, interceptor.rejected);

--- a/lib/core/dispatchRequest.js
+++ b/lib/core/dispatchRequest.js
@@ -74,6 +74,6 @@ module.exports = function dispatchRequest(config) {
       }
     }
 
-    return Promise.reject(reason);
+    return utils.Promise.reject(reason);
   });
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -165,6 +165,48 @@ function isURLSearchParams(val) {
   return typeof URLSearchParams !== 'undefined' && val instanceof URLSearchParams;
 }
 
+
+/**
+ * Determine if a value is a Promise-like instance
+ * @param {*} obj
+ * @see {@link https://github.com/then/is-promise/blob/master/index.js|from then/is-promise}
+ */
+function isThenable(obj) {
+  return !!obj && (typeof obj === 'object' || typeof obj === 'function') && typeof obj.then === 'function';
+}
+
+/**
+ * Determine if value is a valid promise constructor
+ * @param {Promise} PromiseCandidate
+ */
+function validatePromiseConstructor(PromiseCandidate) {
+  if (typeof PromiseCandidate !== 'function') throw new TypeError('Promise should be a Function.');
+
+  var promise = new PromiseCandidate(function selfResolved(resolve) { resolve(); });
+  if (!isThenable(promise)) throw new TypeError('Promise should return a thenable.');
+
+  ['resolve', 'reject', 'all']
+    .forEach(function testMethod(methodName) {
+      if (typeof PromiseCandidate[methodName] !== 'function') throw new TypeError('Promise should have static method: ' + methodName);
+      var methodPromise = PromiseCandidate[methodName]();
+      methodPromise && methodPromise.then(null, function ignoreCatch() {});
+      if (!isThenable(methodPromise)) throw new TypeError('Promise.' + methodName + ' method should return a thenable.');
+    });
+}
+
+var CurrentPromise = Promise;
+
+/**
+ * Uses custom Promise as default for axios
+ * @param {Promise} PromiseCandidate
+ */
+function usePromise(PromiseCandidate) {
+  if (!arguments.length) return CurrentPromise;
+  validatePromiseConstructor(PromiseCandidate);
+  CurrentPromise = PromiseCandidate;
+  return CurrentPromise;
+}
+
 /**
  * Trim excess whitespace off the beginning and end of a string
  *
@@ -320,6 +362,9 @@ function extend(a, b, thisArg) {
 }
 
 module.exports = {
+  get Promise() {
+    return CurrentPromise;
+  },
   isArray: isArray,
   isArrayBuffer: isArrayBuffer,
   isBuffer: isBuffer,
@@ -335,6 +380,8 @@ module.exports = {
   isFunction: isFunction,
   isStream: isStream,
   isURLSearchParams: isURLSearchParams,
+  validatePromiseConstructor: validatePromiseConstructor,
+  usePromise: usePromise,
   isStandardBrowserEnv: isStandardBrowserEnv,
   forEach: forEach,
   merge: merge,

--- a/test/specs/instance.spec.js
+++ b/test/specs/instance.spec.js
@@ -17,6 +17,7 @@ describe('instance', function () {
         'Cancel',
         'CancelToken',
         'isCancel',
+        'usePromise',
         'all',
         'spread',
         'default'].indexOf(prop) > -1) {

--- a/test/specs/promise.spec.js
+++ b/test/specs/promise.spec.js
@@ -1,3 +1,6 @@
+
+var utils = require('../../lib/utils');
+
 describe('promise', function () {
   beforeEach(function () {
     jasmine.Ajax.install();
@@ -66,5 +69,85 @@ describe('promise', function () {
       expect(result).toEqual('hello world');
       done();
     }, 100);
+  });
+
+  it('should validate custom Promise', function () {
+
+    var thenable = Promise.resolve();
+
+    expect(function() {
+      axios.usePromise(null);
+    }).toThrowError(TypeError, 'Promise should be a Function.');
+
+    expect(function() {
+      axios.usePromise('string');
+    }).toThrowError(TypeError, 'Promise should be a Function.');
+
+    expect(function() {
+      function P () {}
+
+      axios.usePromise(function P () {});
+    }).toThrowError(TypeError, 'Promise should return a thenable.');
+
+    expect(function() {
+      function P () { return thenable; }
+
+      axios.usePromise(P);
+    }).toThrowError(TypeError, 'Promise should have static method: resolve');
+
+    expect(function() {
+      function P () { return thenable; }
+      P.resolve = function resolve () {};
+
+      axios.usePromise(P);
+    }).toThrowError(TypeError, 'Promise.resolve method should return a thenable.');
+
+    expect(function() {
+      function P () { return thenable; }
+      P.resolve = function resolve () { return thenable; };
+
+      axios.usePromise(P);
+    }).toThrowError(TypeError, 'Promise should have static method: reject');
+
+    expect(function() {
+      function P () { return thenable; }
+      P.resolve = function resolve () { return thenable; };
+      P.reject = function reject () {};
+
+      axios.usePromise(P);
+    }).toThrowError(TypeError, 'Promise.reject method should return a thenable.');
+
+    expect(function() {
+      function P () { return thenable; }
+      P.resolve = function resolve () { return thenable; }
+      P.reject = function reject () { return thenable; }
+
+      axios.usePromise(P);
+    }).toThrowError(TypeError, 'Promise should have static method: all');
+
+    expect(function() {
+      function P () { return thenable; }
+      P.resolve = function resolve () { return thenable; };
+      P.reject = function reject () { return thenable; };
+      P.all = function all () {};
+
+      axios.usePromise(P);
+    }).toThrowError(TypeError, 'Promise.all method should return a thenable.');
+
+    function ValidPromise () { return thenable; }
+    ValidPromise.resolve = function resolve () { return thenable; };
+    ValidPromise.reject = function reject () { return thenable; };
+    ValidPromise.all = function all () { return thenable; };
+
+    var OriginalPromise = axios.usePromise();
+
+    axios.usePromise(ValidPromise);
+    
+    expect(axios.usePromise()).toBe(ValidPromise);
+
+    axios.usePromise(OriginalPromise);
+
+    expect(axios.usePromise()).toBe(OriginalPromise);
+
   });
 });


### PR DESCRIPTION
The goal of this feature is to provide a way to use a custom Promise library.

There are some scenarios where is not recommended to use polyfills.

For example when you needs to develop a library to be used in a client site. Using polyfills may cause unexpected behaviors on both sides.

Also, when you use custom Promise  you can use an implementation that throws (or not) errors when uncaught exceptions. Or maybe show uncaught exceptions only when the reason is an instance of Error.
( see: https://github.com/then/promise#unhandled-rejections )

> Proposed solution `axios.usePromise()`

This PR adds a static method to change Promise library used internally by axios for all instances

``` js
var axios = require('axios');
var Promise = require('promise');

axios.usePromise(Promise)
```

Using this approach you can bundle your app/library without using global Promise (or polyfill)
