### PR TITLE
docs: Fix simple typo, existant -> existent

### DIFF
--- a/test/specs/requests.spec.js
+++ b/test/specs/requests.spec.js
@@ -53,7 +53,7 @@ describe('requests', function () {
   });
 
   it('should reject on network errors', function (done) {
-    // disable jasmine.Ajax since we're hitting a non-existant server anyway
+    // disable jasmine.Ajax since we're hitting a non-existent server anyway
     jasmine.Ajax.uninstall();
 
     var resolveSpy = jasmine.createSpy('resolve');


### PR DESCRIPTION
There is a small typo in test/specs/requests.spec.js.

Should read `existent` rather than `existant`.

