### PR TITLE
Fix Non-standard environment `pathname` is undefined #2799

### DIFF
--- a/lib/helpers/isURLSameOrigin.js
+++ b/lib/helpers/isURLSameOrigin.js
@@ -28,7 +28,7 @@ module.exports = (
         }
 
         urlParsingNode.setAttribute('href', href);
-        
+
         // Fix Non-standard environment `urlParsingNode.pathname` is undefined (issue #2799)
         urlParsingNode.pathname = urlParsingNode.pathname || '';
 

--- a/lib/helpers/isURLSameOrigin.js
+++ b/lib/helpers/isURLSameOrigin.js
@@ -28,6 +28,9 @@ module.exports = (
         }
 
         urlParsingNode.setAttribute('href', href);
+        
+        // Fix Non-standard environment `urlParsingNode.pathname` is undefined (issue #2799)
+        urlParsingNode.pathname = urlParsingNode.pathname || '';
 
         // urlParsingNode provides the UrlUtils interface - http://url.spec.whatwg.org/#urlutils
         return {


### PR DESCRIPTION
Fix Non-standard environment `pathname` is undefined #2799