### PR TITLE
Fix "Content-Length" header for GET and DELETE methods

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -81,8 +81,9 @@ module.exports = function httpAdapter(config) {
         ));
       }
 
-      // Add Content-Length header if data exists
-      headers['Content-Length'] = data.length;
+      // Add Content-Length header if data exists, except GET, DELETE
+      headers['Content-Length'] = !['GET', 'DELETE'].includes(config.method.toUpperCase())
+          ? data.length : 0;
     }
 
     // HTTP basic authentication


### PR DESCRIPTION
This PR fixes #3946. For methods GET and DELETE request header "CONTENT-LENGTH" should be 0 or removed.