### PR TITLE
Fixing node types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -59,8 +59,8 @@ export interface AxiosRequestConfig {
   responseType?: ResponseType;
   xsrfCookieName?: string;
   xsrfHeaderName?: string;
-  onUploadProgress?: (progressEvent: ProgressEvent) => void;
-  onDownloadProgress?: (progressEvent: ProgressEvent) => void;
+  onUploadProgress?: (progressEvent: any) => void;
+  onDownloadProgress?: (progressEvent: any) => void;
   maxContentLength?: number;
   validateStatus?: ((status: number) => boolean | null);
   maxBodyLength?: number;


### PR DESCRIPTION
The `ProgressEvent` type comes from the `DOM` lib. This is typically unwanted when using axios in a NodeJS environment.

Fixes #3219