### PR TITLE
Fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ Fixes and Functionality:
   - Fixing test\unit\adapters\http.js lint errors
   - Adding test for disabling auto decompression
   - Removing changes that fixed lint errors in tests
-  - Removing formating change to unit test
+  - Removing formatting change to unit test
 - Add independent `maxBodyLength` option ([#2781](https://github.com/axios/axios/pull/2781))
   - Add independent option to set the maximum size of the request body
   - Remove maxBodyLength check
@@ -104,14 +104,14 @@ Internal and Tests:
 - Adding console log on sandbox server startup ([#2210](https://github.com/axios/axios/pull/2210))
   - Adding console log on sandbox server startup
   - Update server.js
-    Add server error handeling
+    Add server error handling
   - Update server.js
     Better error message, remove retry.
 - Adding tests for method `options` type definitions ([#1996](https://github.com/axios/axios/pull/1996))
   Update tests.
 - Add test for redirecting with too large response ([#2695](https://github.com/axios/axios/pull/2695))
 - Fixing unit test failure in Windows OS ([#2601](https://github.com/axios/axios/pull/2601))
-- Fixing issue for HEAD method and gziped repsonse ([#2666](https://github.com/axios/axios/pull/2666))
+- Fixing issue for HEAD method and gzipped response ([#2666](https://github.com/axios/axios/pull/2666))
 - Fix tests in browsers ([#2748](https://github.com/axios/axios/pull/2748))
 - chore: add `jsdelivr` and `unpkg` support ([#2443](https://github.com/axios/axios/pull/2443))
 
@@ -149,7 +149,7 @@ Documentation:
 - Add CDNJS version badge in README.md ([#878](https://github.com/axios/axios/pull/878))
   This badge will show the version on CDNJS!
 - Documentation update to clear up ambiguity in code examples ([#2928](https://github.com/axios/axios/pull/2928))
-  - Made a adjustment to the documenation to clear up any ambiguity around the use of "fs". This should help clear up that the code examples with "fs" cannot be used on the client side.
+  - Made an adjustment to the documentation to clear up any ambiguity around the use of "fs". This should help clear up that the code examples with "fs" cannot be used on the client side.
 - Update README.md about validateStatus ([#2912](https://github.com/axios/axios/pull/2912))
   Rewrote the comment from "Reject only if the status code is greater than or equal to 500" to "Resolve only if the status code is less than 500"
 - Updating documentation for usage form-data ([#2805](https://github.com/axios/axios/pull/2805))
@@ -276,7 +276,7 @@ Documentation:
 - Update response interceptor docs ([#2399](https://github.com/axios/axios/pull/2399))
 - Update README.md ([#2504](https://github.com/axios/axios/pull/2504))
 - Fix word 'sintaxe' to 'syntax' in README.md ([#2432](https://github.com/axios/axios/pull/2432))
-- upadating README: notes on CommonJS autocomplete ([#2256](https://github.com/axios/axios/pull/2256))
+- updating README: notes on CommonJS autocomplete ([#2256](https://github.com/axios/axios/pull/2256))
 - Fix grammar in README.md ([#2271](https://github.com/axios/axios/pull/2271))
 - Doc fixes, minor examples cleanup ([#2198](https://github.com/axios/axios/pull/2198))
 
@@ -329,7 +329,7 @@ New Functionality:
 
 - Add getUri method ([#1712](https://github.com/axios/axios/issues/1712))
 - Add support for no_proxy env variable ([#1693](https://github.com/axios/axios/issues/1693))
-- Add toJSON to decorated Axios errors to faciliate serialization ([#1625](https://github.com/axios/axios/issues/1625))
+- Add toJSON to decorated Axios errors to facilitate serialization ([#1625](https://github.com/axios/axios/issues/1625))
 - Add second then on axios call ([#1623](https://github.com/axios/axios/issues/1623))
 - Typings: allow custom return types
 - Add option to specify character set in responses (with http adapter)

--- a/UPGRADE_GUIDE.md
+++ b/UPGRADE_GUIDE.md
@@ -135,7 +135,7 @@ This will polyfill the global environment, and only needs to be done once.
 
 #### `axios.success`/`axios.error`
 
-The `success`, and `error` aliases were deprectated in [0.4.0](https://github.com/axios/axios/blob/master/CHANGELOG.md#040-oct-03-2014). As of this release they have been removed entirely. Instead please use `axios.then`, and `axios.catch` respectively.
+The `success`, and `error` aliases were deprecated in [0.4.0](https://github.com/axios/axios/blob/master/CHANGELOG.md#040-oct-03-2014). As of this release they have been removed entirely. Instead please use `axios.then`, and `axios.catch` respectively.
 
 ```js
 axios.get('some/url')

--- a/test/specs/requests.spec.js
+++ b/test/specs/requests.spec.js
@@ -263,7 +263,7 @@ describe('requests', function () {
     });
   });
 
-  it('should make cross domian http request', function (done) {
+  it('should make cross domain http request', function (done) {
     var response;
 
     axios.post('www.someurl.com/foo').then(function(res){


### PR DESCRIPTION
Fix typos found in the Changelog, upgrade guide, and the spec tests. 