### PR TITLE
Fixing requestHeaders.Authorization

### DIFF
--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -30,7 +30,7 @@ module.exports = function xhrAdapter(config) {
     // HTTP basic authentication
     if (config.auth) {
       var username = config.auth.username || '';
-      var password = unescape(encodeURIComponent(config.auth.password)) || '';
+      var password = config.auth.password ? unescape(encodeURIComponent(config.auth.password)) : '';
       requestHeaders.Authorization = 'Basic ' + btoa(username + ':' + password);
     }
 

--- a/test/specs/__helpers.js
+++ b/test/specs/__helpers.js
@@ -85,7 +85,6 @@ setupBasicAuthTest = function setupBasicAuthTest() {
 
     setTimeout(function () {
       var request = jasmine.Ajax.requests.mostRecent();
-      console.log(request.requestHeaders['Authorization'], '\n\n\n');
 
       expect(request.requestHeaders['Authorization']).toEqual('Basic QWxhZGRpbjo=');
       done();
@@ -102,7 +101,6 @@ setupBasicAuthTest = function setupBasicAuthTest() {
 
     setTimeout(function () {
       var request = jasmine.Ajax.requests.mostRecent();
-      console.log(request.requestHeaders['Authorization'], '\n\n\n');
 
       expect(request.requestHeaders['Authorization']).toEqual('Basic QWxhZGRpbjpvcGVuIMOfw6fCo+KYg3Nlc2FtZQ==');
       done();

--- a/test/specs/__helpers.js
+++ b/test/specs/__helpers.js
@@ -76,6 +76,22 @@ setupBasicAuthTest = function setupBasicAuthTest() {
     }, 100);
   });
 
+  it('should accept HTTP Basic auth credentials without the password parameter', function (done) {
+    axios('/foo', {
+      auth: {
+        username: 'Aladdin'
+      }
+    });
+
+    setTimeout(function () {
+      var request = jasmine.Ajax.requests.mostRecent();
+      console.log(request.requestHeaders['Authorization'], '\n\n\n');
+
+      expect(request.requestHeaders['Authorization']).toEqual('Basic QWxhZGRpbjo=');
+      done();
+    }, 100);
+  });
+
   it('should accept HTTP Basic auth credentials with non-Latin1 characters in password', function (done) {
     axios('/foo', {
       auth: {


### PR DESCRIPTION
Correction of the requestHeaders.Authorization parameter concatenation.

Close #3286.

Correction of the compatibility of the requestHeaders.Authorization parameter for situations in which the "password" parameter is not passed.