### PR TITLE
Dont throw/catch transform exceptions on 304

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -56,7 +56,7 @@ var defaults = {
 
   transformResponse: [function transformResponse(data) {
     /*eslint no-param-reassign:0*/
-    if (typeof data === 'string' && data != "") {
+    if (typeof data === 'string' && data !== "") {
       try {
         data = JSON.parse(data);
       } catch (e) { /* Ignore */ }

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -56,7 +56,7 @@ var defaults = {
 
   transformResponse: [function transformResponse(data) {
     /*eslint no-param-reassign:0*/
-    if (typeof data === 'string' && data !== "") {
+    if (typeof data === 'string' && data !== '') {
       try {
         data = JSON.parse(data);
       } catch (e) { /* Ignore */ }

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -56,7 +56,7 @@ var defaults = {
 
   transformResponse: [function transformResponse(data) {
     /*eslint no-param-reassign:0*/
-    if (typeof data === 'string') {
+    if (typeof data === 'string' && data != "") {
       try {
         data = JSON.parse(data);
       } catch (e) { /* Ignore */ }


### PR DESCRIPTION
Dont try to parse response data from 304 requests, as it is suppose to not have a body.

The real problem is A)
https://github.com/axios/axios/blob/36f0ad2f985c3289018f0fdaaddf309cc9458d9b/lib/adapters/xhr.js#L28
in some browsers set response/responseText to "" in XMLHttpRequest.

At this point B)
https://github.com/axios/axios/blob/36f0ad2f985c3289018f0fdaaddf309cc9458d9b/lib/adapters/xhr.js#L61
the response/responseText is copied directly without checking if there should be a body; copying "".

The same problem at this place: C)
https://github.com/axios/axios/blob/5b08fc4ac7ecc896efa37952645ea578a3609fc2/lib/core/dispatchRequest.js#L57

And finally at the patched line, where the "" is attempted to be parsed as JSON, which it is not, nor should be.

I dont think A) will change, and changing B+C) is a lot of complex code for very little.