### PR TITLE
Missing info regarding semver exception in contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ Please don't include changes to `dist/` in your pull request. This should only b
 
 ### Releasing
 
-Releasing a new version is mostly automated. For now the [CHANGELOG](https://github.com/axios/axios/blob/master/CHANGELOG.md) requires being updated manually. Once this has been done run the commands below. Versions should follow [semantic versioning](http://semver.org/).
+Releasing a new version is mostly automated. For now the [CHANGELOG](https://github.com/axios/axios/blob/master/CHANGELOG.md) requires being updated manually. Once this has been done run the commands below. Versions should follow [semantic versioning](http://semver.org/) with [exception](https://github.com/axios/axios#semver) for releases prior to 1.0.0
 
 - `npm version <newversion> -m "Releasing %s"`
 - `npm publish`


### PR DESCRIPTION
### The [contributing.md](https://github.com/axios/axios/blob/master/CONTRIBUTING.md#releasing) file is misleading.
In the contributing file, it is stated the following
> Versions should follow semantic versioning.

However, on the last line of the [readme.md](https://github.com/axios/axios#semver), it's stated
>Until axios reaches a 1.0 release, breaking changes will be released with a new minor version. For example 0.5.1, and 0.5.4 will have the same API, but 0.6.0 will have breaking changes.

You cannot say you should follow semantic versioning when you are indeed not doing it. This is nonsensical.

You can see [here](https://github.com/axios/axios/issues/3294) how this makes things confusing.