### PR TITLE
Uses only 'application/json' as default 'Accept' header

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -104,7 +104,7 @@ var defaults = {
 
 defaults.headers = {
   common: {
-    'Accept': 'application/json, text/plain, */*'
+    'Accept': 'application/json'
   }
 };
 


### PR DESCRIPTION
Using 'application/json, plain/text, */*' is too open for modern web
applications, instead, setting `application/json` as default makes total
sense as is a reasonable assumption that the apis are by default json in
most cases.

<!-- Click "Preview" for a more readable version -->

#### Instructions

Please read and follow the instructions before creating and submitting a pull request:

- Create an issue explaining the feature. It could save you some effort in case we don't consider it should be included in axios.
- If you're fixing a bug, try to commit the failing test/s and the code fixing it in different commits.
- Ensure you're following our [contributing guide](https://github.com/axios/axios/blob/master/CONTRIBUTING.md).

**⚠️👆 Delete the instructions before submitting the pull request 👆⚠️**

Describe your pull request here.
