### PR TITLE
fix: Use String.prototype.trim() if available

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -187,6 +187,9 @@ function isURLSearchParams(val) {
  * @returns {String} The String freed of excess whitespace
  */
 function trim(str) {
+  if (typeof str.trim === 'function') {
+    return str.trim();
+  }
   return str.replace(/^\s*/, '').replace(/\s*$/, '');
 }
 


### PR DESCRIPTION
Using a custom RegEx to trim a string is much slower (see [JSBench example](https://jsben.ch/4XgY0)) than using `String.prototype.trim()`.