### PR TITLE
Leave traces about 'content-encoding'

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -196,6 +196,9 @@ module.exports = function httpAdapter(config) {
         // add the unzipper to the body stream processing pipeline
           stream = stream.pipe(zlib.createUnzip());
 
+          // leave some traces about the 'content-encoding' before removing it
+          res.headers['axios-content-encoding'] = res.headers['content-encoding'];
+            
           // remove the content-encoding in order to not confuse downstream operations
           delete res.headers['content-encoding'];
           break;

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -196,9 +196,9 @@ module.exports = function httpAdapter(config) {
         // add the unzipper to the body stream processing pipeline
           stream = stream.pipe(zlib.createUnzip());
 
-          // leave some traces about the 'content-encoding' before removing it
+          // leave traces about the 'content-encoding' before removing it
           res.headers['axios-content-encoding'] = res.headers['content-encoding'];
-            
+
           // remove the content-encoding in order to not confuse downstream operations
           delete res.headers['content-encoding'];
           break;


### PR DESCRIPTION
# Issue

Sometimes you want to check the 'content-encoding' in response header.
But the data is decompressed automatically and hence the header is removed.
I think we should add some mark before removing the header.
Closed #2925. 

```typescript
it('transfer with gzip encoding', async () => {
        const res = await axios.get('https://....');
        expect(res).to.have.status(200);
        expect(res).have.header('Content-Encoding', 'gzip');
        expect(res.data.results).exist;
    });
```

# Solution

I can think of two possible solutions:

1. Copy 'content-encoding' to 'axios-content-encoding' before removing it.
So later the test code can check this header.
2. Add a `Response.actualContentEncoding` field. Maybe this approach can be documented easier?

I can't decide. Any suggestions?

