### PR TITLE
Added data type that defaults to any

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -148,9 +148,9 @@ export interface AxiosInstance {
   delete<T = any, R = AxiosResponse<T>>(url: string, config?: AxiosRequestConfig): Promise<R>;
   head<T = any, R = AxiosResponse<T>>(url: string, config?: AxiosRequestConfig): Promise<R>;
   options<T = any, R = AxiosResponse<T>>(url: string, config?: AxiosRequestConfig): Promise<R>;
-  post<T = any, R = AxiosResponse<T>>(url: string, data?: any, config?: AxiosRequestConfig): Promise<R>;
-  put<T = any, R = AxiosResponse<T>>(url: string, data?: any, config?: AxiosRequestConfig): Promise<R>;
-  patch<T = any, R = AxiosResponse<T>>(url: string, data?: any, config?: AxiosRequestConfig): Promise<R>;
+  post<T = any, R = AxiosResponse<T>, D = any>(url: string, data?: D, config?: AxiosRequestConfig): Promise<R>;
+  put<T = any, R = AxiosResponse<T>, D = any>(url: string, data?: D, config?: AxiosRequestConfig): Promise<R>;
+  patch<T = any, R = AxiosResponse<T>, D = any>(url: string, data?: D, config?: AxiosRequestConfig): Promise<R>;
 }
 
 export interface AxiosStatic extends AxiosInstance {


### PR DESCRIPTION
This PR adds typing support for `data` params for these methods:
- post
- put
- patch

so now you can call post method like this:
```ts
interface RequestType { username: string; password: string; }
await Axios.post<unknown, unknown, RequestType>("https:/api.example.com/login", { username: "john.doe", password: "123password" })
```

which will give you intellisense as well as type-checking for your request body.

**Note**
This is not a breaking change, as the old way of calling these methods will also work, and the `data` param type will default to `any`