### PR TITLE
Fixing ProgressEvent type definitions so that Axios doesn't have to depend on lib dom (Fixes #3219)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -59,8 +59,8 @@ export interface AxiosRequestConfig {
   responseType?: ResponseType;
   xsrfCookieName?: string;
   xsrfHeaderName?: string;
-  onUploadProgress?: (progressEvent: ProgressEvent) => void;
-  onDownloadProgress?: (progressEvent: ProgressEvent) => void;
+  onUploadProgress?: (progressEvent: { lengthComputable?: boolean; loaded?: number; total?: number }) => void;
+  onDownloadProgress?: (progressEvent: { lengthComputable?: boolean; loaded?: number; total?: number }) => void;
   maxContentLength?: number;
   validateStatus?: ((status: number) => boolean | null);
   maxBodyLength?: number;

--- a/index.d.ts
+++ b/index.d.ts
@@ -41,6 +41,22 @@ export type ResponseType =
   | 'text'
   | 'stream'
 
+/**
+ * The ProgressEvent interface represents events measuring progress of an underlying process,
+ * like an HTTP request (for an XMLHttpRequest, or the loading of the underlying resource of
+ * an <img>, <audio>, <video>, <style> or <link>).
+ *
+ * The reason for introducing a custom AxiosProgressEvent instead of using the ProgressEvent
+ * itself is so that Axios does not have to rely on lib dom when used in pure Node.js environment.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent
+ */
+export interface AxiosProgressEvent {
+  lengthComputable?: boolean;
+  loaded?: number;
+  total?: number;
+}
+
 export interface AxiosRequestConfig {
   url?: string;
   method?: Method;
@@ -59,8 +75,8 @@ export interface AxiosRequestConfig {
   responseType?: ResponseType;
   xsrfCookieName?: string;
   xsrfHeaderName?: string;
-  onUploadProgress?: (progressEvent: { lengthComputable?: boolean; loaded?: number; total?: number }) => void;
-  onDownloadProgress?: (progressEvent: { lengthComputable?: boolean; loaded?: number; total?: number }) => void;
+  onUploadProgress?: (progressEvent: AxiosProgressEvent) => void;
+  onDownloadProgress?: (progressEvent: AxiosProgressEvent) => void;
   maxContentLength?: number;
   validateStatus?: ((status: number) => boolean | null);
   maxBodyLength?: number;


### PR DESCRIPTION
As noted in #3219, Axios 0.20.0 introduced an implicit dependency on lib dom, which prevents transpilation of pure Node.js  projects using Axios (such as [Serenity/JS REST](https://serenity-js.org/modules/rest)).

Instead of making the dependency semi-explicit, as per the suggestion in #3221, I'd like to propose to avoid the dependency altogether by replacing [`ProgeressEvent`](https://github.com/microsoft/TypeScript/blob/bfa69b7bb7bf1c41d0a0b1a1750921a6167b60f4/lib/lib.dom.d.ts#L11817-L11822) type with its structural equivalent:
```typescript
{ lengthComputable?: boolean; loaded?: number; total?: number }
```

This change will allow Axios (and any other project using, for that matter) to avoid having to depend on lib dom while still providing type information better than using `any`.