### PR TITLE
Don't drop ERR_FR_REDIRECTION_FAILURE #2811

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -245,7 +245,9 @@ module.exports = function httpAdapter(config) {
 
     // Handle errors
     req.on('error', function handleRequestError(err) {
-      if (req.aborted && err.code !== 'ERR_FR_TOO_MANY_REDIRECTS') return;
+      if (req.aborted
+        && err.code !== 'ERR_FR_TOO_MANY_REDIRECTS'
+        && err.code !== 'ERR_FR_REDIRECTION_FAILURE') return;
       reject(enhanceError(err, config, null, req));
     });
 


### PR DESCRIPTION
`ERR_FR_REDIRECTION_FAILURE` error coming from `follow-redirects` is silently dropped as described here #2811
This will make sure that error is propagated to the caller.