### PR TITLE
Add independent `maxBodyLength` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,7 +361,6 @@ These are the available config options for making requests. Only the `url` is re
   // `maxContentLength` defines the max size of the http response content in bytes allowed
   maxContentLength: 2000,
 
-  // `maxBodyLength` defines the max size of the http request content in bytes allowed
   // `maxBodyLength` (Node only option) defines the max size of the http request content in bytes allowed
   maxBodyLength: 2000,
 

--- a/README.md
+++ b/README.md
@@ -362,6 +362,7 @@ These are the available config options for making requests. Only the `url` is re
   maxContentLength: 2000,
 
   // `maxBodyLength` defines the max size of the http request content in bytes allowed
+  // `maxBodyLength` (Node only option) defines the max size of the http request content in bytes allowed
   maxBodyLength: 2000,
 
   // `validateStatus` defines whether to resolve or reject the promise for a given

--- a/README.md
+++ b/README.md
@@ -361,6 +361,9 @@ These are the available config options for making requests. Only the `url` is re
   // `maxContentLength` defines the max size of the http response content in bytes allowed
   maxContentLength: 2000,
 
+  // `maxBodyLength` defines the max size of the http request content in bytes allowed
+  maxBodyLength: 2000,
+
   // `validateStatus` defines whether to resolve or reject the promise for a given
   // HTTP response status code. If `validateStatus` returns `true` (or is set to `null`
   // or `undefined`), the promise will be resolved; otherwise, the promise will be

--- a/index.d.ts
+++ b/index.d.ts
@@ -32,12 +32,12 @@ export type Method =
   | 'link' | 'LINK'
   | 'unlink' | 'UNLINK'
 
-export type ResponseType = 
-  | 'arraybuffer' 
-  | 'blob' 
-  | 'document' 
-  | 'json' 
-  | 'text' 
+export type ResponseType =
+  | 'arraybuffer'
+  | 'blob'
+  | 'document'
+  | 'json'
+  | 'text'
   | 'stream'
 
 export interface AxiosRequestConfig {
@@ -61,6 +61,7 @@ export interface AxiosRequestConfig {
   onUploadProgress?: (progressEvent: any) => void;
   onDownloadProgress?: (progressEvent: any) => void;
   maxContentLength?: number;
+  maxBodyLength?: number;
   validateStatus?: (status: number) => boolean;
   maxRedirects?: number;
   socketPath?: string | null;

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -171,8 +171,12 @@ module.exports = function httpAdapter(config) {
       transport = isHttpsProxy ? httpsFollow : httpFollow;
     }
 
-    if (config.maxContentLength && config.maxContentLength > -1) {
-      options.maxBodyLength = config.maxContentLength;
+    if (config.maxBodyLength > -1) {
+      options.maxBodyLength = config.maxBodyLength;
+      if (data.length > config.maxBodyLength) {
+        reject(createError('maxBodyLength size of ' + config.maxBodyLength + ' exceeded',
+          config, null, null));
+      }
     }
 
     // Create the request

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -173,10 +173,6 @@ module.exports = function httpAdapter(config) {
 
     if (config.maxBodyLength > -1) {
       options.maxBodyLength = config.maxBodyLength;
-      if (data.length > config.maxBodyLength) {
-        reject(createError('maxBodyLength size of ' + config.maxBodyLength + ' exceeded',
-          config, null, null));
-      }
     }
 
     // Create the request

--- a/lib/core/mergeConfig.js
+++ b/lib/core/mergeConfig.js
@@ -21,7 +21,7 @@ module.exports = function mergeConfig(config1, config2) {
     'baseURL', 'url', 'transformRequest', 'transformResponse', 'paramsSerializer',
     'timeout', 'withCredentials', 'adapter', 'responseType', 'xsrfCookieName',
     'xsrfHeaderName', 'onUploadProgress', 'onDownloadProgress',
-    'maxContentLength', 'validateStatus', 'maxRedirects', 'httpAgent',
+    'maxContentLength', 'maxBodyLength', 'validateStatus', 'maxRedirects', 'httpAgent',
     'httpsAgent', 'cancelToken', 'socketPath', 'responseEncoding'
   ];
 

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -74,6 +74,7 @@ var defaults = {
   xsrfHeaderName: 'X-XSRF-TOKEN',
 
   maxContentLength: -1,
+  maxBodyLength: -1,
 
   validateStatus: function validateStatus(status) {
     return status >= 200 && status < 300;

--- a/test/typescript/axios.ts
+++ b/test/typescript/axios.ts
@@ -34,6 +34,7 @@ const config: AxiosRequestConfig = {
   onUploadProgress: (progressEvent: any) => {},
   onDownloadProgress: (progressEvent: any) => {},
   maxContentLength: 2000,
+  maxBodyLength: 2000,
   validateStatus: (status: number) => status >= 200 && status < 300,
   maxRedirects: 5,
   proxy: {

--- a/test/unit/adapters/http.js
+++ b/test/unit/adapters/http.js
@@ -296,6 +296,35 @@ describe('supports http with nodejs', function () {
     });
   });
 
+  it('should support max body length', function (done) {
+    var data = Array(100000).join('ж');
+
+    server = http.createServer(function (req, res) {
+      res.setHeader('Content-Type', 'text/html; charset=UTF-8');
+      res.end();
+    }).listen(4444, function () {
+      var success = false, failure = false, error;
+
+      axios.post('http://localhost:4444/', {
+        data: data
+      }, {
+        maxBodyLength: 2000
+      }).then(function (res) {
+        success = true;
+      }).catch(function (err) {
+        error = err;
+        failure = true;
+      });
+
+      setTimeout(function () {
+        assert.equal(success, false, 'request should not succeed');
+        assert.equal(failure, true, 'request should fail');
+        assert.equal(error.message, 'maxBodyLength size of 2000 exceeded');
+        done();
+      }, 100);
+    });
+  });
+
   it.skip('should support sockets', function (done) {
     server = net.createServer(function (socket) {
       socket.on('data', function () {

--- a/test/unit/adapters/http.js
+++ b/test/unit/adapters/http.js
@@ -316,9 +316,12 @@ describe('supports http with nodejs', function () {
         failure = true;
       });
 
+
       setTimeout(function () {
         assert.equal(success, false, 'request should not succeed');
         assert.equal(failure, true, 'request should fail');
+        assert.equal(error.code, 'ERR_FR_MAX_BODY_LENGTH_EXCEEDED');
+        assert.equal(error.message, 'Request body larger than maxBodyLength limit');
         done();
       }, 100);
     });

--- a/test/unit/adapters/http.js
+++ b/test/unit/adapters/http.js
@@ -319,7 +319,6 @@ describe('supports http with nodejs', function () {
       setTimeout(function () {
         assert.equal(success, false, 'request should not succeed');
         assert.equal(failure, true, 'request should fail');
-        assert.equal(error.message, 'maxBodyLength size of 2000 exceeded');
         done();
       }, 100);
     });


### PR DESCRIPTION
This PR is intended to solve the confusion described on https://github.com/axios/axios/issues/2696 by adding a separate option in the request config to forward the `maxBodyLength` to the `follow-redirects` library.