### PR TITLE
fix: added generic support for `AxiosInstance`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -128,8 +128,8 @@ export interface AxiosInterceptorManager<V> {
 }
 
 export interface AxiosInstance {
-  (config: AxiosRequestConfig): AxiosPromise;
-  (url: string, config?: AxiosRequestConfig): AxiosPromise;
+  <T = any, R = AxiosResponse<T>>(config: AxiosRequestConfig): R;
+  <T = any, R = AxiosResponse<T>>(url: string, config?: AxiosRequestConfig): R;
   defaults: AxiosRequestConfig;
   interceptors: {
     request: AxiosInterceptorManager<AxiosRequestConfig>;


### PR DESCRIPTION
fix: added generic support for `AxiosInstance`

example:
```
//...
let rs = await axios<{id: number}>({
    url: '/api/user'
});
rs.id; //ok
rs.name; //incorrect
```