### PR TITLE
Error handling when stream is destroyed while reading

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -321,9 +321,22 @@ module.exports = function httpAdapter(config) {
 
     // Send the request
     if (utils.isStream(data)) {
-      data.on('error', function handleStreamError(err) {
+      var streamDataBuffer = [];
+      var endStatus = false;
+      data.on('data', function onData(chunk) {
+        streamDataBuffer.push(chunk);
+      }).on('error', function handleStreamError(err) {
         reject(enhanceError(err, config, null, req));
-      }).pipe(req);
+      }).on('close', function onClose() {
+        if (endStatus === false) {
+          req.abort();
+          reject(createError('Stream destroyed', config, 'ERR_STREAM_PREMATURE_CLOSE', req));
+        }
+      }).on('end', function onEnd() {
+        endStatus = true;
+        var streamData = Buffer.concat(streamDataBuffer);
+        req.end(streamData);
+      });
     } else {
       req.end(data);
     }


### PR DESCRIPTION
This PR fixes #3780. The problem is that when the input data is stream and the stream gets destroyed while the it is being read, then axios gets stuck and nothing is displayed. If an `Error` is provided to the `stream.destroy()` then the error is displayed but still axios is stuck after the error message is displayed. This PR solves this issue.
