### PR TITLE
Fixing HTTPS proxy from env

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -130,7 +130,8 @@ module.exports = function httpAdapter(config) {
         if (shouldProxy) {
           proxy = {
             host: parsedProxyUrl.hostname,
-            port: parsedProxyUrl.port
+            port: parsedProxyUrl.port,
+            protocol: parsedProxyUrl.protocol
           };
 
           if (parsedProxyUrl.auth) {


### PR DESCRIPTION
Inside the http adapter we use a check on `proxy.protocol` to determine
whether to use HTTP or HTTPS transport
This works fine when we use a `protocol` key in the `proxy`
configuration object
However when the proxy configuration comes from the `http_proxy` or
`https_proxy` environment variable, we parse the URL to set the `host`
and `port` keys in the proxy configuration **but** the protocol is never
extracted from that URL thus causing HTTPS requests to always use HTTP
transport.

I've tried to add some tests to `test/unit/adapters/http.js` to validate the fix but it requires both the server and the proxy to use HTTPS. As the other tests seems to focus on HTTP proxies and servers I don't know how to add those.
I'm willing to work on them if you can point me in the right direction.