### PR TITLE
Fixing remove Content-Type when data is instance of FormData

### DIFF
--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -15,10 +15,6 @@ module.exports = function xhrAdapter(config) {
     var requestHeaders = config.headers;
     var responseType = config.responseType;
 
-    if (utils.isFormData(requestData)) {
-      delete requestHeaders['Content-Type']; // Let the browser set it
-    }
-
     var request = new XMLHttpRequest();
 
     // HTTP basic authentication


### PR DESCRIPTION
Fixes https://github.com/axios/axios/issues/1603

Similar motivation as in https://github.com/axios/axios/pull/3289
Seems more logical to give freedom to the developer