### PR TITLE
Adding ability to omit User-Agent header

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -54,9 +54,17 @@ module.exports = function httpAdapter(config) {
     var headers = config.headers;
 
     // Set User-Agent (required by some servers)
-    // Only set header if it hasn't been set in config
     // See https://github.com/axios/axios/issues/69
-    if (!headers['User-Agent'] && !headers['user-agent']) {
+    if ('User-Agent' in headers || 'user-agent' in headers) {
+      // User-Agent is specified; handle case where no UA header is desired
+      var useragent = headers['User-Agent'] || headers['user-agent'];
+      if (!useragent) {
+        delete headers['User-Agent'];
+        delete headers['user-agent'];
+      }
+      // Otherwise, use specified value
+    } else {
+      // Only set header if it hasn't been set in config
       headers['User-Agent'] = 'axios/' + pkg.version;
     }
 

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -57,8 +57,7 @@ module.exports = function httpAdapter(config) {
     // See https://github.com/axios/axios/issues/69
     if ('User-Agent' in headers || 'user-agent' in headers) {
       // User-Agent is specified; handle case where no UA header is desired
-      var useragent = headers['User-Agent'] || headers['user-agent'];
-      if (!useragent) {
+      if (!headers['User-Agent'] && !headers['user-agent']) {
         delete headers['User-Agent'];
         delete headers['user-agent'];
       }

--- a/test/unit/adapters/http.js
+++ b/test/unit/adapters/http.js
@@ -7,6 +7,7 @@ var zlib = require('zlib');
 var assert = require('assert');
 var fs = require('fs');
 var path = require('path');
+var pkg = require('./../../../package.json');
 var server, proxy;
 
 describe('supports http with nodejs', function () {
@@ -879,5 +880,35 @@ describe('supports http with nodejs', function () {
       });
     });
   });
+
+  it('should supply a user-agent if one is not specified', function (done) {
+    server = http.createServer(function (req, res) {
+      assert.equal(req.headers["user-agent"], 'axios/' + pkg.version);
+      res.end();
+    }).listen(4444, function () {
+      axios.get('http://localhost:4444/'
+      ).then(function (res) {
+        done();
+      });
+    });
+  });
+
+  it('should omit a user-agent if one is explicitly disclaimed', function (done) {
+    server = http.createServer(function (req, res) {
+      assert.equal("user-agent" in req.headers, false);
+      assert.equal("User-Agent" in req.headers, false);
+      res.end();
+    }).listen(4444, function () {
+      axios.get('http://localhost:4444/', {
+        headers: {
+          "User-Agent": null
+        }
+      }
+      ).then(function (res) {
+        done();
+      });
+    });
+  });
+
 });
 


### PR DESCRIPTION
Fixes #3702.  

Old behavior:
- If `headers["User-Agent"]` (or `"user-agent"`, not repeated hereafter) is falsy or absent, override with the Axios User-Agent string
- If `headers["User-Agent"]` is present and truthy, use it

New behavior:
- If `headers["User-Agent"]` is absent, override with the Axios User-Agent string
- If `headers["User-Agent"]` is present and truthy, use it
- If `headers["User-Agent"]` is present and falsy, omit the header

This maintains the existing behavior for any reasonable usage, but enables explicit action to omit the UA header when desired.