### PR TITLE
Fix broken type-declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,168 +1,170 @@
-export interface AxiosTransformer {
-  (data: any, headers?: any): any;
-}
+declare namespace axios {
+  export interface AxiosTransformer {
+    (data: any, headers?: any): any;
+  }
 
-export interface AxiosAdapter {
-  (config: AxiosRequestConfig): AxiosPromise<any>;
-}
+  export interface AxiosAdapter {
+    (config: AxiosRequestConfig): AxiosPromise<any>;
+  }
 
-export interface AxiosBasicCredentials {
-  username: string;
-  password: string;
-}
-
-export interface AxiosProxyConfig {
-  host: string;
-  port: number;
-  auth?: {
+  export interface AxiosBasicCredentials {
     username: string;
-    password:string;
-  };
-  protocol?: string;
+    password: string;
+  }
+
+  export interface AxiosProxyConfig {
+    host: string;
+    port: number;
+    auth?: {
+      username: string;
+      password:string;
+    };
+    protocol?: string;
+  }
+
+  export type Method =
+    | 'get' | 'GET'
+    | 'delete' | 'DELETE'
+    | 'head' | 'HEAD'
+    | 'options' | 'OPTIONS'
+    | 'post' | 'POST'
+    | 'put' | 'PUT'
+    | 'patch' | 'PATCH'
+    | 'purge' | 'PURGE'
+    | 'link' | 'LINK'
+    | 'unlink' | 'UNLINK'
+
+  export type ResponseType =
+    | 'arraybuffer'
+    | 'blob'
+    | 'document'
+    | 'json'
+    | 'text'
+    | 'stream'
+
+  export interface TransitionalOptions{
+    silentJSONParsing: boolean;
+    forcedJSONParsing: boolean;
+    clarifyTimeoutError: boolean;
+  }
+
+  export interface AxiosRequestConfig {
+    url?: string;
+    method?: Method;
+    baseURL?: string;
+    transformRequest?: AxiosTransformer | AxiosTransformer[];
+    transformResponse?: AxiosTransformer | AxiosTransformer[];
+    headers?: any;
+    params?: any;
+    paramsSerializer?: (params: any) => string;
+    data?: any;
+    timeout?: number;
+    timeoutErrorMessage?: string;
+    withCredentials?: boolean;
+    adapter?: AxiosAdapter;
+    auth?: AxiosBasicCredentials;
+    responseType?: ResponseType;
+    xsrfCookieName?: string;
+    xsrfHeaderName?: string;
+    onUploadProgress?: (progressEvent: any) => void;
+    onDownloadProgress?: (progressEvent: any) => void;
+    maxContentLength?: number;
+    validateStatus?: ((status: number) => boolean) | null;
+    maxBodyLength?: number;
+    maxRedirects?: number;
+    socketPath?: string | null;
+    httpAgent?: any;
+    httpsAgent?: any;
+    proxy?: AxiosProxyConfig | false;
+    cancelToken?: CancelToken;
+    decompress?: boolean;
+    transitional?: TransitionalOptions
+  }
+
+  export interface AxiosResponse<T = any>  {
+    data: T;
+    status: number;
+    statusText: string;
+    headers: any;
+    config: AxiosRequestConfig;
+    request?: any;
+  }
+
+  export interface AxiosError<T = any> extends Error {
+    config: AxiosRequestConfig;
+    code?: string;
+    request?: any;
+    response?: AxiosResponse<T>;
+    isAxiosError: boolean;
+    toJSON: () => object;
+  }
+
+  export interface AxiosPromise<T = any> extends Promise<AxiosResponse<T>> {
+  }
+
+  export interface CancelStatic {
+    new (message?: string): Cancel;
+  }
+
+  export interface Cancel {
+    message: string;
+  }
+
+  export interface Canceler {
+    (message?: string): void;
+  }
+
+  export interface CancelTokenStatic {
+    new (executor: (cancel: Canceler) => void): CancelToken;
+    source(): CancelTokenSource;
+  }
+
+  export interface CancelToken {
+    promise: Promise<Cancel>;
+    reason?: Cancel;
+    throwIfRequested(): void;
+  }
+
+  export interface CancelTokenSource {
+    token: CancelToken;
+    cancel: Canceler;
+  }
+
+  export interface AxiosInterceptorManager<V> {
+    use(onFulfilled?: (value: V) => V | Promise<V>, onRejected?: (error: any) => any): number;
+    eject(id: number): void;
+  }
+
+  export interface AxiosInstance {
+    (config: AxiosRequestConfig): AxiosPromise;
+    (url: string, config?: AxiosRequestConfig): AxiosPromise;
+    defaults: AxiosRequestConfig;
+    interceptors: {
+      request: AxiosInterceptorManager<AxiosRequestConfig>;
+      response: AxiosInterceptorManager<AxiosResponse>;
+    };
+    getUri(config?: AxiosRequestConfig): string;
+    request<T = any, R = AxiosResponse<T>> (config: AxiosRequestConfig): Promise<R>;
+    get<T = any, R = AxiosResponse<T>>(url: string, config?: AxiosRequestConfig): Promise<R>;
+    delete<T = any, R = AxiosResponse<T>>(url: string, config?: AxiosRequestConfig): Promise<R>;
+    head<T = any, R = AxiosResponse<T>>(url: string, config?: AxiosRequestConfig): Promise<R>;
+    options<T = any, R = AxiosResponse<T>>(url: string, config?: AxiosRequestConfig): Promise<R>;
+    post<T = any, R = AxiosResponse<T>>(url: string, data?: any, config?: AxiosRequestConfig): Promise<R>;
+    put<T = any, R = AxiosResponse<T>>(url: string, data?: any, config?: AxiosRequestConfig): Promise<R>;
+    patch<T = any, R = AxiosResponse<T>>(url: string, data?: any, config?: AxiosRequestConfig): Promise<R>;
+  }
+
+  export interface AxiosStatic extends AxiosInstance {
+    create(config?: AxiosRequestConfig): AxiosInstance;
+    Cancel: CancelStatic;
+    CancelToken: CancelTokenStatic;
+    isCancel(value: any): boolean;
+    all<T>(values: (T | Promise<T>)[]): Promise<T[]>;
+    spread<T, R>(callback: (...args: T[]) => R): (array: T[]) => R;
+    isAxiosError(payload: any): payload is AxiosError;
+  }
 }
 
-export type Method =
-  | 'get' | 'GET'
-  | 'delete' | 'DELETE'
-  | 'head' | 'HEAD'
-  | 'options' | 'OPTIONS'
-  | 'post' | 'POST'
-  | 'put' | 'PUT'
-  | 'patch' | 'PATCH'
-  | 'purge' | 'PURGE'
-  | 'link' | 'LINK'
-  | 'unlink' | 'UNLINK'
+declare const axios: axios.AxiosStatic;
 
-export type ResponseType =
-  | 'arraybuffer'
-  | 'blob'
-  | 'document'
-  | 'json'
-  | 'text'
-  | 'stream'
-
-export interface TransitionalOptions{
-  silentJSONParsing: boolean;
-  forcedJSONParsing: boolean;
-  clarifyTimeoutError: boolean;
-}
-
-export interface AxiosRequestConfig {
-  url?: string;
-  method?: Method;
-  baseURL?: string;
-  transformRequest?: AxiosTransformer | AxiosTransformer[];
-  transformResponse?: AxiosTransformer | AxiosTransformer[];
-  headers?: any;
-  params?: any;
-  paramsSerializer?: (params: any) => string;
-  data?: any;
-  timeout?: number;
-  timeoutErrorMessage?: string;
-  withCredentials?: boolean;
-  adapter?: AxiosAdapter;
-  auth?: AxiosBasicCredentials;
-  responseType?: ResponseType;
-  xsrfCookieName?: string;
-  xsrfHeaderName?: string;
-  onUploadProgress?: (progressEvent: any) => void;
-  onDownloadProgress?: (progressEvent: any) => void;
-  maxContentLength?: number;
-  validateStatus?: ((status: number) => boolean) | null;
-  maxBodyLength?: number;
-  maxRedirects?: number;
-  socketPath?: string | null;
-  httpAgent?: any;
-  httpsAgent?: any;
-  proxy?: AxiosProxyConfig | false;
-  cancelToken?: CancelToken;
-  decompress?: boolean;
-  transitional?: TransitionalOptions
-}
-
-export interface AxiosResponse<T = any>  {
-  data: T;
-  status: number;
-  statusText: string;
-  headers: any;
-  config: AxiosRequestConfig;
-  request?: any;
-}
-
-export interface AxiosError<T = any> extends Error {
-  config: AxiosRequestConfig;
-  code?: string;
-  request?: any;
-  response?: AxiosResponse<T>;
-  isAxiosError: boolean;
-  toJSON: () => object;
-}
-
-export interface AxiosPromise<T = any> extends Promise<AxiosResponse<T>> {
-}
-
-export interface CancelStatic {
-  new (message?: string): Cancel;
-}
-
-export interface Cancel {
-  message: string;
-}
-
-export interface Canceler {
-  (message?: string): void;
-}
-
-export interface CancelTokenStatic {
-  new (executor: (cancel: Canceler) => void): CancelToken;
-  source(): CancelTokenSource;
-}
-
-export interface CancelToken {
-  promise: Promise<Cancel>;
-  reason?: Cancel;
-  throwIfRequested(): void;
-}
-
-export interface CancelTokenSource {
-  token: CancelToken;
-  cancel: Canceler;
-}
-
-export interface AxiosInterceptorManager<V> {
-  use(onFulfilled?: (value: V) => V | Promise<V>, onRejected?: (error: any) => any): number;
-  eject(id: number): void;
-}
-
-export interface AxiosInstance {
-  (config: AxiosRequestConfig): AxiosPromise;
-  (url: string, config?: AxiosRequestConfig): AxiosPromise;
-  defaults: AxiosRequestConfig;
-  interceptors: {
-    request: AxiosInterceptorManager<AxiosRequestConfig>;
-    response: AxiosInterceptorManager<AxiosResponse>;
-  };
-  getUri(config?: AxiosRequestConfig): string;
-  request<T = any, R = AxiosResponse<T>> (config: AxiosRequestConfig): Promise<R>;
-  get<T = any, R = AxiosResponse<T>>(url: string, config?: AxiosRequestConfig): Promise<R>;
-  delete<T = any, R = AxiosResponse<T>>(url: string, config?: AxiosRequestConfig): Promise<R>;
-  head<T = any, R = AxiosResponse<T>>(url: string, config?: AxiosRequestConfig): Promise<R>;
-  options<T = any, R = AxiosResponse<T>>(url: string, config?: AxiosRequestConfig): Promise<R>;
-  post<T = any, R = AxiosResponse<T>>(url: string, data?: any, config?: AxiosRequestConfig): Promise<R>;
-  put<T = any, R = AxiosResponse<T>>(url: string, data?: any, config?: AxiosRequestConfig): Promise<R>;
-  patch<T = any, R = AxiosResponse<T>>(url: string, data?: any, config?: AxiosRequestConfig): Promise<R>;
-}
-
-export interface AxiosStatic extends AxiosInstance {
-  create(config?: AxiosRequestConfig): AxiosInstance;
-  Cancel: CancelStatic;
-  CancelToken: CancelTokenStatic;
-  isCancel(value: any): boolean;
-  all<T>(values: (T | Promise<T>)[]): Promise<T[]>;
-  spread<T, R>(callback: (...args: T[]) => R): (array: T[]) => R;
-  isAxiosError(payload: any): payload is AxiosError;
-}
-
-declare const axios: AxiosStatic;
-
-export default axios;
+export = axios;

--- a/test/typescript/axios.ts
+++ b/test/typescript/axios.ts
@@ -1,4 +1,6 @@
-import axios, {
+import axios = require('../..');
+
+import {
   AxiosRequestConfig,
   AxiosResponse,
   AxiosError,

--- a/test/typescript/axios.ts
+++ b/test/typescript/axios.ts
@@ -338,11 +338,11 @@ axios.get('/user')
 
 axios.get('/user')
   .catch((error: any) => 'foo')
-  .then((value: string) => {});
+  .then((value) => {});
 
 axios.get('/user')
   .catch((error: any) => Promise.resolve('foo'))
-  .then((value: string) => {});
+  .then((value) => {});
 
 // Cancellation
 


### PR DESCRIPTION
The type-declaration shipped with the current version of `axios` suggests, that `axios` is exported as `default` (using a syntax such as `export default axios;` or `module.exports.default = axios;`).

Therefore, the current version of `axios` can't be consumed by TypeScript-users.

But, as seen here:
https://github.com/axios/axios/blob/9c2528d9cca7c7be0b0e5c6cc58f2ad13a1d5689/index.js#L1
`axios` neither uses `export default [...];` nor `module.exports.default = [...];`, but `module.exports = [...]`.

The proper way to reflect this in a type declaration is `export = [...];`.

This PR fixes the broken type-declaration.