### PR TITLE
added generic support for AxiosInstance

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -128,8 +128,8 @@ export interface AxiosInterceptorManager<V> {
 }
 
 export interface AxiosInstance {
-  <T = any, R = AxiosResponse<T>>(config: AxiosRequestConfig): R;
-  <T = any, R = AxiosResponse<T>>(url: string, config?: AxiosRequestConfig): R;
+  <T = any, R = AxiosResponse<T>>(config: AxiosRequestConfig): Promise<R>;
+  <T = any, R = AxiosResponse<T>>(url: string, config?: AxiosRequestConfig): Promise<R>;
   defaults: AxiosRequestConfig;
   interceptors: {
     request: AxiosInterceptorManager<AxiosRequestConfig>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -128,8 +128,8 @@ export interface AxiosInterceptorManager<V> {
 }
 
 export interface AxiosInstance {
-  (config: AxiosRequestConfig): AxiosPromise;
-  (url: string, config?: AxiosRequestConfig): AxiosPromise;
+  <T = any, R = AxiosResponse<T>>(config: AxiosRequestConfig): R;
+  <T = any, R = AxiosResponse<T>>(url: string, config?: AxiosRequestConfig): R;
   defaults: AxiosRequestConfig;
   interceptors: {
     request: AxiosInterceptorManager<AxiosRequestConfig>;

--- a/test/typescript/axios.ts
+++ b/test/typescript/axios.ts
@@ -119,6 +119,10 @@ const handleUserResponse = (response: AxiosResponse<User>) => {
 	console.log(response.config);
 };
 
+axios<User>({url: '/user?id=12345'})
+  .then(handleUserResponse)
+  .catch(handleError)
+
 axios.get<User>('/user?id=12345')
 	.then(handleUserResponse)
 	.catch(handleError);


### PR DESCRIPTION
fix: added generic support for AxiosInstance

example:

//...
let rs = await axios<{id: number}>({
    url: '/api/user'
});
rs.id; //ok
rs.name; //incorrect