### PR TITLE
Fixing a regression issue #2234 where url of instance config is ignored

### DIFF
--- a/lib/core/mergeConfig.js
+++ b/lib/core/mergeConfig.js
@@ -15,10 +15,10 @@ module.exports = function mergeConfig(config1, config2) {
   config2 = config2 || {};
   var config = {};
 
-  var valueFromConfig2Keys = ['url', 'method', 'data'];
+  var valueFromConfig2Keys = ['method', 'data'];
   var mergeDeepPropertiesKeys = ['headers', 'auth', 'proxy', 'params'];
   var defaultToConfig2Keys = [
-    'baseURL', 'transformRequest', 'transformResponse', 'paramsSerializer',
+    'baseURL', 'url', 'transformRequest', 'transformResponse', 'paramsSerializer',
     'timeout', 'timeoutMessage', 'withCredentials', 'adapter', 'responseType', 'xsrfCookieName',
     'xsrfHeaderName', 'onUploadProgress', 'onDownloadProgress', 'decompress',
     'maxContentLength', 'maxBodyLength', 'maxRedirects', 'transport', 'httpAgent',

--- a/test/specs/core/mergeConfig.spec.js
+++ b/test/specs/core/mergeConfig.spec.js
@@ -101,7 +101,7 @@ describe('core::mergeConfig', function() {
   });
 
   describe('valueFromConfig2Keys', function() {
-    var config1 = {url: '/foo', method: 'post', data: {a: 3}};
+    var config1 = {method: 'post', data: {a: 3}};
 
     it('should skip if config2 is undefined', function() {
       expect(mergeConfig(config1, {})).toEqual({});

--- a/test/specs/instance.spec.js
+++ b/test/specs/instance.spec.js
@@ -38,12 +38,39 @@ describe('instance', function () {
     });
   });
 
-  it('should make an http request with url instead of baseURL', function (done) {
+  it('should make an http request overrides url of instance', function (done) {
     var instance = axios.create({
       url: 'https://api.example.com'
     });
 
     instance('/foo');
+
+    getAjaxRequest().then(function (request) {
+      expect(request.url).toBe('/foo');
+      done();
+    });
+  });
+
+  it('should make an http request with url instead of baseURL', function (done) {
+    var instance = axios.create({
+      url: 'https://api.example.com',
+    });
+
+    instance.request({});
+
+    getAjaxRequest().then(function (request) {
+      expect(request.url).toBe('https://api.example.com');
+      done();
+    });
+  });
+
+  it('should make an http request with url instead of baseURL and this can be overridden by request config', function (done) {
+    var instance = axios.create({
+      url: 'https://api.example.com',
+      method: 'get'
+    });
+
+    instance.request({url: '/foo'});
 
     getAjaxRequest().then(function (request) {
       expect(request.url).toBe('/foo');


### PR DESCRIPTION
This pull request fixes regression of #2234.
The issue had been fixed once by #2290, but the issue has been reproduced currently caused by #2844.
I think this is a regression bug, so I create this pull request.