### PR TITLE
Keep precision of big numbers, swapping json parser for json-bigint parser

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var JSONBig = require('json-bigint');
 var utils = require('./utils');
 var normalizeHeaderName = require('./helpers/normalizeHeaderName');
 
@@ -58,7 +59,7 @@ var defaults = {
     /*eslint no-param-reassign:0*/
     if (typeof data === 'string') {
       try {
-        data = JSON.parse(data);
+        data = JSONBig.parse(data);
       } catch (e) { /* Ignore */ }
     }
     return data;

--- a/package.json
+++ b/package.json
@@ -75,7 +75,8 @@
   "unpkg": "dist/axios.min.js",
   "typings": "./index.d.ts",
   "dependencies": {
-    "follow-redirects": "^1.10.0"
+    "follow-redirects": "^1.10.0",
+    "json-bigint": "^1.0.0"
   },
   "bundlesize": [
     {


### PR DESCRIPTION
This change would use the `json-bigint` parser instead of the core json parser.  The following issue describes the problem I'm trying to solve here: https://github.com/axios/axios/issues/3440 