### PR TITLE
fix/Avoid package.json import;

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,148 +1,151 @@
+// eslint-disable-next-line strict
 module.exports = {
-  "globals": {
-    "console": true,
-    "module": true,
-    "require": true
+  'globals': {
+    'console': true,
+    'module': true,
+    'require': true
   },
-  "env": {
-    "browser": true,
-    "node": true
+  'env': {
+    'browser': true,
+    'node': true
   },
-  "rules": {
-/**
+  'rules': {
+    /**
  * Strict mode
  */
-    "strict": [2, "global"],         // http://eslint.org/docs/rules/strict
+    'strict': [2, 'global'],         // http://eslint.org/docs/rules/strict
 
-/**
+    /**
  * Variables
  */
-    "no-shadow": 2,                  // http://eslint.org/docs/rules/no-shadow
-    "no-shadow-restricted-names": 2, // http://eslint.org/docs/rules/no-shadow-restricted-names
-    "no-unused-vars": [2, {          // http://eslint.org/docs/rules/no-unused-vars
-      "vars": "local",
-      "args": "after-used"
+    'no-shadow': 2,                  // http://eslint.org/docs/rules/no-shadow
+    'no-shadow-restricted-names': 2, // http://eslint.org/docs/rules/no-shadow-restricted-names
+    'no-unused-vars': [2, {          // http://eslint.org/docs/rules/no-unused-vars
+      'vars': 'local',
+      'args': 'after-used'
     }],
-    "no-use-before-define": 2,       // http://eslint.org/docs/rules/no-use-before-define
+    'no-use-before-define': 2,       // http://eslint.org/docs/rules/no-use-before-define
 
-/**
+    /**
  * Possible errors
  */
-    "comma-dangle": [2, "never"],    // http://eslint.org/docs/rules/comma-dangle
-    "no-cond-assign": [2, "except-parens"], // http://eslint.org/docs/rules/no-cond-assign
-    "no-console": 1,                 // http://eslint.org/docs/rules/no-console
-    "no-debugger": 1,                // http://eslint.org/docs/rules/no-debugger
-    "no-alert": 1,                   // http://eslint.org/docs/rules/no-alert
-    "no-constant-condition": 1,      // http://eslint.org/docs/rules/no-constant-condition
-    "no-dupe-keys": 2,               // http://eslint.org/docs/rules/no-dupe-keys
-    "no-duplicate-case": 2,          // http://eslint.org/docs/rules/no-duplicate-case
-    "no-empty": 2,                   // http://eslint.org/docs/rules/no-empty
-    "no-ex-assign": 2,               // http://eslint.org/docs/rules/no-ex-assign
-    "no-extra-boolean-cast": 0,      // http://eslint.org/docs/rules/no-extra-boolean-cast
-    "no-extra-semi": 2,              // http://eslint.org/docs/rules/no-extra-semi
-    "no-func-assign": 2,             // http://eslint.org/docs/rules/no-func-assign
-    "no-inner-declarations": 2,      // http://eslint.org/docs/rules/no-inner-declarations
-    "no-invalid-regexp": 2,          // http://eslint.org/docs/rules/no-invalid-regexp
-    "no-irregular-whitespace": 2,    // http://eslint.org/docs/rules/no-irregular-whitespace
-    "no-obj-calls": 2,               // http://eslint.org/docs/rules/no-obj-calls
-    "no-sparse-arrays": 2,           // http://eslint.org/docs/rules/no-sparse-arrays
-    "no-unreachable": 2,             // http://eslint.org/docs/rules/no-unreachable
-    "use-isnan": 2,                  // http://eslint.org/docs/rules/use-isnan
-    "block-scoped-var": 2,           // http://eslint.org/docs/rules/block-scoped-var
+    'comma-dangle': [2, 'never'],    // http://eslint.org/docs/rules/comma-dangle
+    'no-cond-assign': [2, 'except-parens'], // http://eslint.org/docs/rules/no-cond-assign
+    'no-console': 1,                 // http://eslint.org/docs/rules/no-console
+    'no-debugger': 1,                // http://eslint.org/docs/rules/no-debugger
+    'no-alert': 1,                   // http://eslint.org/docs/rules/no-alert
+    'no-constant-condition': 1,      // http://eslint.org/docs/rules/no-constant-condition
+    'no-dupe-keys': 2,               // http://eslint.org/docs/rules/no-dupe-keys
+    'no-duplicate-case': 2,          // http://eslint.org/docs/rules/no-duplicate-case
+    'no-empty': 2,                   // http://eslint.org/docs/rules/no-empty
+    'no-ex-assign': 2,               // http://eslint.org/docs/rules/no-ex-assign
+    'no-extra-boolean-cast': 0,      // http://eslint.org/docs/rules/no-extra-boolean-cast
+    'no-extra-semi': 2,              // http://eslint.org/docs/rules/no-extra-semi
+    'no-func-assign': 2,             // http://eslint.org/docs/rules/no-func-assign
+    'no-inner-declarations': 2,      // http://eslint.org/docs/rules/no-inner-declarations
+    'no-invalid-regexp': 2,          // http://eslint.org/docs/rules/no-invalid-regexp
+    'no-irregular-whitespace': 2,    // http://eslint.org/docs/rules/no-irregular-whitespace
+    'no-obj-calls': 2,               // http://eslint.org/docs/rules/no-obj-calls
+    'no-sparse-arrays': 2,           // http://eslint.org/docs/rules/no-sparse-arrays
+    'no-unreachable': 2,             // http://eslint.org/docs/rules/no-unreachable
+    'use-isnan': 2,                  // http://eslint.org/docs/rules/use-isnan
+    'block-scoped-var': 2,           // http://eslint.org/docs/rules/block-scoped-var
 
-/**
+    /**
  * Best practices
  */
-    "consistent-return": 2,          // http://eslint.org/docs/rules/consistent-return
-    "curly": [2, "multi-line"],      // http://eslint.org/docs/rules/curly
-    "default-case": 2,               // http://eslint.org/docs/rules/default-case
-    "dot-notation": [2, {            // http://eslint.org/docs/rules/dot-notation
-      "allowKeywords": true
+    'consistent-return': 2,          // http://eslint.org/docs/rules/consistent-return
+    'curly': [2, 'multi-line'],      // http://eslint.org/docs/rules/curly
+    'default-case': 2,               // http://eslint.org/docs/rules/default-case
+    'dot-notation': [2, {            // http://eslint.org/docs/rules/dot-notation
+      'allowKeywords': true
     }],
-    "eqeqeq": 2,                     // http://eslint.org/docs/rules/eqeqeq
-    "guard-for-in": 2,               // http://eslint.org/docs/rules/guard-for-in
-    "no-caller": 2,                  // http://eslint.org/docs/rules/no-caller
-    "no-else-return": 2,             // http://eslint.org/docs/rules/no-else-return
-    "no-eq-null": 2,                 // http://eslint.org/docs/rules/no-eq-null
-    "no-eval": 2,                    // http://eslint.org/docs/rules/no-eval
-    "no-extend-native": 2,           // http://eslint.org/docs/rules/no-extend-native
-    "no-extra-bind": 2,              // http://eslint.org/docs/rules/no-extra-bind
-    "no-fallthrough": 2,             // http://eslint.org/docs/rules/no-fallthrough
-    "no-floating-decimal": 2,        // http://eslint.org/docs/rules/no-floating-decimal
-    "no-implied-eval": 2,            // http://eslint.org/docs/rules/no-implied-eval
-    "no-lone-blocks": 2,             // http://eslint.org/docs/rules/no-lone-blocks
-    "no-loop-func": 2,               // http://eslint.org/docs/rules/no-loop-func
-    "no-multi-str": 2,               // http://eslint.org/docs/rules/no-multi-str
-    "no-native-reassign": 2,         // http://eslint.org/docs/rules/no-native-reassign
-    "no-new": 2,                     // http://eslint.org/docs/rules/no-new
-    "no-new-func": 2,                // http://eslint.org/docs/rules/no-new-func
-    "no-new-wrappers": 2,            // http://eslint.org/docs/rules/no-new-wrappers
-    "no-octal": 2,                   // http://eslint.org/docs/rules/no-octal
-    "no-octal-escape": 2,            // http://eslint.org/docs/rules/no-octal-escape
-    "no-param-reassign": 2,          // http://eslint.org/docs/rules/no-param-reassign
-    "no-proto": 2,                   // http://eslint.org/docs/rules/no-proto
-    "no-redeclare": 2,               // http://eslint.org/docs/rules/no-redeclare
-    "no-return-assign": 2,           // http://eslint.org/docs/rules/no-return-assign
-    "no-script-url": 2,              // http://eslint.org/docs/rules/no-script-url
-    "no-self-compare": 2,            // http://eslint.org/docs/rules/no-self-compare
-    "no-sequences": 2,               // http://eslint.org/docs/rules/no-sequences
-    "no-throw-literal": 2,           // http://eslint.org/docs/rules/no-throw-literal
-    "no-with": 2,                    // http://eslint.org/docs/rules/no-with
-    "radix": 2,                      // http://eslint.org/docs/rules/radix
-    "vars-on-top": 0,                // http://eslint.org/docs/rules/vars-on-top
-    "wrap-iife": [2, "any"],         // http://eslint.org/docs/rules/wrap-iife
-    "yoda": 2,                       // http://eslint.org/docs/rules/yoda
+    'eqeqeq': 2,                     // http://eslint.org/docs/rules/eqeqeq
+    'guard-for-in': 2,               // http://eslint.org/docs/rules/guard-for-in
+    'no-caller': 2,                  // http://eslint.org/docs/rules/no-caller
+    'no-else-return': 2,             // http://eslint.org/docs/rules/no-else-return
+    'no-eq-null': 2,                 // http://eslint.org/docs/rules/no-eq-null
+    'no-eval': 2,                    // http://eslint.org/docs/rules/no-eval
+    'no-extend-native': 2,           // http://eslint.org/docs/rules/no-extend-native
+    'no-extra-bind': 2,              // http://eslint.org/docs/rules/no-extra-bind
+    'no-fallthrough': 2,             // http://eslint.org/docs/rules/no-fallthrough
+    'no-floating-decimal': 2,        // http://eslint.org/docs/rules/no-floating-decimal
+    'no-implied-eval': 2,            // http://eslint.org/docs/rules/no-implied-eval
+    'no-lone-blocks': 2,             // http://eslint.org/docs/rules/no-lone-blocks
+    'no-loop-func': 2,               // http://eslint.org/docs/rules/no-loop-func
+    'no-multi-str': 2,               // http://eslint.org/docs/rules/no-multi-str
+    'no-native-reassign': 2,         // http://eslint.org/docs/rules/no-native-reassign
+    'no-new': 2,                     // http://eslint.org/docs/rules/no-new
+    'no-new-func': 2,                // http://eslint.org/docs/rules/no-new-func
+    'no-new-wrappers': 2,            // http://eslint.org/docs/rules/no-new-wrappers
+    'no-octal': 2,                   // http://eslint.org/docs/rules/no-octal
+    'no-octal-escape': 2,            // http://eslint.org/docs/rules/no-octal-escape
+    'no-param-reassign': 2,          // http://eslint.org/docs/rules/no-param-reassign
+    'no-proto': 2,                   // http://eslint.org/docs/rules/no-proto
+    'no-redeclare': 2,               // http://eslint.org/docs/rules/no-redeclare
+    'no-return-assign': 2,           // http://eslint.org/docs/rules/no-return-assign
+    'no-script-url': 2,              // http://eslint.org/docs/rules/no-script-url
+    'no-self-compare': 2,            // http://eslint.org/docs/rules/no-self-compare
+    'no-sequences': 2,               // http://eslint.org/docs/rules/no-sequences
+    'no-throw-literal': 2,           // http://eslint.org/docs/rules/no-throw-literal
+    'no-with': 2,                    // http://eslint.org/docs/rules/no-with
+    'radix': 2,                      // http://eslint.org/docs/rules/radix
+    'vars-on-top': 0,                // http://eslint.org/docs/rules/vars-on-top
+    'wrap-iife': [2, 'any'],         // http://eslint.org/docs/rules/wrap-iife
+    'yoda': 2,                       // http://eslint.org/docs/rules/yoda
 
-/**
+    /**
  * Style
  */
-    "indent": [2, 2],                // http://eslint.org/docs/rules/indent
-    "brace-style": [2,               // http://eslint.org/docs/rules/brace-style
-      "1tbs", {
-      "allowSingleLine": true
-    }],
-    "quotes": [
-      2, "single", "avoid-escape"    // http://eslint.org/docs/rules/quotes
+    'indent': [2, 2],                // http://eslint.org/docs/rules/indent
+    'brace-style': [2,               // http://eslint.org/docs/rules/brace-style
+      '1tbs', {
+        'allowSingleLine': true
+      }],
+    'quotes': [
+      2, 'single', 'avoid-escape'    // http://eslint.org/docs/rules/quotes
     ],
-    "camelcase": [2, {               // http://eslint.org/docs/rules/camelcase
-      "properties": "never"
+    'camelcase': [2, {               // http://eslint.org/docs/rules/camelcase
+      'properties': 'never'
     }],
-    "comma-spacing": [2, {           // http://eslint.org/docs/rules/comma-spacing
-      "before": false,
-      "after": true
+    'comma-spacing': [2, {           // http://eslint.org/docs/rules/comma-spacing
+      'before': false,
+      'after': true
     }],
-    "comma-style": [2, "last"],      // http://eslint.org/docs/rules/comma-style
-    "eol-last": 2,                   // http://eslint.org/docs/rules/eol-last
-    "func-names": 1,                 // http://eslint.org/docs/rules/func-names
-    "key-spacing": [2, {             // http://eslint.org/docs/rules/key-spacing
-        "beforeColon": false,
-        "afterColon": true
+    'comma-style': [2, 'last'],      // http://eslint.org/docs/rules/comma-style
+    'eol-last': 2,                   // http://eslint.org/docs/rules/eol-last
+    'func-names': 1,                 // http://eslint.org/docs/rules/func-names
+    'key-spacing': [2, {             // http://eslint.org/docs/rules/key-spacing
+      'beforeColon': false,
+      'afterColon': true
     }],
-    "new-cap": [2, {                 // http://eslint.org/docs/rules/new-cap
-      "newIsCap": true
+    'new-cap': [2, {                 // http://eslint.org/docs/rules/new-cap
+      'newIsCap': true
     }],
-    "no-multiple-empty-lines": [2, { // http://eslint.org/docs/rules/no-multiple-empty-lines
-      "max": 2
+    'no-multiple-empty-lines': [2, { // http://eslint.org/docs/rules/no-multiple-empty-lines
+      'max': 2
     }],
-    "no-nested-ternary": 2,          // http://eslint.org/docs/rules/no-nested-ternary
-    "no-new-object": 2,              // http://eslint.org/docs/rules/no-new-object
-    "no-spaced-func": 2,             // http://eslint.org/docs/rules/no-spaced-func
-    "no-trailing-spaces": 2,         // http://eslint.org/docs/rules/no-trailing-spaces
-    "no-extra-parens": [2, "functions"], // http://eslint.org/docs/rules/no-extra-parens
-    "no-underscore-dangle": 0,       // http://eslint.org/docs/rules/no-underscore-dangle
-    "one-var": [2, "never"],         // http://eslint.org/docs/rules/one-var
-    "padded-blocks": [2, "never"],   // http://eslint.org/docs/rules/padded-blocks
-    "semi": [2, "always"],           // http://eslint.org/docs/rules/semi
-    "semi-spacing": [2, {            // http://eslint.org/docs/rules/semi-spacing
-      "before": false,
-      "after": true
+    'no-nested-ternary': 2,          // http://eslint.org/docs/rules/no-nested-ternary
+    'no-new-object': 2,              // http://eslint.org/docs/rules/no-new-object
+    'no-spaced-func': 2,             // http://eslint.org/docs/rules/no-spaced-func
+    'no-trailing-spaces': 2,         // http://eslint.org/docs/rules/no-trailing-spaces
+    'no-extra-parens': [2, 'functions'], // http://eslint.org/docs/rules/no-extra-parens
+    'no-underscore-dangle': 0,       // http://eslint.org/docs/rules/no-underscore-dangle
+    'one-var': [2, 'never'],         // http://eslint.org/docs/rules/one-var
+    'padded-blocks': [2, 'never'],   // http://eslint.org/docs/rules/padded-blocks
+    'semi': [2, 'always'],           // http://eslint.org/docs/rules/semi
+    'semi-spacing': [2, {            // http://eslint.org/docs/rules/semi-spacing
+      'before': false,
+      'after': true
     }],
-    "keyword-spacing": 2,       // http://eslint.org/docs/rules/keyword-spacing
-    "space-before-blocks": 2,        // http://eslint.org/docs/rules/space-before-blocks
-    "space-before-function-paren": [2, "never"], // http://eslint.org/docs/rules/space-before-function-paren
-    "space-infix-ops": 2,            // http://eslint.org/docs/rules/space-infix-ops
-    "spaced-comment": [2, "always",  {// http://eslint.org/docs/rules/spaced-comment
-      "markers": ["global", "eslint"]
+    'keyword-spacing': 2,       // http://eslint.org/docs/rules/keyword-spacing
+    'space-before-blocks': 2,        // http://eslint.org/docs/rules/space-before-blocks
+    'space-before-function-paren': [2, 'never'], // http://eslint.org/docs/rules/space-before-function-paren
+    'space-infix-ops': 2,            // http://eslint.org/docs/rules/space-infix-ops
+    'spaced-comment': [2, 'always',  {// http://eslint.org/docs/rules/spaced-comment
+      'markers': ['global', 'eslint']
     }]
-  }
-}
+  },
+
+  'ignorePatterns': ['**/env/data.js']
+};

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line strict
 module.exports = function(grunt) {
   require('load-grunt-tasks')(grunt);
 
@@ -37,6 +38,10 @@ module.exports = function(grunt) {
       }
     },
 
+    package2env: {
+      all: {}
+    },
+
     usebanner: {
       all: {
         options: {
@@ -70,8 +75,8 @@ module.exports = function(grunt) {
         src: ['test/unit/**/*.js']
       },
       options: {
-        timeout: 30000,
-      },
+        timeout: 30000
+      }
     },
 
     watch: {
@@ -88,12 +93,12 @@ module.exports = function(grunt) {
     webpack: require('./webpack.config.js')
   });
 
-  grunt.registerMultiTask('package2bower', 'Sync package.json to bower.json', function () {
+  grunt.registerMultiTask('package2bower', 'Sync package.json to bower.json', function() {
     var npm = grunt.file.readJSON('package.json');
     var bower = grunt.file.readJSON('bower.json');
     var fields = this.data.fields || [];
 
-    for (var i=0, l=fields.length; i<l; i++) {
+    for (var i = 0, l = fields.length; i < l; i++) {
       var field = fields[i];
       bower[field] = npm[field];
     }
@@ -101,7 +106,17 @@ module.exports = function(grunt) {
     grunt.file.write('bower.json', JSON.stringify(bower, null, 2));
   });
 
+  grunt.registerMultiTask('package2env', 'Sync package.json to env.json', function() {
+    var npm = grunt.file.readJSON('package.json');
+    grunt.file.write('./lib/env/data.js', [
+      'module.exports = ',
+      JSON.stringify({
+        version: npm.version
+      }, null, 2),
+      ';'].join(''));
+  });
+
   grunt.registerTask('test', 'Run the jasmine and mocha tests', ['eslint', 'mochaTest', 'karma:single', 'ts']);
   grunt.registerTask('build', 'Run webpack and bundle the source', ['clean', 'webpack']);
-  grunt.registerTask('version', 'Sync version info for a release', ['usebanner', 'package2bower']);
+  grunt.registerTask('version', 'Sync version info for a release', ['usebanner', 'package2bower', 'package2env']);
 };

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -10,7 +10,7 @@ var httpFollow = require('follow-redirects').http;
 var httpsFollow = require('follow-redirects').https;
 var url = require('url');
 var zlib = require('zlib');
-var pkg = require('./../../package.json');
+var VERSION = require('./../env/data').version;
 var createError = require('../core/createError');
 var enhanceError = require('../core/enhanceError');
 
@@ -68,7 +68,7 @@ module.exports = function httpAdapter(config) {
       // Otherwise, use specified value
     } else {
       // Only set header if it hasn't been set in config
-      headers['User-Agent'] = 'axios/' + pkg.version;
+      headers['User-Agent'] = 'axios/' + VERSION;
     }
 
     if (data && !utils.isStream(data)) {

--- a/lib/core/Axios.js
+++ b/lib/core/Axios.js
@@ -51,9 +51,9 @@ Axios.prototype.request = function request(config) {
 
   if (transitional !== undefined) {
     validator.assertOptions(transitional, {
-      silentJSONParsing: validators.transitional(validators.boolean, '1.0.0'),
-      forcedJSONParsing: validators.transitional(validators.boolean, '1.0.0'),
-      clarifyTimeoutError: validators.transitional(validators.boolean, '1.0.0')
+      silentJSONParsing: validators.transitional(validators.boolean),
+      forcedJSONParsing: validators.transitional(validators.boolean),
+      clarifyTimeoutError: validators.transitional(validators.boolean)
     }, false);
   }
 

--- a/lib/env/README.md
+++ b/lib/env/README.md
@@ -1,0 +1,3 @@
+# axios // env
+
+The `data.js` file is updated automatically when the package version is upgrading. Please do not edit it manually.

--- a/lib/env/data.js
+++ b/lib/env/data.js
@@ -1,0 +1,3 @@
+module.exports = {
+  "version": "0.21.4"
+};

--- a/lib/helpers/validator.js
+++ b/lib/helpers/validator.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var pkg = require('./../../package.json');
+var VERSION = require('../env/data').version;
 
 var validators = {};
 
@@ -12,48 +12,26 @@ var validators = {};
 });
 
 var deprecatedWarnings = {};
-var currentVerArr = pkg.version.split('.');
-
-/**
- * Compare package versions
- * @param {string} version
- * @param {string?} thanVersion
- * @returns {boolean}
- */
-function isOlderVersion(version, thanVersion) {
-  var pkgVersionArr = thanVersion ? thanVersion.split('.') : currentVerArr;
-  var destVer = version.split('.');
-  for (var i = 0; i < 3; i++) {
-    if (pkgVersionArr[i] > destVer[i]) {
-      return true;
-    } else if (pkgVersionArr[i] < destVer[i]) {
-      return false;
-    }
-  }
-  return false;
-}
 
 /**
  * Transitional option validator
- * @param {function|boolean?} validator
- * @param {string?} version
- * @param {string} message
+ * @param {function|boolean?} validator - set to false if the transitional option has been removed
+ * @param {string?} version - deprecated version / removed since version
+ * @param {string?} message - some message with additional info
  * @returns {function}
  */
 validators.transitional = function transitional(validator, version, message) {
-  var isDeprecated = version && isOlderVersion(version);
-
   function formatMessage(opt, desc) {
-    return '[Axios v' + pkg.version + '] Transitional option \'' + opt + '\'' + desc + (message ? '. ' + message : '');
+    return '[Axios v' + VERSION + '] Transitional option \'' + opt + '\'' + desc + (message ? '. ' + message : '');
   }
 
   // eslint-disable-next-line func-names
   return function(value, opt, opts) {
     if (validator === false) {
-      throw new Error(formatMessage(opt, ' has been removed in ' + version));
+      throw new Error(formatMessage(opt, ' has been removed' + (version ? ' in ' + version : '')));
     }
 
-    if (isDeprecated && !deprecatedWarnings[opt]) {
+    if (version && !deprecatedWarnings[opt]) {
       deprecatedWarnings[opt] = true;
       // eslint-disable-next-line no-console
       console.warn(
@@ -99,7 +77,6 @@ function assertOptions(options, schema, allowUnknown) {
 }
 
 module.exports = {
-  isOlderVersion: isOlderVersion,
   assertOptions: assertOptions,
   validators: validators
 };

--- a/test/specs/helpers/validator.spec.js
+++ b/test/specs/helpers/validator.spec.js
@@ -2,23 +2,8 @@
 
 var validator = require('../../../lib/helpers/validator');
 
-describe('validator::isOlderVersion', function () {
-  it('should return true if dest version is older than the package version', function () {
-    expect(validator.isOlderVersion('0.0.1', '1.0.0')).toEqual(true);
-    expect(validator.isOlderVersion('0.0.1', '0.1.0')).toEqual(true);
-    expect(validator.isOlderVersion('0.0.1', '0.0.1')).toEqual(false);
-
-
-    expect(validator.isOlderVersion('100.0.0', '1.0.0')).toEqual(false);
-    expect(validator.isOlderVersion('100.0.0', '0.1.0')).toEqual(false);
-    expect(validator.isOlderVersion('100.0.0', '0.0.1')).toEqual(false);
-
-    expect(validator.isOlderVersion('0.10000.0', '1000.0.1')).toEqual(true);
-  });
-});
-
-describe('validator::assertOptions', function () {
-  it('should throw only if unknown an option was passed', function () {
+describe('validator::assertOptions', function() {
+  it('should throw only if unknown an option was passed', function() {
     expect(function() {
       validator.assertOptions({
         x: true
@@ -37,7 +22,7 @@ describe('validator::assertOptions', function () {
     }).not.toThrow(new Error('Unknown option x'));
   });
 
-  it('should throw TypeError only if option type doesn\'t match', function () {
+  it('should throw TypeError only if option type doesn\'t match', function() {
     expect(function() {
       validator.assertOptions({
         x: 123


### PR DESCRIPTION
- Added auto-generated `/env/data.js` to import package version into the code instead of importing entire `package.json` (#4028);
- Refactored the logic for showing warnings about the deprecation of transient options;
- Fixed some ESLint issues;

