### PR TITLE
Adding an error message for FormData when you use http adapter

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -67,6 +67,11 @@ module.exports = function httpAdapter(config) {
         data = Buffer.from(new Uint8Array(data));
       } else if (utils.isString(data)) {
         data = Buffer.from(data, 'utf-8');
+      } else if (utils.isFormData(data)) {
+        return reject(createError(
+          'Data after transformation must not be a FormData. if you want FormData, use xhr adapter instead',
+          config
+        ));
       } else {
         return reject(createError(
           'Data after transformation must be a string, an ArrayBuffer, a Buffer, or a Stream',


### PR DESCRIPTION
<!-- Click "Preview" for a more readable version -->
#3616
```js
    const data = new FormData()
    data.append('test', files[0])
    await axios.post('http://localhost:3333', data)
```
When you use `mock` or other library to test your axios apis you can't test with these when data is FormData.
 because these are mock `http` so I added an error message for it not to make users confusing.


ps) I tried to add some test cases, but seems `isFormData()` not fits with `form-data` of nodejs