### PR TITLE
Fixed confusion in baseURL in config section

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ These are the available config options for making requests. Only the `url` is re
   // `baseURL` will be prepended to `url` unless `url` is absolute.
   // It can be convenient to set `baseURL` for an instance of axios to pass relative URLs
   // to methods of that instance.
-  baseURL: 'https://some-domain.com/api/',
+  baseURL: 'https://some-domain.com/api',
 
   // `transformRequest` allows changes to the request data before it is sent to the server
   // This is only applicable for request methods 'PUT', 'POST', 'PATCH' and 'DELETE'


### PR DESCRIPTION
```js
url: '/user',
baseURL: 'https://some-domain.com/api/'
                                     ^
```

this extra slash was creating confusion about the actual behavior of the config. about whether this Slash is necessary or not. In reality it is not necessary when used with the previous line `url: '/user'`. So, to avoid confusion one of the Slashes is needed to be removed. I removed the slash in `baseURL` cause it looks better in actuall usage of code.
Like the following line
```js
axios.get('/user/id');
```
Looks better than
```js
axios.get('user/id');
```