### PR TITLE
toFormData helper function

### DIFF
--- a/lib/helpers/toFormData.js
+++ b/lib/helpers/toFormData.js
@@ -1,0 +1,55 @@
+'use strict';
+
+function combinedKey(parentKey, elKey) {
+  return parentKey + '.' + elKey;
+}
+
+function buildFormData(formData, data, parentKey) {
+  if (Array.isArray(data)) {
+    data.forEach(function buildArray(el, i) {
+      buildFormData(formData, el, combinedKey(parentKey, i));
+    });
+  } else if (
+    typeof data === 'object' &&
+    !(data instanceof File || data === null)
+  ) {
+    Object.keys(data).forEach(function buildObject(key) {
+      buildFormData(
+        formData,
+        data[key],
+        parentKey ? combinedKey(parentKey, key) : key
+      );
+    });
+  } else {
+    if (data === undefined) {
+      return;
+    }
+
+    var value =
+      typeof data === 'boolean' || typeof data === 'number'
+        ? data.toString()
+        : data;
+    formData.append(parentKey, value);
+  }
+}
+
+/**
+ * convert a data object to FormData
+ *
+ * type FormDataPrimitive = string | Blob | number | boolean
+ * interface FormDataNest {
+ *   [x: string]: FormVal
+ * }
+ *
+ * type FormVal = FormDataNest | FormDataPrimitive
+ *
+ * @param {FormVal} data
+ */
+
+module.exports = function getFormData(data) {
+  var formData = new FormData();
+
+  buildFormData(formData, data);
+
+  return formData;
+};

--- a/test/specs/helpers/toFormData.spec.js
+++ b/test/specs/helpers/toFormData.spec.js
@@ -1,0 +1,18 @@
+var toFormData = require("../../../lib/helpers/toFormData");
+
+describe("toFormData", function () {
+  it("Convert nested data object to FormDAta", function () {
+    var o = {
+      val: 123,
+      nested: {
+        arr: ["hello", "world"],
+      },
+    };
+
+    convertedVal = toFormData(o);
+    expect(convertedVal instanceof FormData).toEqual(true);
+    expect(Array.from(convertedVal.keys()).length).toEqual(3);
+    expect(convertedVal.get("val")).toEqual("123")
+    expect(convertedVal.get("nested.arr.0")).toEqual("hello")
+  });
+});


### PR DESCRIPTION
With this functionality we can provide the user an option to pass a data object, instead of building FormData by himself. When the data is nested, building form data isn't trivial, and can result in an inappropriate structure and bugs. Hence usage of this functionality seems more reliable. 

The function can handle nested data of the following types: object, array, string, number, boolean, null, undefined, Fiile. 

Related feature request thread: https://github.com/axios/axios/issues/3721

This doesn't deal with the API in which this functionality will be offered to the user. 
