### PR TITLE
Removing '[' and ']' from URL encode exclude characters

### DIFF
--- a/lib/helpers/buildURL.js
+++ b/lib/helpers/buildURL.js
@@ -7,9 +7,7 @@ function encode(val) {
     replace(/%3A/gi, ':').
     replace(/%24/g, '$').
     replace(/%2C/gi, ',').
-    replace(/%20/g, '+').
-    replace(/%5B/gi, '[').
-    replace(/%5D/gi, ']');
+    replace(/%20/g, '+');
 }
 
 /**

--- a/test/specs/helpers/buildURL.spec.js
+++ b/test/specs/helpers/buildURL.spec.js
@@ -34,10 +34,10 @@ describe('helpers::buildURL', function () {
     })).toEqual('/foo?date=' + date.toISOString());
   });
 
-  it('should support array params', function () {
+  it('should support array params with encode', function () {
     expect(buildURL('/foo', {
       foo: ['bar', 'baz']
-    })).toEqual('/foo?foo[]=bar&foo[]=baz');
+    })).toEqual('/foo?foo%5B%5D=bar&foo%5B%5D=baz');
   });
 
   it('should support special char params', function () {


### PR DESCRIPTION
Close #3316, Close #3345 

This is a re-created pull request of #3380 because of major changes.