### PR TITLE
Add type for the third parameter to use

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -122,8 +122,12 @@ export interface CancelTokenSource {
   cancel: Canceler;
 }
 
+export interface AxiosInterceptorOptions {
+  synchronous: boolean;
+  runWhen: (config: AxiosRequestConfig) => boolean;
+}
 export interface AxiosInterceptorManager<V> {
-  use(onFulfilled?: (value: V) => V | Promise<V>, onRejected?: (error: any) => any): number;
+  use(onFulfilled?: (value: V) => V | Promise<V>, onRejected?: (error: any) => any, options?: AxiosInterceptorOptions): number;
   eject(id: number): void;
 }
 


### PR DESCRIPTION
Add the third parameter to `AxiosInterceptorManager.use` to the type declarations. Addresses https://github.com/axios/axios/issues/3733
