### PR TITLE
Fixing possible runtime error in isAxiosError.js type guard

### DIFF
--- a/lib/helpers/isAxiosError.js
+++ b/lib/helpers/isAxiosError.js
@@ -7,5 +7,5 @@
  * @returns {boolean} True if the payload is an error thrown by Axios, otherwise false
  */
 module.exports = function isAxiosError(payload) {
-  return (typeof payload === 'object') && (payload.isAxiosError === true);
+  return (typeof payload === 'object') && (payload !== null) && (payload.isAxiosError === true);
 };


### PR DESCRIPTION
AxiosError type guard can cause runtime error if payload is a `null`, since `null` also passes the check `typeof payload === 'object'`. Then the code cannot access `.isAxiosError` of a `null`.

```
TypeError: Cannot read property 'isAxiosError' of null
```