### PR TITLE
headers type check

### DIFF
--- a/lib/helpers/normalizeHeaderName.js
+++ b/lib/helpers/normalizeHeaderName.js
@@ -3,6 +3,7 @@
 var utils = require('../utils');
 
 module.exports = function normalizeHeaderName(headers, normalizedName) {
+  if (headers instanceof Object == false) throw new Error("Headers must be object");
   utils.forEach(headers, function processHeader(value, name) {
     if (name !== normalizedName && name.toUpperCase() === normalizedName.toUpperCase()) {
       headers[normalizedName] = value;

--- a/lib/helpers/normalizeHeaderName.js
+++ b/lib/helpers/normalizeHeaderName.js
@@ -3,7 +3,7 @@
 var utils = require('../utils');
 
 module.exports = function normalizeHeaderName(headers, normalizedName) {
-  if (headers instanceof Object == false) throw new Error("Headers must be object");
+  if (headers instanceof Object === false) throw new Error('Headers must be object');
   utils.forEach(headers, function processHeader(value, name) {
     if (name !== normalizedName && name.toUpperCase() === normalizedName.toUpperCase()) {
       headers[normalizedName] = value;


### PR DESCRIPTION
When we pass string, we will get "UnhandledPromiseRejectionWarning: TypeError: name.toUpperCase is not a function", because strings also iterable, but name parameter will be integer (current position), not string as expected.