### PR TITLE
Adding documentation for the type guard `isAxiosError`

### DIFF
--- a/README.md
+++ b/README.md
@@ -826,10 +826,21 @@ axios depends on a native ES6 Promise implementation to be [supported](http://ca
 If your environment doesn't support ES6 Promises, you can [polyfill](https://github.com/jakearchibald/es6-promise).
 
 ## TypeScript
-axios includes [TypeScript](http://typescriptlang.org) definitions.
+
+axios includes [TypeScript](http://typescriptlang.org) definitions and a type guard for axios errors.
+
 ```typescript
-import axios from 'axios';
-axios.get('/user?ID=12345');
+let user: User = null;
+try {
+  const { data } = await axios.get('/user?ID=12345');
+  user = data.userDetails;
+} catch (error) {
+  if (axios.isAxiosError(error)) {
+    handleAxiosError(error);
+  } else {
+    handleUnexpectedError(error);
+  }
+}
 ```
 
 ## Online one-click setup


### PR DESCRIPTION
#### Instructions

- Adding documentation for the type guard `isAxiosError` as requested in issue https://github.com/axios/axios/issues/3732

Both mentioning the type guard and show a short example of how it can be used. The example uses `async`/`await` as I felt it was the most natural way.

I recommend merging this at the same time (or after) merging PR https://github.com/axios/axios/pull/3546 since it fixes the bug `isAxiosError(null) // true`.

This (https://github.com/axios/axios/pull/3645) is also a nice PR that would increase confidence in the type guard.


Closes https://github.com/axios/axios/issues/3732