### PR TITLE
Fix README typo under Request Config

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,7 +465,7 @@ These are the available config options for making requests. Only the `url` is re
     // `false` - throw SyntaxError if JSON parsing failed (Note: responseType must be set to 'json')
     silentJSONParsing: true; // default value for the current Axios version
 
-    // try to parse the response string as JSON even if `resposeType` is not 'json'
+    // try to parse the response string as JSON even if `responseType` is not 'json'
     forcedJSONParsing: true;
     
     // throw ETIMEDOUT error instead of generic ECONNABORTED on request timeouts


### PR DESCRIPTION
Under the Request Config section, the key 'responseType' was misspelled as 'resposeType'