### PR TITLE
Fixing interceptor chain when request interceptor is asynchronous

### DIFF
--- a/lib/core/Axios.js
+++ b/lib/core/Axios.js
@@ -81,7 +81,7 @@ Axios.prototype.request = function request(config) {
     var chain = [dispatchRequest, undefined];
 
     Array.prototype.unshift.apply(chain, requestInterceptorChain);
-    chain.concat(responseInterceptorChain);
+    chain = chain.concat(responseInterceptorChain);
 
     promise = Promise.resolve(config);
     while (chain.length) {

--- a/test/specs/interceptors.spec.js
+++ b/test/specs/interceptors.spec.js
@@ -252,6 +252,35 @@ describe('interceptors', function () {
     });
   });
 
+  it('should add a response interceptor when request interceptor is defined', function (done) {
+    var response;
+
+    axios.interceptors.request.use(function (data) {
+      return data;
+    });
+
+    axios.interceptors.response.use(function (data) {
+      data.data = data.data + ' - modified by interceptor';
+      return data;
+    });
+
+    axios('/foo').then(function (data) {
+      response = data;
+    });
+
+    getAjaxRequest().then(function (request) {
+      request.respondWith({
+        status: 200,
+        responseText: 'OK'
+      });
+
+      setTimeout(function () {
+        expect(response.data).toBe('OK - modified by interceptor');
+        done();
+      }, 100);
+    });
+  });
+
   it('should add a response interceptor that returns a new data object', function (done) {
     var response;
 


### PR DESCRIPTION
Currently response interceptors are not executed when an async request interceptor was attached, see https://github.com/axios/axios/issues/4012