### PR TITLE
Adding `insecureHTTPParser` property to TypeScript typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -77,6 +77,7 @@ export interface AxiosRequestConfig<T = any> {
   proxy?: AxiosProxyConfig | false;
   cancelToken?: CancelToken;
   decompress?: boolean;
+  insecureHTTPParser?: boolean;
   transitional?: TransitionalOptions
 }
 


### PR DESCRIPTION
Closes #4044