### PR TITLE
Fixing an issue that type 'null' is not assignable to validateStatus

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -32,12 +32,12 @@ export type Method =
   | 'link' | 'LINK'
   | 'unlink' | 'UNLINK'
 
-export type ResponseType = 
-  | 'arraybuffer' 
-  | 'blob' 
-  | 'document' 
-  | 'json' 
-  | 'text' 
+export type ResponseType =
+  | 'arraybuffer'
+  | 'blob'
+  | 'document'
+  | 'json'
+  | 'text'
   | 'stream'
 
 export interface AxiosRequestConfig {
@@ -61,7 +61,7 @@ export interface AxiosRequestConfig {
   onUploadProgress?: (progressEvent: any) => void;
   onDownloadProgress?: (progressEvent: any) => void;
   maxContentLength?: number;
-  validateStatus?: (status: number) => boolean;
+  validateStatus?: ((status: number) => boolean | null);
   maxRedirects?: number;
   socketPath?: string | null;
   httpAgent?: any;


### PR DESCRIPTION
I'm using typescript 3.8.2.

>   // `validateStatus` defines whether to resolve or reject the promise for a given
  // HTTP response status code. If `validateStatus` returns `true` (or is set to `null`
  // or `undefined`), the promise will be resolved; otherwise, the promise will be
  // rejected.

According to the readme, It's possible to assign (status: number) => boolean function, undefined, and null types on AxiosRequestConfig.validateStatus.

But current index.d.ts, it's doesn't care about null types.

So I added null type on AxiosRequestConfig.validateStatus definition.