### PR TITLE
use utils.toString instead Object.prototype.toString

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -18,7 +18,7 @@ function getDefaultAdapter() {
   if (typeof XMLHttpRequest !== 'undefined') {
     // For browsers use XHR adapter
     adapter = require('./adapters/xhr');
-  } else if (typeof process !== 'undefined' && Object.prototype.toString.call(process) === '[object process]') {
+  } else if (typeof process !== 'undefined' && utils.toString.call(process) === '[object process]') {
     // For node use HTTP adapter
     adapter = require('./adapters/http');
   }


### PR DESCRIPTION
Just shorten some words in file `lib/default.js`.