### PR TITLE
Add missing "port" definition to AxiosRequestConfig

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -43,6 +43,7 @@ export type ResponseType =
 
 export interface AxiosRequestConfig {
   url?: string;
+  port?: number;
   method?: Method;
   baseURL?: string;
   transformRequest?: AxiosTransformer | AxiosTransformer[];


### PR DESCRIPTION
AxiosRequestConfig have missing "port" property definition
