### PR TITLE
Lock travis to not use node v15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: node_js
 node_js:
   - 10
   - 12
-  - node
+  - 14
 email:
   on_failure: change
   on_success: never


### PR DESCRIPTION
I have made this change due to current builds failing. We should not be testing in node v15 as you can see on this graph https://nodejs.org/en/about/releases/ 10 till 14 should be fine till 2023 and v15 is not LTS so should be excluded for now.
