### PR TITLE
Removing unused imports

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,3 @@
-const TerserPlugin = require('terser-webpack-plugin');
-var webpack = require('webpack');
 var config = {};
 
 function generateConfig(name) {


### PR DESCRIPTION
This pull request removes the unused (and unneeded) imports for `webpack` and `TerserWebpackPlugin`.