### PR TITLE
Update the 'Global axios defaults' README to use a safer example

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,7 +510,7 @@ You can specify config defaults that will be applied to every request.
 
 ```js
 axios.defaults.baseURL = 'https://api.example.com';
-axios.defaults.headers.common['Authorization'] = AUTH_TOKEN;
+axios.defaults.headers.common['User-Agent'] = /* eg. 'AppName/1.0.0' */;
 axios.defaults.headers.post['Content-Type'] = 'application/x-www-form-urlencoded';
 ```
 
@@ -518,12 +518,12 @@ axios.defaults.headers.post['Content-Type'] = 'application/x-www-form-urlencoded
 
 ```js
 // Set config defaults when creating the instance
-const instance = axios.create({
+const api = axios.create({
   baseURL: 'https://api.example.com'
 });
 
-// Alter defaults after instance has been created
-instance.defaults.headers.common['Authorization'] = AUTH_TOKEN;
+// Alter defaults after api instance has been created
+api.defaults.headers.common['Authorization'] = AUTH_TOKEN;
 ```
 
 ### Config order of precedence


### PR DESCRIPTION
The existing example usage it isn't safe in the general case as it can
lead to auth tokens being leaked to 3rd party endpoints by unexpectedly.

This change instead gives an example using
"axios.defaults.headers.common" to set the User-Agent, which is an
equally helpful use-case to document.

The 'Custom instance defaults' example just below the 'Global axios
defaults' example shows a method to set the 'Authorization' header
specific to a given API. I've also updated the variable in the 'Custom
instance defaults' code to use a semantically more relevant name within
that example.