### PR TITLE
[Updated] follow-redirects version

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   "unpkg": "dist/axios.min.js",
   "typings": "./index.d.ts",
   "dependencies": {
-    "follow-redirects": "^1.10.0"
+    "follow-redirects": "^1.13.3"
   },
   "bundlesize": [
     {


### PR DESCRIPTION
As noted in #3217 and potentially other places, I have updated the version of follow redirects to see if this will fix a potential memory leak that has been noted by a couple users. We will also see if the build passes allowing the update to the latest version of follow-redirects