### PR TITLE
Adding some overlaping error checking

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -74,6 +74,8 @@ export interface AxiosRequestConfig {
 }
 
 export interface AxiosResponse<T = any>  {
+  ok: boolean;
+  error: boolean;
   data: T;
   status: number;
   statusText: string;
@@ -83,6 +85,8 @@ export interface AxiosResponse<T = any>  {
 }
 
 export interface AxiosError<T = any> extends Error {
+  ok: boolean;
+  error: boolean;
   config: AxiosRequestConfig;
   code?: string;
   request?: any;

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -203,6 +203,8 @@ module.exports = function httpAdapter(config) {
       }
 
       var response = {
+        ok: true,
+        error: false,
         status: res.statusCode,
         statusText: res.statusMessage,
         headers: res.headers,

--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -58,6 +58,8 @@ module.exports = function xhrAdapter(config) {
       var responseHeaders = 'getAllResponseHeaders' in request ? parseHeaders(request.getAllResponseHeaders()) : null;
       var responseData = !config.responseType || config.responseType === 'text' ? request.responseText : request.response;
       var response = {
+        ok: true,
+        error: false,
         data: responseData,
         status: request.status,
         statusText: request.statusText,

--- a/lib/core/enhanceError.js
+++ b/lib/core/enhanceError.js
@@ -11,6 +11,9 @@
  * @returns {Error} The error.
  */
 module.exports = function enhanceError(error, config, code, request, response) {
+  error: true;
+  ok: false;
+  
   error.config = config;
   if (code) {
     error.code = code;


### PR DESCRIPTION
Axios doesn't deliver a `boolean` value to verify if the response if an error. It had `status: number;` for `AxiosResponse` and an **optional** `code?: string;` for `AxiosError`, so it can be annoying to do error handing. This is a quick and easy way to check if there's an error or not.

I understand that when using `.then()` and `.catch()`, this is not a problem. But it is when using `async await`.

This is an example of a type decalration I had to make to bypass the issue:
```
import { AxiosError, AxiosResponse } from 'axios'

export declare namespace Axios {
    type Success = {
        ok: boolean
        axios: AxiosResponse
    }
    type Error = {
        ok: boolean
        axios: AxiosError
    }
}
```

Thanks for considering this feature.

Herbie