### PR TITLE
Make default transformResponse parse JSON more properly

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 export interface AxiosTransformer {
-  (data: any, headers?: any): any;
+  (data: any, headers?: any, config?: AxiosRequestConfig): any;
 }
 
 export interface AxiosAdapter {

--- a/lib/core/dispatchRequest.js
+++ b/lib/core/dispatchRequest.js
@@ -30,6 +30,7 @@ module.exports = function dispatchRequest(config) {
   config.data = transformData(
     config.data,
     config.headers,
+    config,
     config.transformRequest
   );
 
@@ -56,6 +57,7 @@ module.exports = function dispatchRequest(config) {
     response.data = transformData(
       response.data,
       response.headers,
+      config,
       config.transformResponse
     );
 
@@ -69,6 +71,7 @@ module.exports = function dispatchRequest(config) {
         reason.response.data = transformData(
           reason.response.data,
           reason.response.headers,
+          config,
           config.transformResponse
         );
       }

--- a/lib/core/transformData.js
+++ b/lib/core/transformData.js
@@ -7,13 +7,14 @@ var utils = require('./../utils');
  *
  * @param {Object|String} data The data to be transformed
  * @param {Array} headers The headers for the request or response
+ * @param {Object} config The axios request config
  * @param {Array|Function} fns A single function or Array of functions
  * @returns {*} The resulting transformed data
  */
-module.exports = function transformData(data, headers, fns) {
+module.exports = function transformData(data, headers, config, fns) {
   /*eslint no-param-reassign:0*/
   utils.forEach(fns, function transform(fn) {
-    data = fn(data, headers);
+    data = fn(data, headers, config);
   });
 
   return data;

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -54,9 +54,9 @@ var defaults = {
     return data;
   }],
 
-  transformResponse: [function transformResponse(data) {
+  transformResponse: [function transformResponse(data, headers, config) {
     /*eslint no-param-reassign:0*/
-    if (typeof data === 'string') {
+    if (config.responseType !== 'text' && typeof data === 'string') {
       try {
         data = JSON.parse(data);
       } catch (e) { /* Ignore */ }

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -57,9 +57,7 @@ var defaults = {
   transformResponse: [function transformResponse(data, headers, config) {
     /*eslint no-param-reassign:0*/
     if (config.responseType !== 'text' && typeof data === 'string') {
-      try {
-        data = JSON.parse(data);
-      } catch (e) { /* Ignore */ }
+      return JSON.parse(data);
     }
     return data;
   }],

--- a/test/specs/core/transformData.spec.js
+++ b/test/specs/core/transformData.spec.js
@@ -3,7 +3,7 @@ var transformData = require('../../../lib/core/transformData');
 describe('core::transformData', function () {
   it('should support a single transformer', function () {
     var data;
-    data = transformData(data, null, function (data) {
+    data = transformData(data, null, {}, function (data) {
       data = 'foo';
       return data;
     });
@@ -13,7 +13,7 @@ describe('core::transformData', function () {
 
   it('should support an array of transformers', function () {
     var data = '';
-    data = transformData(data, null, [function (data) {
+    data = transformData(data, null, {}, [function (data) {
       data += 'f';
       return data;
     }, function (data) {

--- a/test/specs/transform.spec.js
+++ b/test/specs/transform.spec.js
@@ -64,6 +64,33 @@ describe('transform', function () {
     });
   });
 
+  it('should reject if failed to transform string to JSON', function (done) {
+    var resolveSpy = jasmine.createSpy('resolve');
+    var rejectSpy = jasmine.createSpy('reject');
+
+    axios('/foo')
+      .then(resolveSpy)
+      .catch(rejectSpy)
+      .then(function () {
+        expect(resolveSpy).not.toHaveBeenCalled();
+        expect(rejectSpy).toHaveBeenCalled();
+        done();
+      });
+
+    getAjaxRequest().then(function (request) {
+      request.respondWith({
+        status: 200,
+        responseText: 'invalid json'
+      });
+
+      setTimeout(function () {
+        expect(typeof response.data).toEqual('object');
+        expect(response.data.foo).toEqual('bar');
+        done();
+      }, 100);
+    });
+  });
+
   it('should override default transform', function (done) {
     var data = {
       foo: 'bar'

--- a/test/specs/transform.spec.js
+++ b/test/specs/transform.spec.js
@@ -41,6 +41,29 @@ describe('transform', function () {
     });
   });
 
+  it('should not transform string to JSON if responseType is text', function (done) {
+    var response;
+
+    axios('/foo', {
+      responseType: 'text'
+    }).then(function (data) {
+      response = data;
+    });
+
+    getAjaxRequest().then(function (request) {
+      request.respondWith({
+        status: 200,
+        responseText: '{"foo": "bar"}'
+      });
+
+      setTimeout(function () {
+        expect(typeof response.data).toEqual('string');
+        expect(response.data).toEqual('{"foo": "bar"}');
+        done();
+      }, 100);
+    });
+  });
+
   it('should override default transform', function (done) {
     var data = {
       foo: 'bar'


### PR DESCRIPTION
Similar PRs before,

- #2424, parse JSON in adapters
- #2849, throw errors for invalid JSONs if content-type is application/json

Not sure this is the best solution, because it changes transformers with a new parameter and will break codes depending on silent parsing. So I will not fix tests until we have determined to do.

- Now the default `transformResponse` will not parse the string as JSON if `responseType` is `text`. Fixes #2791 and several issues in https://github.com/axios/axios/issues/811#issuecomment-580158620.

- But once tried, invalid JSON string will cause axios rejects. Fixes #61.