### PR TITLE
fix: set user-agent header case-insensitively for http adapter

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -13,6 +13,7 @@ var zlib = require('zlib');
 var pkg = require('./../../package.json');
 var createError = require('../core/createError');
 var enhanceError = require('../core/enhanceError');
+var normalizeHeaderName = require('../helpers/normalizeHeaderName');
 
 var isHttps = /https:?/;
 
@@ -55,16 +56,17 @@ module.exports = function httpAdapter(config) {
 
     // Set User-Agent (required by some servers)
     // See https://github.com/axios/axios/issues/69
-    if ('User-Agent' in headers || 'user-agent' in headers) {
+    var USER_AGENT_HEADER = 'User-Agent';
+    normalizeHeaderName(headers, USER_AGENT_HEADER);
+    if (USER_AGENT_HEADER in headers) {
       // User-Agent is specified; handle case where no UA header is desired
-      if (!headers['User-Agent'] && !headers['user-agent']) {
-        delete headers['User-Agent'];
-        delete headers['user-agent'];
+      if (!headers[USER_AGENT_HEADER]) {
+        delete headers[USER_AGENT_HEADER];
       }
       // Otherwise, use specified value
     } else {
       // Only set header if it hasn't been set in config
-      headers['User-Agent'] = 'axios/' + pkg.version;
+      headers[USER_AGENT_HEADER] = 'axios/' + pkg.version;
     }
 
     if (data && !utils.isStream(data)) {

--- a/test/unit/adapters/http.js
+++ b/test/unit/adapters/http.js
@@ -968,5 +968,20 @@ describe('supports http with nodejs', function () {
     });
   });
 
+  it('should apply custom user-agent case-insensitively if one is specified', function (done) {
+    server = http.createServer(function (req, res) {
+      assert.equal(req.headers["user-agent"], "custom-ua");
+      res.end();
+    }).listen(4444, function () {
+      axios.get('http://localhost:4444/', {
+        headers: {
+          "uSeR-AGenT": "custom-ua"
+        }
+      }
+      ).then(function (res) {
+        done();
+      });
+    });
+  });
 });
 


### PR DESCRIPTION
FIxes #3844

When using `http` adapter, axios sets the user-agent header only if the header is named "User-Agent" or "user-agent". Otherwise it is over-written by the default user-agent string.

With this fix the goal is to preserve a custom user-agent when specified, irrespective of string case used for naming the header. 