### PR TITLE
[Updated] follow-redirects to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   "unpkg": "dist/axios.min.js",
   "typings": "./index.d.ts",
   "dependencies": {
-    "follow-redirects": "^1.13.3"
+    "follow-redirects": "^1.14.0"
   },
   "bundlesize": [
     {


### PR DESCRIPTION
Update follow redirects to the latest version to patch potential memory leak
