### PR TITLE
Add GitHub actions to close invalid issues

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,6 +1,4 @@
-<!-- Click "Preview" for a more readable version -->
-
-#### Instructions
+<!-- Click "Preview" for a more readable version --
 
 Please read and follow the instructions before submitting an issue:
 
@@ -12,6 +10,8 @@ Please read and follow the instructions before submitting an issue:
 
 **⚠️👆 Delete the instructions before submitting the issue 👆⚠️**
 
+-->
+
 #### Summary
 
 Describe your issue here, including as much detail as necessary.
@@ -20,7 +20,11 @@ If you're reporting a bug, include the relevant code and stack traces to debug i
 
 If you're requesting a feature, include some context and examples of code using it.
 
-#### Context
-
-- axios version: *e.g.: v0.16.0*
-- Environment: *e.g.: node v6.9.4, chrome 54, windows 7*
+#### Environment
+ - Axios Version [e.g. 0.18.0]
+ - Adapter [e.g. XHR/HTTP]
+ - Browser [e.g. Chrome, Safari]
+ - Browser Version [e.g. 22]
+ - Node.js Version [e.g. 13.0.1]
+ - OS: [e.g. iOS 12.1.0, OSX 10.13.4]
+ - Additional Library Versions [e.g. React 16.7, React Native 0.58.0]

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -7,6 +7,7 @@ Please read and follow the instructions before submitting an issue:
 - If you aren't sure that the issue is caused by axios or you just need help, please use [Stack Overflow](https://stackoverflow.com/questions/tagged/axios) or [our chat](https://gitter.im/mzabriskie/axios).
 - If you're reporting a bug, ensure it isn't already fixed in the latest axios version.
 - If you need a new feature there's a chance it's already implemented in a [library](https://github.com/axios/axios/blob/master/ECOSYSTEM.md) or you can implement it using [interceptors](https://github.com/axios/axios#interceptors).
+- Don't remove any title of the issue template, or it will be treated as invalid by the bot.
 
 **⚠️👆 Delete the instructions before submitting the issue 👆⚠️**
 

--- a/.github/ISSUE_TEMPLATE/---bug-report.md
+++ b/.github/ISSUE_TEMPLATE/---bug-report.md
@@ -15,6 +15,7 @@ Please read and follow the instructions before submitting an issue:
 - Ensure your issue isn't already [reported](https://github.com/axios/axios/issues?utf8=%E2%9C%93&q=is%3Aissue).
 - If you aren't sure that the issue is caused by Axios or you just need help, please use [Stack Overflow](https://stackoverflow.com/questions/tagged/axios) or [our chat](https://gitter.im/mzabriskie/axios).
 - If you're reporting a bug, ensure it isn't already fixed in the latest Axios version.
+- Don't remove any title of the issue template, or it will be treated as invalid by the bot.
 
 ⚠️👆 Feel free to these instructions before submitting the issue 👆⚠️
 -->

--- a/.github/ISSUE_TEMPLATE/---bug-report.md
+++ b/.github/ISSUE_TEMPLATE/---bug-report.md
@@ -2,7 +2,7 @@
 name: "\U0001F41E Bug Report"
 about: Report a reproducible bug
 title: ''
-labels: bug
+labels: 'status:possible bug'
 assignees: ''
 
 ---
@@ -19,25 +19,27 @@ Please read and follow the instructions before submitting an issue:
 ⚠️👆 Feel free to these instructions before submitting the issue 👆⚠️
 -->
 
-**Describe the bug**
+#### Describe the bug
 A clear and concise description of what the bug is. **If your problem is not a bug, please file under Support or Usage Question**
 
-**To Reproduce**
+#### To Reproduce
 Code snippet to reproduce, ideally that will work by pasting into something like https://npm.runkit.com/axios, a hosted solution, or a repository that illustrates the issue. **If your problem is not reproducible, please file under Support or Usage Question**
 
 ```js
 // Example code here
 ```
 
-**Expected behavior**
+#### Expected behavior
 A clear and concise description of what you expected to happen.
 
-**Environment:**
+#### Environment
  - Axios Version [e.g. 0.18.0]
- - OS: [e.g. iOS 12.1.0, OSX 10.13.4]
+ - Adapter [e.g. XHR/HTTP]
  - Browser [e.g. Chrome, Safari]
  - Browser Version [e.g. 22]
+ - Node.js Version [e.g. 13.0.1]
+ - OS: [e.g. iOS 12.1.0, OSX 10.13.4]
  - Additional Library Versions [e.g. React 16.7, React Native 0.58.0]
 
-**Additional context/Screenshots**
+#### Additional context/Screenshots
 Add any other context about the problem here. If applicable, add screenshots to help explain.

--- a/.github/ISSUE_TEMPLATE/---documentation.md
+++ b/.github/ISSUE_TEMPLATE/---documentation.md
@@ -11,6 +11,8 @@ assignees: ''
 
 If you found an area that needs clarification, feel free to open a PR or list the section/content that could be improved below
 
+Don't remove any title of the issue template, or it will be treated as invalid by the bot.
+
 ⚠️👆 Feel free to refer to these instructions before submitting the issue 👆⚠️
 -->
 

--- a/.github/ISSUE_TEMPLATE/---documentation.md
+++ b/.github/ISSUE_TEMPLATE/---documentation.md
@@ -2,7 +2,7 @@
 name: "\U0001F4DA Documentation"
 about: Report an error or area that needs clarification
 title: ''
-labels: documentation
+labels: 'type:documentation'
 assignees: ''
 
 ---
@@ -14,10 +14,11 @@ If you found an area that needs clarification, feel free to open a PR or list th
 ⚠️👆 Feel free to refer to these instructions before submitting the issue 👆⚠️
 -->
 
-**Section/Content To Improve**
+#### Section/Content To Improve
 Quote or link to section
 
-**Suggested Improvement**
+#### Suggested Improvement
 Identify what is confusing or incorrect and what could make it better
 
-**Relevant File(s)**: [e.g. README.md]
+#### Relevant File(s)
+[e.g. README.md]

--- a/.github/ISSUE_TEMPLATE/---feature-request.md
+++ b/.github/ISSUE_TEMPLATE/---feature-request.md
@@ -2,19 +2,19 @@
 name: "✨ Feature Request"
 about: Suggest an idea or feature
 title: ''
-labels: feature
+labels: 'type:feature'
 assignees: ''
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
+#### Is your feature request related to a problem? Please describe.
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
-**Describe the solution you'd like**
+#### Describe the solution you'd like
 A clear and concise description of what you want to happen.
 
-**Describe alternatives you've considered**
+#### Describe alternatives you've considered
 A clear and concise description of any alternative solutions or features you've considered.
 
-**Additional context**
+#### Additional context
 Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/---feature-request.md
+++ b/.github/ISSUE_TEMPLATE/---feature-request.md
@@ -7,6 +7,19 @@ assignees: ''
 
 ---
 
+<!-- Click "Preview" for a more readable version --
+
+Please read and follow the instructions before submitting an issue:
+
+- Read all our documentation, especially the [README](https://github.com/axios/axios/blob/master/README.md). It may contain information that helps you solve your issue.
+- Ensure your issue isn't already [reported](https://github.com/axios/axios/issues?utf8=%E2%9C%93&q=is%3Aissue).
+- If you aren't sure that the issue is caused by Axios or you just need help, please use [Stack Overflow](https://stackoverflow.com/questions/tagged/axios) or [our chat](https://gitter.im/mzabriskie/axios).
+- If you're reporting a bug, ensure it isn't already fixed in the latest Axios version.
+- Don't remove any title of the issue template, or it will be treated as invalid by the bot.
+
+⚠️👆 Feel free to these instructions before submitting the issue 👆⚠️
+-->
+
 #### Is your feature request related to a problem? Please describe.
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 

--- a/.github/ISSUE_TEMPLATE/---support-or-usage-question.md
+++ b/.github/ISSUE_TEMPLATE/---support-or-usage-question.md
@@ -15,6 +15,7 @@ Please read and follow the instructions before submitting an issue:
 - Ensure your issue isn't already [reported](https://github.com/axios/axios/issues?utf8=%E2%9C%93&q=is%3Aissue).
 - If you aren't sure that the issue is caused by Axios or you just need help, please use [Stack Overflow](https://stackoverflow.com/questions/tagged/axios) or [our chat](https://gitter.im/mzabriskie/axios).
 - If you're reporting a bug, ensure it isn't already fixed in the latest Axios version.
+- Don't remove any title of the issue template, or it will be treated as invalid by the bot.
 
 ⚠️👆 Feel free to these instructions before submitting the issue 👆⚠️
 -->

--- a/.github/ISSUE_TEMPLATE/---support-or-usage-question.md
+++ b/.github/ISSUE_TEMPLATE/---support-or-usage-question.md
@@ -2,7 +2,7 @@
 name: "\U0001F914 Support or Usage Question"
 about: Get help using Axios
 title: ''
-labels: question
+labels: 'type:question'
 assignees: ''
 
 ---
@@ -19,25 +19,27 @@ Please read and follow the instructions before submitting an issue:
 ⚠️👆 Feel free to these instructions before submitting the issue 👆⚠️
 -->
 
-**Describe the issue**
+#### Describe the issue
 A clear and concise description of what the issue is.
 
-**Example Code**
+#### Example Code
 Code snippet to illustrate your question
 
 ```js
 // Example code here
 ```
 
-**Expected behavior, if applicable**
+#### Expected behavior, if applicable
 A clear and concise description of what you expected to happen.
 
-**Environment:**
+#### Environment
  - Axios Version [e.g. 0.18.0]
- - OS: [e.g. iOS 12.1.0, OSX 10.13.4]
+ - Adapter [e.g. XHR/HTTP]
  - Browser [e.g. Chrome, Safari]
  - Browser Version [e.g. 22]
+ - Node.js Version [e.g. 13.0.1]
+ - OS: [e.g. iOS 12.1.0, OSX 10.13.4]
  - Additional Library Versions [e.g. React 16.7, React Native 0.58.0]
 
-**Additional context/Screenshots**
+#### Additional context/Screenshots
 Add any other context about the problem here. If applicable, add screenshots to help explain.

--- a/.github/workflows/close-issues.yml
+++ b/.github/workflows/close-issues.yml
@@ -14,4 +14,4 @@ jobs:
         uses: lucasbento/auto-close-issues@v1.0.2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          issue-close-message: "Closed by the issue bot. Make sure you have followed the issue template. Thanks."
+          issue-close-message: "Closed by the issue bot. Make sure you have followed the issue template will all required sections/titles. Thanks."

--- a/.github/workflows/close-issues.yml
+++ b/.github/workflows/close-issues.yml
@@ -8,6 +8,8 @@ jobs:
   auto_close_issues:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
       - name: Automatically close issues that don't follow the issue template
         uses: lucasbento/auto-close-issues@v1.0.2
         with:

--- a/.github/workflows/close-issues.yml
+++ b/.github/workflows/close-issues.yml
@@ -1,0 +1,15 @@
+name: 'Close Invalid Issues'
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  auto_close_issues:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Automatically close issues that don't follow the issue template
+        uses: lucasbento/auto-close-issues@v1.0.2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-close-message: "Closed by the issue bot. Make sure you have followed the issue template. Thanks."


### PR DESCRIPTION
In this PR,

- Add GitHub actions [auto-close-issues](https://github.com/marketplace/actions/auto-close-issues), which will close issues those without required markdown titles
- Update our issues templates,
  - rename `--feature-request.md` with the same format of file name
  - to use markdown titles so that the action can work
  - with right labels because we changed them recently
  - with clear environment information template, especially for adapters (they can reduce 50% of work to resolve the issue)
  - with special comments to remind the logic of the close bot

I have tested it in my fork and it works as expected. See https://github.com/chinesedfan/axios/issues/4 and others issues in the repository.
