### PR TITLE
Fixing buildURL anchor hash removal when no params are provided

### DIFF
--- a/lib/helpers/buildURL.js
+++ b/lib/helpers/buildURL.js
@@ -21,6 +21,11 @@ function encode(val) {
  */
 module.exports = function buildURL(url, params, paramsSerializer) {
   /*eslint no-param-reassign:0*/
+  var hashmarkIndex = url.indexOf('#');
+  if (hashmarkIndex !== -1) {
+    url = url.slice(0, hashmarkIndex);
+  }
+
   if (!params) {
     return url;
   }
@@ -58,11 +63,6 @@ module.exports = function buildURL(url, params, paramsSerializer) {
   }
 
   if (serializedParams) {
-    var hashmarkIndex = url.indexOf('#');
-    if (hashmarkIndex !== -1) {
-      url = url.slice(0, hashmarkIndex);
-    }
-
     url += (url.indexOf('?') === -1 ? '?' : '&') + serializedParams;
   }
 

--- a/test/specs/helpers/buildURL.spec.js
+++ b/test/specs/helpers/buildURL.spec.js
@@ -60,6 +60,12 @@ describe('helpers::buildURL', function () {
     })).toEqual('/foo?foo=bar&query=baz');
   });
 
+  it('should correctly discard url hash mark when no additional params are provided', function () {
+    expect(buildURL('/foo?foo=bar&query=baz#hash')).toEqual(
+      '/foo?foo=bar&query=baz'
+    );
+  });
+
   it('should use serializer if provided', function () {
     serializer = sinon.stub();
     params = {foo: 'bar'};


### PR DESCRIPTION
There was an early return in the buildURL method when params are not provided, which would make it so that the anchor hash was only removed when paramters are present.

So `buildURL('/foo?foo=bar#hash', { query: 'baz' })` was not the same as `buildURL('/foo?foo=bar&query=baz#hash')` as the `#hash` would only be removed on the former

This PR adds the test case and the fix for it