### PR TITLE
feat: fix proxy agent

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -198,6 +198,11 @@ module.exports = function httpAdapter(config) {
       options.maxBodyLength = config.maxBodyLength;
     }
 
+    if (proxy) {
+      agent = isHttps.test(proxy.protocol) ? config.httpsAgent : config.httpAgent;
+      options.agent = agent;
+    }
+
     // Create the request
     var req = transport.request(options, function handleResponse(res) {
       if (req.aborted) return;

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@youzanyun/axios",
+  "name": "@youzan/yun-axios",
   "version": "0.0.1",
   "description": "Promise based HTTP client for the browser and node.js",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "promise",
     "node"
   ],
-  "author": "Matt Zabriskie",
+  "author": "hanxiao",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/axios/axios/issues"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "axios",
-  "version": "0.21.1",
+  "name": "@youzanyun/axios",
+  "version": "0.0.1",
   "description": "Promise based HTTP client for the browser and node.js",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
bugfix:
when request width proxy and the url is start with HTTPS, the options.agent will use HTTPS.
but proxy is using proxy protocol with http