### PR TITLE
Change homepage link to https://axios-http.com

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "bugs": {
     "url": "https://github.com/axios/axios/issues"
   },
-  "homepage": "https://github.com/axios/axios",
+  "homepage": "https://axios-http.com",
   "devDependencies": {
     "coveralls": "^3.0.0",
     "es6-promise": "^4.2.4",


### PR DESCRIPTION
<!-- Click "Preview" for a more readable version -->

Since axios now has a website, I updated the "homepage" link on the npm page to point to it.

Closes #3680 
@jasonsaayman 