### PR TITLE
Fixes the sauce labs tests by bumping karma-sauce-launcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "karma-jasmine": "^1.1.1",
     "karma-jasmine-ajax": "^0.1.13",
     "karma-safari-launcher": "^1.0.0",
-    "karma-sauce-launcher": "^4.3.5",
+    "karma-sauce-launcher": "^4.3.6",
     "karma-sinon": "^1.0.5",
     "karma-sourcemap-loader": "^0.3.8",
     "karma-webpack": "^4.0.2",


### PR DESCRIPTION
I was unable to run the sauce labs tests on `master` so I tracked down some discussion here https://github.com/karma-runner/karma-sauce-launcher/issues/230#issuecomment-735591811 and after testing locally, I believe this should make the sauce labs tests pass.  Here are the errors I was seeing

```
25 05 2021 21:51:40.455:ERROR [SaucelabsLauncher]: Could not quit the Saucelabs selenium connection. Failure message:
25 05 2021 21:51:40.455:ERROR [SaucelabsLauncher]: TypeError: Cannot read property 'deleteSession' of undefined
    at SaucelabsLauncher.<anonymous> (/Users/brian/staffbar/axios/node_modules/karma-sauce-launcher/dist/launcher/launcher.js:149:26)
    at Generator.next (<anonymous>)
    at /Users/brian/staffbar/axios/node_modules/karma-sauce-launcher/dist/launcher/launcher.js:8:71
    at new Promise (<anonymous>)
    at __awaiter (/Users/brian/staffbar/axios/node_modules/karma-sauce-launcher/dist/launcher/launcher.js:4:12)
    at SaucelabsLauncher.<anonymous> (/Users/brian/staffbar/axios/node_modules/karma-sauce-launcher/dist/launcher/launcher.js:141:31)
    at SaucelabsLauncher.emit (node:events:365:28)
    at SaucelabsLauncher.emit (node:domain:470:12)
    at SaucelabsLauncher.emitAsync (/Users/brian/staffbar/axios/node_modules/karma/lib/events.js:52:10)
    at SaucelabsLauncher.BaseLauncher.kill (/Users/brian/staffbar/axios/node_modules/karma/lib/launchers/base.js:61:27)
25 05 2021 21:51:40.455:ERROR [SaucelabsLauncher]: Could not quit the Saucelabs selenium connection. Failure message:
25 05 2021 21:51:40.455:ERROR [SaucelabsLauncher]: TypeError: Cannot read property 'deleteSession' of undefined
```

![Screen Shot 2021-05-25 at 11 22 00 PM](https://user-images.githubusercontent.com/2637602/119611887-1d653d80-bdb0-11eb-91d5-4471560c2c8b.png)

