### PR TITLE
Check Content-Type before using JSON.parse on response.

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -7,6 +7,9 @@ var DEFAULT_CONTENT_TYPE = {
   'Content-Type': 'application/x-www-form-urlencoded'
 };
 
+// `text/json` is not standard but some servers use it.
+var JSON_PARSABLE_TYPES = ['application/json', 'text/json'];
+
 function setContentTypeIfUnset(headers, value) {
   if (!utils.isUndefined(headers) && utils.isUndefined(headers['Content-Type'])) {
     headers['Content-Type'] = value;
@@ -54,14 +57,15 @@ var defaults = {
     return data;
   }],
 
-  transformResponse: [function transformResponse(data) {
-    /*eslint no-param-reassign:0*/
-    if (typeof data === 'string') {
-      try {
-        data = JSON.parse(data);
-      } catch (e) { /* Ignore */ }
+  transformResponse: [function transformResponse(data, headers) {
+    var result = data;
+    if (headers && utils.isString(headers['content-type'])) {
+      var type = headers['content-type'].split(/;\s?/);
+      if (utils.isString(result) && JSON_PARSABLE_TYPES.indexOf(type[0]) > -1) {
+        result = JSON.parse(result);
+      }
     }
-    return data;
+    return result;
   }],
 
   /**

--- a/test/unit/transforms/transformResponse.js
+++ b/test/unit/transforms/transformResponse.js
@@ -1,0 +1,30 @@
+var defaults = require('../../../lib/defaults');
+var transformData = require('../../../lib/core/transformData');
+var assert = require('assert');
+
+describe('transformResponse', function () {
+    describe('200 request', function () {
+        it('parses json', function () {
+            var data = '{"message": "hello, world"}';
+            var result = transformData(data, {'content-type': 'application/json'}, defaults.transformResponse);
+            assert.strictEqual(result.message, 'hello, world');
+        });
+        it('ignores XML', function () {
+            var data = '<message>hello, world</message>';
+            var result = transformData(data, {'content-type': 'text/xml'}, defaults.transformResponse);
+            assert.strictEqual(result, data);
+        });
+    });
+    describe('204 request', function () {
+        it('does not parse non-json', function () {
+            var data = '';
+            var result = transformData(data, {'content-type': undefined}, defaults.transformResponse);
+            assert.strictEqual(result, '');
+        });
+        it('does not parse undefined', function () {
+            var data = undefined;
+            var result = transformData(data, {'content-type': undefined}, defaults.transformResponse);
+            assert.strictEqual(result, data);
+        });
+    });
+});


### PR DESCRIPTION
Updates as referenced in #3374 

 - Tests for `transformResponse`
 - Remove eslint error.
 - Check that there is a content-type and it's value is an expected string
 - application/json and text/json are the content-types that are parsed.