### PR TITLE
use Record<string, string> for headers

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 export interface AxiosTransformer {
-  (data: any, headers?: any): any;
+  (data: any, headers?: Record<string, string>): any;
 }
 
 export interface AxiosAdapter {
@@ -53,7 +53,7 @@ export interface AxiosRequestConfig {
   baseURL?: string;
   transformRequest?: AxiosTransformer | AxiosTransformer[];
   transformResponse?: AxiosTransformer | AxiosTransformer[];
-  headers?: any;
+  headers?: Record<string, string>;
   params?: any;
   paramsSerializer?: (params: any) => string;
   data?: any;
@@ -84,7 +84,7 @@ export interface AxiosResponse<T = any>  {
   data: T;
   status: number;
   statusText: string;
-  headers: any;
+  headers: Record<string, string>;
   config: AxiosRequestConfig;
   request?: any;
 }


### PR DESCRIPTION
I might be wrong but from what I can tell, headers can be typed as `Record<string, string>`. I understand that any is probably used for better UX but Record<string, string> has similar UX imo.