### PR TITLE
fix json transform when data is pre-stringified

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -26,6 +26,21 @@ function getDefaultAdapter() {
   return adapter;
 }
 
+function stringifySafely(rawValue, parser, encoder) {
+  if (utils.isString(rawValue)) {
+    try {
+      (parser || JSON.parse)(rawValue);
+      return utils.trim(rawValue);
+    } catch (e) {
+      if (e.name !== 'SyntaxError') {
+        throw e;
+      }
+    }
+  }
+
+  return (encoder || JSON.stringify)(rawValue);
+}
+
 var defaults = {
 
   transitional: {
@@ -58,7 +73,7 @@ var defaults = {
     }
     if (utils.isObject(data) || (headers && headers['Content-Type'] === 'application/json')) {
       setContentTypeIfUnset(headers, 'application/json');
-      return JSON.stringify(data);
+      return stringifySafely(data);
     }
     return data;
   }],

--- a/test/specs/defaults.spec.js
+++ b/test/specs/defaults.spec.js
@@ -20,6 +20,19 @@ describe('defaults', function () {
     expect(defaults.transformRequest[0]({foo: 'bar'})).toEqual('{"foo":"bar"}');
   });
 
+  it("should also transform request json when 'Content-Type' is 'application/json'", function () {
+    var headers = {
+      'Content-Type': 'application/json',
+    };
+    expect(defaults.transformRequest[0](JSON.stringify({ foo: 'bar' }), headers)).toEqual('{"foo":"bar"}');
+    expect(defaults.transformRequest[0]([42, 43], headers)).toEqual('[42,43]');
+    expect(defaults.transformRequest[0]('foo', headers)).toEqual('"foo"');
+    expect(defaults.transformRequest[0](42, headers)).toEqual('42');
+    expect(defaults.transformRequest[0](true, headers)).toEqual('true');
+    expect(defaults.transformRequest[0](false, headers)).toEqual('false');
+    expect(defaults.transformRequest[0](null, headers)).toEqual('null');
+  });  
+
   it('should do nothing to request string', function () {
     expect(defaults.transformRequest[0]('foo=bar')).toEqual('foo=bar');
   });


### PR DESCRIPTION
Just spent my Sunday afternoon on this nasty bug introduced by PR https://github.com/axios/axios/pull/3688 (to fix https://github.com/axios/axios/issues/2613). It should be OK for people :

- using interceptors with JSON data. Indeed, the fact is that when we retry the request with the request interceptor, because the data is already stringified the second time https://github.com/axios/axios/issues/1386, we fall into this bug (the payload is stringified 2 times instead of only one) cc @ddolcimascolo @rdsedmundo : https://github.com/axios/axios/issues/3986

- using pre-stringified data cc @kawanet : https://github.com/axios/axios/issues/4018 

cc @jasonsaayman  @chinesedfan @DigitalBrainJS 