### PR TITLE
Fixing sometimes response.data is string instead of object

### DIFF
--- a/lib/core/dispatchRequest.js
+++ b/lib/core/dispatchRequest.js
@@ -4,6 +4,7 @@ var utils = require('./../utils');
 var transformData = require('./transformData');
 var isCancel = require('../cancel/isCancel');
 var defaults = require('../defaults');
+var createError = require('./createError');
 
 /**
  * Throws a `Cancel` if cancellation has been requested.
@@ -52,12 +53,23 @@ module.exports = function dispatchRequest(config) {
   return adapter(config).then(function onAdapterResolution(response) {
     throwIfCancellationRequested(config);
 
-    // Transform response data
-    response.data = transformData(
-      response.data,
-      response.headers,
-      config.transformResponse
-    );
+    try {
+      // Transform response data
+      response.data = transformData(
+        response.data,
+        response.headers,
+        config.transformResponse
+      );
+    } catch (e) {
+      var error = createError(
+        e.name + ': ' + e.message,
+        config,
+        null,
+        response.request,
+        response
+      );
+      return Promise.reject(error);
+    }
 
     return response;
   }, function onAdapterRejection(reason) {

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -54,12 +54,25 @@ var defaults = {
     return data;
   }],
 
-  transformResponse: [function transformResponse(data) {
+  transformResponse: [function transformResponse(data, headers) {
     /*eslint no-param-reassign:0*/
     if (typeof data === 'string') {
       try {
+        if (data === '') {
+          return {};
+        }
         data = JSON.parse(data);
-      } catch (e) { /* Ignore */ }
+      } catch (e) {
+        if (
+          !utils.isUndefined(headers) &&
+          !utils.isUndefined(headers['content-type']) &&
+          headers['content-type'].match(new RegExp('application/json', 'i'))
+        ) {
+          throw e;
+        }
+        // Ignore error when content-type isn't set to JSON
+        // For the sake of backward compatibility
+      }
     }
     return data;
   }],

--- a/test/specs/cancel.spec.js
+++ b/test/specs/cancel.spec.js
@@ -40,7 +40,8 @@ describe('cancel', function() {
         source.cancel('Operation has been canceled.');
         request.respondWith({
           status: 200,
-          responseText: 'OK'
+          responseText: 'OK',
+          contentType: 'text/plain'
         });
       });
     });
@@ -81,7 +82,8 @@ describe('cancel', function() {
       getAjaxRequest().then(function (request) {
         request.respondWith({
           status: 200,
-          responseText: 'OK'
+          responseText: 'OK',
+          contentType: 'text/plain'
         });
       });
     });

--- a/test/specs/defaults.spec.js
+++ b/test/specs/defaults.spec.js
@@ -35,6 +35,14 @@ describe('defaults', function () {
     expect(defaults.transformResponse[0]('foo=bar')).toEqual('foo=bar');
   });
 
+  it('should throw error for invalid JSON if response content-type is json', function () {
+    expect(function() {
+      defaults.transformResponse[0]('foo=bar', {
+        'content-type': 'application/json'
+      });
+    }).toThrow();
+  });
+
   it('should use global defaults config', function (done) {
     axios('/foo');
 

--- a/test/specs/interceptors.spec.js
+++ b/test/specs/interceptors.spec.js
@@ -20,7 +20,8 @@ describe('interceptors', function () {
     getAjaxRequest().then(function (request) {
       request.respondWith({
         status: 200,
-        responseText: 'OK'
+        responseText: 'OK',
+        contentType: 'text/plain'
       });
 
       expect(request.requestHeaders.test).toBe('added by interceptor');
@@ -103,7 +104,8 @@ describe('interceptors', function () {
     getAjaxRequest().then(function (request) {
       request.respondWith({
         status: 200,
-        responseText: 'OK'
+        responseText: 'OK',
+        contentType: 'text/plain'
       });
 
       setTimeout(function () {
@@ -129,7 +131,8 @@ describe('interceptors', function () {
     getAjaxRequest().then(function (request) {
       request.respondWith({
         status: 200,
-        responseText: 'OK'
+        responseText: 'OK',
+        contentType: 'text/plain'
       });
 
       setTimeout(function () {
@@ -159,7 +162,8 @@ describe('interceptors', function () {
     getAjaxRequest().then(function (request) {
       request.respondWith({
         status: 200,
-        responseText: 'OK'
+        responseText: 'OK',
+        contentType: 'text/plain'
       });
 
       setTimeout(function () {
@@ -192,7 +196,8 @@ describe('interceptors', function () {
     getAjaxRequest().then(function (request) {
       request.respondWith({
         status: 200,
-        responseText: 'OK'
+        responseText: 'OK',
+        contentType: 'text/plain'
       });
 
       setTimeout(function () {
@@ -227,7 +232,8 @@ describe('interceptors', function () {
     getAjaxRequest().then(function (request) {
       request.respondWith({
         status: 200,
-        responseText: 'OK'
+        responseText: 'OK',
+        contentType: 'text/plain'
       });
 
       setTimeout(function () {


### PR DESCRIPTION
<!-- Click "Preview" for a more readable version -->

This PR is a fix for [this](https://github.com/axios/axios/issues/1723). In summary, it ensures to throw error when response's content-type is json but the response data isn't a valid JSON.

This PR might cause a little backward compatibility issue, but IMO it's still worth it.  