### PR TITLE
Fixing an issue that type 'null' and 'undefined' is not assignable to validateStatus when typescript strict option is enabled

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -62,7 +62,7 @@ export interface AxiosRequestConfig {
   onUploadProgress?: (progressEvent: any) => void;
   onDownloadProgress?: (progressEvent: any) => void;
   maxContentLength?: number;
-  validateStatus?: ((status: number) => boolean | null);
+  validateStatus?: ((status: number) => boolean) | null;
   maxBodyLength?: number;
   maxRedirects?: number;
   socketPath?: string | null;

--- a/test/typescript/axios.ts
+++ b/test/typescript/axios.ts
@@ -44,6 +44,14 @@ const config: AxiosRequestConfig = {
   cancelToken: new axios.CancelToken((cancel: Canceler) => {})
 };
 
+const nullValidateStatusConfig: AxiosRequestConfig = {
+  validateStatus: null
+};
+
+const undefinedValidateStatusConfig: AxiosRequestConfig = {
+  validateStatus: undefined
+};
+
 const handleResponse = (response: AxiosResponse) => {
   console.log(response.data);
   console.log(response.status);


### PR DESCRIPTION
In previous my PR(https://github.com/axios/axios/pull/2773), I had missed about two things.

1. Assign function type (one status number parameter, return boolean or null type) instead of function type(one status number parameter, return boolean type), null and undefined type
2. Doesn't care about undefined type

So I fix above things in this PR.