### PR TITLE
Adding Request Hooks functionality to axios

### DIFF
--- a/lib/core/Axios.js
+++ b/lib/core/Axios.js
@@ -5,6 +5,7 @@ var buildURL = require('../helpers/buildURL');
 var InterceptorManager = require('./InterceptorManager');
 var dispatchRequest = require('./dispatchRequest');
 var mergeConfig = require('./mergeConfig');
+var Hooks = require('./hooks');
 
 /**
  * Create a new instance of Axios
@@ -34,34 +35,45 @@ Axios.prototype.request = function request(config) {
     config = config || {};
   }
 
-  config = mergeConfig(this.defaults, config);
+  var self = this;
 
-  // Set config.method
-  if (config.method) {
-    config.method = config.method.toLowerCase();
-  } else if (this.defaults.method) {
-    config.method = this.defaults.method.toLowerCase();
-  } else {
-    config.method = 'get';
+  function fn(_config) {
+    _config = mergeConfig(self.defaults, _config);
+
+    // Set config.method
+    if (_config.method) {
+      _config.method = _config.method.toLowerCase();
+    } else if (self.defaults.method) {
+      _config.method = self.defaults.method.toLowerCase();
+    } else {
+      _config.method = 'get';
+    }
+
+    // Hook up interceptors middleware
+    var chain = [dispatchRequest, undefined];
+    var promise = Promise.resolve(_config);
+
+    self.interceptors.request.forEach(function unshiftRequestInterceptors(interceptor) {
+      chain.unshift(interceptor.fulfilled, interceptor.rejected);
+    });
+
+    self.interceptors.response.forEach(function pushResponseInterceptors(interceptor) {
+      chain.push(interceptor.fulfilled, interceptor.rejected);
+    });
+
+    while (chain.length) {
+      promise = promise.then(chain.shift(), chain.shift());
+    }
+
+    return promise;
   }
 
-  // Hook up interceptors middleware
-  var chain = [dispatchRequest, undefined];
-  var promise = Promise.resolve(config);
-
-  this.interceptors.request.forEach(function unshiftRequestInterceptors(interceptor) {
-    chain.unshift(interceptor.fulfilled, interceptor.rejected);
-  });
-
-  this.interceptors.response.forEach(function pushResponseInterceptors(interceptor) {
-    chain.push(interceptor.fulfilled, interceptor.rejected);
-  });
-
-  while (chain.length) {
-    promise = promise.then(chain.shift(), chain.shift());
-  }
-
-  return promise;
+  var hooks  = config.hooks;
+  var axiosHooks = new Hooks();
+  var registered = axiosHooks.register(hooks, fn);
+  // remove the hooks from the config
+  delete config.hooks;
+  return registered ? axiosHooks.fn(config) : fn(config);
 };
 
 Axios.prototype.getUri = function getUri(config) {

--- a/lib/core/hooks.js
+++ b/lib/core/hooks.js
@@ -1,0 +1,230 @@
+/* eslint-disable no-param-reassign */
+/*eslint consistent-return:0*/
+'use strict';
+
+// TODO: beforeRedirect, beforeRetry
+
+var utils = require('../utils');
+// this is the Hooks constructor
+function Hooks() {}
+
+/**
+ * Registers the hooks
+ * @param {Object} hooks this contains the array of pre and post hooks to be registered
+ * @param {*} fn this is the main function to which pre and post hooks are added
+ */
+Hooks.prototype.register = function register(hooks, fn) {
+  var currentSelf = this;
+  if (utils.isUndefined(hooks)) {
+    return false;
+  }
+  if (!utils.isFunction(fn)) {
+    return false;
+  }
+  var hasHook = false;
+  if (utils.isObject(hooks)) {
+    // TODO: need to extract the hook verbs from the hook object and register them
+    if (hooks.beforeRequest && hooks.beforeRequest.length > 0) {
+      // register the pre hook
+      hooks.beforeRequest.map(function registerPreHooks(pre) {
+        if (utils.isFunction(pre)) {
+          hasHook = true;
+          currentSelf.pre(fn.name, pre);
+        }
+      });
+    }
+    if (hooks.beforeError && hooks.beforeError.length > 0) {
+      hooks.beforeError.map(function registerBeforeErrorHooks(post) {
+        if (utils.isFunction(post)) {
+          hasHook = true;
+          currentSelf.beforeError(fn.name, post);
+        }
+      });
+    }
+    if (hooks.afterResponse && hooks.afterResponse.length > 0) {
+      // register the post hook
+      hooks.afterResponse.map(function registerPostHooks(post) {
+        if (utils.isFunction(post)) {
+          hasHook = true;
+          currentSelf.post(fn.name, post);
+        }
+      });
+    }
+    // register the function to the hook
+    if (hasHook) {
+      currentSelf.hook(
+        fn.name,
+        fn,
+        utils.isFunction(hooks.errorHandler) ? hooks.errorHandler : null
+      );
+    }
+  }
+  return hasHook;
+};
+
+/**
+ *  Declares a new hook to which you can add pres and posts
+ *  @param {String} name of the function
+ *  @param {Function} fn method
+ *  @param {Function} err error handler callback
+ */
+Hooks.prototype.hook = function hook(name, fn, err) {
+  if (arguments.length === 1 && utils.isString(arguments[0])) {
+    //* lookup the function
+    fn = this[name] || null;
+    if (!fn) {
+      throw new Error('no function with the name ' + name + ' found');
+    }
+  }
+  if (!err) {
+    err = function errorHandler() {
+      throw new Error('add an Error Handler to handle error thrown in hooks');
+    };
+  }
+  var currentSelf = this;
+  var pres = (currentSelf._pres = currentSelf._pres || {});
+  var posts = (currentSelf._posts = currentSelf._posts || {});
+  var beforeErrors = (currentSelf._beforeErrors =
+    currentSelf._beforeErrors || {});
+  pres[name] = pres[name] || [];
+  posts[name] = posts[name] || [];
+  beforeErrors[name] = beforeErrors[name] || [];
+
+  currentSelf[name] = function mainFunction() {
+    var result = new Promise(function defaultReturnValue() {});
+    var finishValue = new Promise(function defaultReturnValue() {});
+    var called = false;
+    var self = this;
+    pres = self._pres[name];
+    posts = self._posts[name];
+    beforeErrors = self._beforeErrors[name];
+    var hookArgs = [].slice.call(arguments);
+    // this is called by the last post hook => what ever value is passed over by the last post hook is set as the new result value
+    function noop() {
+      if (arguments[0] instanceof Error) return err(arguments[0]);
+      if (arguments.length) hookArgs = [].slice.call(arguments);
+      if (hookArgs.length) {
+        if (hookArgs[0] instanceof Promise) {
+          result = hookArgs[0];
+        } else {
+          result = new Promise(function createReturnValue(res) {
+            res(hookArgs[0]);
+          });
+        }
+      }
+    }
+    function allPresDone() {
+      if (called) return; // check if the function as been called
+      if (arguments[0] instanceof Error) return err(arguments[0]);
+      if (arguments.length) hookArgs = [].slice.call(arguments);
+      var config = hookArgs[0] || {};
+      called = true; // set the called to true
+      result = fn.apply(self, hookArgs);
+      // asign the result promise to the finishValue
+      finishValue = result
+        .then(function handlePostHooks(value) {
+          if (config.responseType !== 'stream') {
+            hookArgs = [
+              value,
+              function retryWithMergedOptions(updatedOptions) {
+                // overwrite the hookArgs with the new return value
+                hookArgs[0] = fn(Object.assign(config, updatedOptions));
+              }
+            ];
+            var postChain = posts.map(function createPostHookWrapper(post, i) {
+              function wrapper() {
+                if (arguments[0] instanceof Error) return err(arguments[0]);
+                if (arguments.length) hookArgs = [].slice.call(arguments);
+                post.apply(self, [postChain[i + 1] || noop].concat(hookArgs));
+              } // end wrapper = function () {...
+              return wrapper;
+            }); // end posts.map(...)noop
+            if (postChain.length) {
+              postChain[0]();
+            }
+          }
+          return result;
+        })
+        .catch(function errorHandler(error) {
+          // beforeError hook
+          var beforeErrorChain = beforeErrors.map(
+            function createBeforeErrorHookWrapper(post, i) {
+              function wrapper() {
+                if (arguments[0] instanceof Error) error = arguments[0];
+                post.apply(
+                  self,
+                  [
+                    beforeErrorChain[i + 1] ||
+                      function passUserDefinedErrorOver() {
+                        if (arguments[0] instanceof Error) error = arguments[0];
+                      }
+                  ].concat(error)
+                );
+              }
+              return wrapper;
+            }
+          );
+          if (beforeErrorChain.length) {
+            beforeErrorChain[0]();
+          }
+          return new Promise(function newPromise(_, rej) {
+            rej(error);
+          });
+        });
+    }
+    var preChain = pres.map(function createPreHookWrapper(pre, i) {
+      function wrapper() {
+        if (arguments[0] instanceof Error) return err(arguments[0]);
+
+        if (arguments.length) hookArgs = [].slice.call(arguments);
+        return pre.apply(
+          self,
+          [preChain[i + 1] || allPresDone].concat(hookArgs)
+        );
+      } // end wrapper = function () {...
+      return wrapper;
+    }); // end posts.map(...)
+
+    (preChain[0] || allPresDone)();
+    return finishValue;
+  };
+};
+
+/**
+ * register a pre hook
+ * @param {*} name name of the hook function
+ * @param {*} fn the pre method
+ */
+Hooks.prototype.pre = function pre(name, fn) {
+  var currentSelf = this;
+  var pres = (currentSelf._pres = currentSelf._pres || {});
+  (pres[name] = pres[name] || []).push(fn);
+  return this;
+};
+
+/**
+ * Register a post hook
+ *  @param {String} name name of the hook function
+ *  @param {Function} fn the post method
+ */
+Hooks.prototype.post = function post(name, fn) {
+  var currentSelf = this;
+  var posts = (currentSelf._posts = currentSelf._posts || {});
+  (posts[name] = posts[name] || []).push(fn);
+  return this;
+};
+
+/**
+ *  Register a beforeError hook
+ *  @param {String} name name of the function
+ *  @param {Function} fn the beforeError method
+ */
+Hooks.prototype.beforeError = function beforeError(name, fn) {
+  var currentSelf = this;
+  var beforeErrors = (currentSelf._beforeErrors =
+    currentSelf._beforeErrors || {});
+  (beforeErrors[name] = beforeErrors[name] || []).push(fn);
+  return this;
+};
+
+module.exports = Hooks;

--- a/test/specs/core/hooks.spec.js
+++ b/test/specs/core/hooks.spec.js
@@ -1,0 +1,600 @@
+var Hooks = require('../../../lib/core/hooks');
+var axios = require('../../../index');
+
+describe('hooks', function() {
+  function returnPromise(check, value) {
+    return new Promise(function(resolve, reject) {
+      if (!check) {
+        resolve(value || true);
+      } else {
+        reject(value || false);
+      }
+    });
+  }
+
+  it('should be able to assign hooks', function() {
+    var a = new Hooks();
+    a.hook('hook1', function() {});
+    expect(typeof a.hook1).toEqual('function');
+  });
+
+  it('should run without pres, posts and beforeError when not present', function(done) {
+    var a = new Hooks();
+    a.hook('save', function() {
+      this.value = 1;
+      return returnPromise();
+    });
+    a.save();
+    setTimeout(function() {
+      expect(a.value).toEqual(1);
+      done();
+    }, 100);
+  });
+
+  it('should run with pres when present', function(done) {
+    var a = new Hooks();
+    a.hook('save', function() {
+      this.value = 1;
+      return returnPromise();
+    });
+    a.pre('save', function(next) {
+      this.preValue = 2;
+      next();
+    });
+    a.save();
+    setTimeout(function() {
+      expect(a.value).toEqual(1);
+      expect(a.preValue).toEqual(2);
+      done();
+    }, 100);
+  });
+
+  it('should run with posts when present', function(done) {
+    var a = new Hooks();
+    a.hook('save', function() {
+      this.value = 1;
+      return returnPromise();
+    });
+    a.post('save', function(next) {
+      this.value = 2;
+      next();
+    });
+    a.save();
+    setTimeout(function() {
+      expect(a.value).toEqual(2);
+      done();
+    }, 100);
+  });
+
+  it('should run with beforeError when present', function(done) {
+    var a = new Hooks();
+    a.hook('save', function() {
+      this.value = 1;
+      return returnPromise();
+    });
+    a.beforeError('save', function(next) {
+      next();
+    });
+    a.save();
+    setTimeout(function() {
+      expect(a.value).toEqual(1);
+      done();
+    }, 100);
+  });
+
+  it('should run pres, posts and beforeError when present', function(done) {
+    var a = new Hooks();
+    a.hook('save', function() {
+      this.value = 1;
+      return returnPromise();
+    });
+    a.pre('save', function(next) {
+      this.preValue = 2;
+      next();
+    });
+    a.post('save', function(next) {
+      this.value = 3;
+      next();
+    });
+    a.beforeError('save', function(next) {
+      next();
+    });
+    a.save();
+    setTimeout(function() {
+      expect(a.value).toEqual(3);
+      expect(a.preValue).toEqual(2);
+      done();
+    }, 100);
+  });
+
+  it('should run posts after pres', function(done) {
+    var a = new Hooks();
+    a.hook('save', function() {
+      this.value = 1;
+      return returnPromise();
+    });
+    a.pre('save', function(next) {
+      this.override = 100;
+      next();
+    });
+    a.post('save', function(next) {
+      this.override = 200;
+      next();
+    });
+    a.save();
+    setTimeout(function() {
+      expect(a.value).toEqual(1);
+      expect(a.override).toEqual(200);
+      done();
+    }, 100);
+  });
+
+  it('should not run a hook if a pre fails', function() {
+    var a = new Hooks();
+    var counter = 0;
+    a.hook(
+      'save',
+      function() {
+        this.value = 1;
+      },
+      function() {
+        counter++;
+      }
+    );
+    a.pre('save', function(next) {
+      next(new Error());
+    });
+    a.save();
+    expect(counter).toEqual(1);
+    expect(typeof a.value).toEqual('undefined');
+  });
+
+  it('should be able to run multiple pres', function() {
+    var a = new Hooks();
+
+    a.hook('save', function() {
+      this.value = 1;
+      return returnPromise();
+    });
+    a.pre('save', function(next) {
+      this.v1 = 1;
+      next();
+    });
+    a.pre('save', function(next) {
+      this.v2 = 2;
+      next();
+    });
+    a.save();
+    expect(a.v1).toEqual(1);
+    expect(a.v2).toEqual(2);
+  });
+
+  it('should run multiple pres until a pre fails and not call the hook', function() {
+    var a = new Hooks();
+
+    a.hook(
+      'save',
+      function() {
+        this.value = 1;
+        return returnPromise();
+      },
+      function() {}
+    );
+    a.pre('save', function(next) {
+      this.v1 = 1;
+      next();
+    });
+    a.pre('save', function(next) {
+      next(new Error());
+    });
+    a.pre('save', function(next) {
+      this.v3 = 3;
+      next();
+    });
+
+    a.save();
+    expect(a.v1).toEqual(1);
+    expect(typeof a.v3).toEqual('undefined');
+    expect(typeof a.value).toEqual('undefined');
+  });
+
+  it('should be able to run multiple posts', function(done) {
+    var a = new Hooks();
+
+    a.hook('save', function() {
+      this.value = 1;
+      return returnPromise();
+    });
+    a.post('save', function(next) {
+      this.value = 2;
+      next();
+    })
+      .post('save', function(next) {
+        this.value = 3.14;
+        next();
+      })
+      .post('save', function(next) {
+        this.v3 = 3;
+        next();
+      });
+
+    a.save();
+    setTimeout(function() {
+      expect(a.value).toEqual(3.14);
+      expect(a.v3).toEqual(3);
+      done();
+    }, 100);
+  });
+
+  it('should run only posts up until an error', function(done) {
+    var a = new Hooks();
+
+    a.hook(
+      'save',
+      function() {
+        this.value = 1;
+        return returnPromise();
+      },
+      function() {}
+    );
+    a.post('save', function(next) {
+      this.value = 2;
+      next();
+    })
+      .post('save', function(next) {
+        this.value = 3;
+        next(new Error());
+      })
+      .post('save', function(next) {
+        this.value = 4;
+        next();
+      });
+
+    a.save();
+    setTimeout(function() {
+      expect(a.value).toEqual(3);
+      done();
+    });
+  });
+
+  it('should fall back second to the default error handler if specified', function() {
+    var a = new Hooks();
+
+    var counter = 0;
+    a.hook(
+      'save',
+      function() {
+        this.value = 1;
+      },
+      function(err) {
+        if (err instanceof Error) counter++;
+      }
+    );
+    a.pre('save', function(next) {
+      next(new Error());
+    });
+
+    a.save();
+    expect(counter).toEqual(1);
+    expect(a.value).toEqual(undefined);
+  });
+
+  it('should proceed without mutating arguments if `next(null|undefined)` is called in a serial pre', function() {
+    var a = new Hooks();
+
+    var counter = 0;
+    a.hook('save', function(callback) {
+      this.value = 1;
+      callback();
+      return returnPromise();
+    });
+    a.pre('save', function(next) {
+      next();
+    });
+    a.pre('save', function(next) {
+      next();
+    });
+
+    a.save(function(err) {
+      if (err instanceof Error) counter++;
+      else counter--;
+    });
+    expect(counter).toEqual(-1);
+    expect(a.value).toEqual(1);
+  });
+
+  it('should proceed with mutating arguments if `next(null|undefined)` is callback in a serial pre, and the last argument of the target method is not a function', function() {
+    var a = new Hooks();
+
+    a.hook('set', function(v) {
+      this.value = v;
+      return returnPromise();
+    });
+    a.pre('set', function(next) {
+      next(undefined);
+    });
+    a.pre('set', function(next) {
+      next(null);
+    });
+
+    a.set(1);
+    expect(a.value).toEqual(null);
+  });
+
+  it('should not run any posts if a pre fails', function() {
+    var a = new Hooks();
+
+    a.hook(
+      'save',
+      function() {
+        this.value = 2;
+      },
+      function() {}
+    );
+    a.pre('save', function(next) {
+      this.value = 1;
+      next(new Error());
+    }).post('save', function(next) {
+      this.value = 3;
+      next();
+    });
+
+    a.save();
+    expect(a.value).toEqual(1);
+  });
+
+  it('hooked funtion return value should be passed to the post', function(done) {
+    var a = new Hooks();
+
+    a.hook('set', function() {
+      return returnPromise(false, { val1: 'hello', val2: 'world' });
+    });
+    a.post('set', function(next, data) {
+      expect(data.val1).toEqual('hello');
+      expect(data.val2).toEqual('world');
+      next();
+      done();
+    });
+    a.set();
+  });
+
+  it("pres should be able to modify and pass on a modified version of the hook's arguments", function() {
+    var a = new Hooks();
+
+    a.hook('set', function(path, val) {
+      this[path] = val;
+      expect(arguments[2]).toEqual('optional');
+      return returnPromise();
+    });
+    a.pre('set', function(next) {
+      next('foo', 'bar');
+    });
+    a.pre('set', function(next, path, val) {
+      expect(path).toEqual('foo');
+      expect(val).toEqual('bar');
+      next('rock', 'says', 'optional');
+    });
+    a.pre('set', function(next, path, val, opt) {
+      expect(path).toEqual('rock');
+      expect(val).toEqual('says');
+      expect(opt).toEqual('optional');
+      next();
+    });
+
+    a.set('hello', 'world');
+    expect(typeof a.hello).toEqual('undefined');
+    expect(a.rock).toEqual('says');
+  });
+
+  it('calling the hook next multiple times should have the effect of only calling it once', function(done) {
+    var a = new Hooks();
+    var counter = 0;
+    a.hook('ack', function() {
+      counter++;
+      return returnPromise();
+    });
+    a.pre('ack', function(next) {
+      next();
+      next();
+    });
+    a.ack();
+    setTimeout(function() {
+      expect(counter).toEqual(1);
+      done();
+    });
+  });
+
+  it('should run beforeError when hooked function return a promise rejection', function(done) {
+    var a = new Hooks();
+    a.hook('save', function() {
+      this.value = 1;
+      return returnPromise(true);
+    });
+    a.beforeError('save', function(next) {
+      next(new Error('my error'));
+    }).post('save', function(next) {
+      this.value = 3;
+      next();
+    });
+    a.save()
+      .then()
+      .catch(function(err) {
+        expect(err.message).toEqual('my error');
+        expect(a.value).toEqual(1);
+        done();
+      });
+  });
+
+  it('should not run any posts if hooked function return a promise rejection', function(done) {
+    var a = new Hooks();
+    a.hook('save', function() {
+      this.value = 1;
+      return returnPromise(true, { message: 'my error' });
+    });
+    a.post('save', function(next) {
+      this.value = 3;
+      next();
+    });
+    a.save()
+      .then()
+      .catch(function(err) {
+        expect(err.message).toEqual('my error');
+        expect(a.value).toEqual(1);
+        done();
+      });
+  });
+
+  it('should register beforeRequest hooks', function(done) {
+    var a = new Hooks();
+    var hook = {
+      beforeRequest: [
+        function(next) {
+          this.value = 1;
+          next();
+        }
+      ]
+    };
+    var registered = a.register(hook, function save() {
+      this.value++;
+      return returnPromise(false, { message: 'my value' });
+    });
+    expect(registered).toEqual(true);
+    a.save()
+      .then(function(res) {
+        expect(res.message).toEqual('my value');
+        expect(a.value).toEqual(2);
+        done();
+      })
+      .catch();
+  });
+
+  it('should register beforeError hooks', function(done) {
+    var a = new Hooks();
+    var hook = {
+      beforeError: [
+        function(next) {
+          next(new Error('new error'));
+        }
+      ]
+    };
+    var registered = a.register(hook, function save() {
+      return returnPromise(true, { message: 'my error' });
+    });
+    expect(registered).toEqual(true);
+    a.save()
+      .then()
+      .catch(function(err) {
+        expect(err.message).toEqual('new error');
+        done();
+      });
+  });
+
+  it('should register afterResponse hooks', function(done) {
+    var a = new Hooks();
+    var hook = {
+      afterResponse: [
+        function(next, res) {
+          this.value++;
+          expect(res.message).toEqual('my value');
+          next(100);
+        }
+      ]
+    };
+    var registered = a.register(hook, function save() {
+      this.value = 1;
+      return returnPromise(false, { message: 'my value' });
+    });
+    expect(registered).toEqual(true);
+    a.save()
+      .then(function(res) {
+        expect(res).toEqual(100);
+        expect(a.value).toEqual(2);
+        done();
+      })
+      .catch();
+  });
+
+  it('should not register if hooks is (null | undefined | {})', function() {
+    var a = new Hooks();
+    var hook = {};
+    var registered = a.register(hook, function() {});
+    expect(registered).toEqual(false);
+  });
+
+  it('should not register if all hooks are empty array', function() {
+    var a = new Hooks();
+    var hook = {
+      beforeRequest: [],
+      beforeError: [],
+      afterResponse: []
+    };
+    var registered = a.register(hook, function() {});
+    expect(registered).toEqual(false);
+  });
+
+  it('should not register if non of the hook is a function', function() {
+    var a = new Hooks();
+    var hook = {
+      beforeRequest: [1],
+      beforeError: [{}, {}],
+      afterResponse: ['a', 'b', 'c']
+    };
+    var registered = a.register(hook, function() {});
+    expect(registered).toEqual(false);
+  });
+  it('should not register if all hooks are empty array', function() {
+    var a = new Hooks();
+    var hook = {
+      beforeRequest: [function() {}],
+      beforeError: [],
+      afterResponse: []
+    };
+    var registered = a.register(hook, '');
+    expect(registered).toEqual(false);
+  });
+
+  it('should register errorHandler if passed', function() {
+    var a = new Hooks();
+    var errorMsg;
+    var hook = {
+      beforeRequest: [
+        function(next) {
+          next(new Error('error1'));
+        }
+      ],
+      beforeError: [],
+      afterResponse: []
+    };
+    hook.errorHandler = function(err) {
+      expect(err.message).toEqual('error1');
+      errorMsg = 'error2';
+    };
+    // };
+    var registered = a.register(hook, function save() {});
+    expect(registered).toEqual(true);
+    a.save();
+    expect(errorMsg).toEqual('error2');
+  });
+
+  it('should register hook if present in the axios request config', function() {
+    var errorMsg;
+    var hooks = {
+      beforeRequest: [
+        function(next) {
+          next(new Error('error1'));
+        }
+      ],
+      beforeError: [],
+      afterResponse: []
+    };
+    hooks.errorHandler = function(err) {
+      expect(err.message).toEqual('error1');
+      errorMsg = 'error2';
+    };
+    axios({
+      url: '/foo',
+      hooks: hooks
+    });
+    expect(errorMsg).toEqual('error2');
+  });
+});


### PR DESCRIPTION
This adds hooks functionality to axios
Giving users the ability to asign hooks to different event that occurs in the request lifecycle.
Events like:
1. beforeRequest: this get triggered before a the request is sent.
1. afterResponse: this get triggered after the request is sent and a response is gotten.
1. beforeError: this get triggered when an error occurred in the request sent.

see: https://github.com/axios/axios/issues/3144#issue-664482736