### PR TITLE
Changed the default values of the Accept header

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -104,7 +104,7 @@ var defaults = {
 
 defaults.headers = {
   common: {
-    'Accept': 'application/json, text/plain, */*'
+    'Accept': '*/*'
   }
 };
 


### PR DESCRIPTION
The default value of the Accept header was: 'application/json, text/plain, */*'. This was changed to '*/*'.