### PR TITLE
Updating deprecated api of abortion in node.js

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -287,6 +287,8 @@ module.exports = function httpAdapter(config) {
       reject(enhanceError(err, config, null, req));
     });
 
+    var abort = (req.destroy || req.abort).bind(req);
+
     // Handle request timeout
     if (config.timeout) {
       // This is forcing a int timeout to avoid problems if the `req` interface doesn't handle other types.
@@ -309,7 +311,7 @@ module.exports = function httpAdapter(config) {
       // And then these socket which be hang up will devoring CPU little by little.
       // ClientRequest.setTimeout will be fired on the specify milliseconds, and can make sure that abort() will be fired after connect.
       req.setTimeout(timeout, function handleRequestTimeout() {
-        req.abort();
+        abort();
         reject(createError(
           'timeout of ' + timeout + 'ms exceeded',
           config,
@@ -323,8 +325,7 @@ module.exports = function httpAdapter(config) {
       // Handle cancellation
       config.cancelToken.promise.then(function onCanceled(cancel) {
         if (req.aborted) return;
-
-        req.abort();
+        abort();
         reject(cancel);
       });
     }


### PR DESCRIPTION
Hi. API `req.abort()` has deprecated since v14.1.0, v13.14.0 in Node.js.

See at [http_request_abort](https://nodejs.org/dist/latest-v16.x/docs/api/http.html#http_request_abort)