### PR TITLE
Returned error treated when requesting illegal URL

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -14,6 +14,7 @@ var pkg = require('./../../package.json');
 var createError = require('../core/createError');
 var enhanceError = require('../core/enhanceError');
 
+var supportedProtocols = [ 'http:', 'https:' ];
 var isHttps = /https:?/;
 
 /**
@@ -90,6 +91,14 @@ module.exports = function httpAdapter(config) {
     var fullPath = buildFullPath(config.baseURL, config.url);
     var parsed = url.parse(fullPath);
     var protocol = parsed.protocol || 'http:';
+
+    if (parsed.path === null) {
+      return reject(createError('Malformed URL ' + fullPath, config));
+    }
+
+    if (!supportedProtocols.includes(protocol)) {
+      return reject(createError('Unsupported protocol ' + protocol, config));
+    }
 
     if (!auth && parsed.auth) {
       var urlAuth = parsed.auth.split(':');

--- a/test/unit/adapters/http.js
+++ b/test/unit/adapters/http.js
@@ -879,5 +879,85 @@ describe('supports http with nodejs', function () {
       });
     });
   });
+
+  it('should support HTTP protocol', function (done) {
+    server = http.createServer(function (req, res) {
+      setTimeout(function () {
+        res.end();
+      }, 1000);
+    }).listen(4444, function () {
+      axios.get('http://localhost:4444')
+        .then(function (res) {
+          assert.equal(res.request.agent.protocol, 'http:');
+          done();
+        })
+    })
+  });
+
+  it('should support HTTPS protocol', function (done) {
+    server = http.createServer(function (req, res) {
+      setTimeout(function () {
+        res.end();
+      }, 1000);
+    }).listen(4444, function () {
+      axios.get('https://www.google.com')
+        .then(function (res) {
+          assert.equal(res.request.agent.protocol, 'https:');
+          done();
+        })
+    })
+  });
+
+  it('should return malformed URL', function (done) {
+    var success = false, failure = false;
+    var error;
+
+    server = http.createServer(function (req, res) {
+      setTimeout(function () {
+        res.end();
+      }, 1000);
+    }).listen(4444, function () {
+      axios.get('tel:484-695-3408')
+        .then(function (res) {
+          success = true;
+        }).catch(function (err) {
+          error = err;
+          failure = true;
+        })
+
+      setTimeout(function () {
+        assert.equal(success, false, 'request should not succeed');
+        assert.equal(failure, true, 'request should fail');
+        assert.equal(error.message, 'Malformed URL tel:484-695-3408');
+        done();
+      }, 300);
+    })
+  });
+
+  it('should return unsupported protocol', function (done) {
+    var success = false, failure = false;
+    var error;
+
+    server = http.createServer(function (req, res) {
+      setTimeout(function () {
+        res.end();
+      }, 1000);
+    }).listen(4444, function () {
+      axios.get('ftp:google.com')
+        .then(function (res) {
+          success = true;
+        }).catch(function (err) {
+          error = err;
+          failure = true;
+        })
+
+      setTimeout(function () {
+        assert.equal(success, false, 'request should not succeed');
+        assert.equal(failure, true, 'request should fail');
+        assert.equal(error.message, 'Unsupported protocol ftp:');
+        done();
+      }, 300);
+    })
+  });
 });
 


### PR DESCRIPTION
#### Fix the irrelevant error returned when requesting uncommon URL - Open Issue #3509

When axios request to an illegal URL like "tel:484-695-3408", the error message is irrelevant.

```
TypeError: Cannot read property 'replace' of null
    at dispatchHttpRequest (node_modules/axios/lib/adapters/http.js:109:74)
    at new Promise (<anonymous>)
    at httpAdapter (node_modules/axios/lib/adapters/http.js:46:10)
    at dispatchRequest (node_modules/axios/lib/core/dispatchRequest.js:52:10)
```

So, I fixed this, validating the "path" property from "parsed" object, cheking if it is null, throwing an error message: "Malformed URL". And I checked too, if the URL protocol is supported (HTTP or HTTPS) throwing a message: "Unsupported protocol <protocol>".