### PR TITLE
Adding defaultReject feature and _instanceId property (resolves #3984)

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,7 +456,7 @@ These are the available config options for making requests. Only the `url` is re
   // automatically. If set to `true` will also remove the 'content-encoding' header 
   // from the responses objects of all decompressed responses
   // - Node only (XHR cannot turn off decompression)
-  decompress: true // default
+  decompress: true, // default
 
   // `insecureHTTPParser` boolean.
   // Indicates where to use an insecure HTTP parser that accepts invalid HTTP headers.
@@ -464,7 +464,7 @@ These are the available config options for making requests. Only the `url` is re
   // Using the insecure parser should be avoided.
   // see options https://nodejs.org/dist/latest-v12.x/docs/api/http.html#http_http_request_url_options_callback
   // see also https://nodejs.org/en/blog/vulnerability/february-2020-security-releases/#strict-http-header-parsing-none
-  insecureHTTPParser: undefined // default
+  insecureHTTPParser: undefined, // default
 
   // transitional options for backward compatibility that may be removed in the newer versions
   transitional: {
@@ -478,6 +478,13 @@ These are the available config options for making requests. Only the `url` is re
     
     // throw ETIMEDOUT error instead of generic ECONNABORTED on request timeouts
     clarifyTimeoutError: false,
+  },
+
+  // `defaultReject`, when set to a function, is executed when your axios request is rejected
+  // and you haven't explicitly used a catch block
+  // it implements the unhandledRejection event
+  defaultReject: function (err) {
+    console.log(err.toJSON());
   }
 }
 ```
@@ -684,6 +691,17 @@ axios.get('/user/12345')
     console.log(error.toJSON());
   });
 ```
+
+You can set a default error handler for axios requests; it will be executed only in case you don't explicitly use a catch block.
+
+```js
+axios.defaults.defaultReject = function (error) {
+    console.log(error.toJSON());
+}
+axios.get('/user/12345'); // will print an error in case promise is rejected
+```
+
+> Warning: since this feature implements unhandled rejections, it might terminate the process in certain node environments; if possible, you should use an interceptor instead.
 
 ## Cancellation
 

--- a/README.md
+++ b/README.md
@@ -701,7 +701,8 @@ axios.defaults.defaultReject = function (error) {
 axios.get('/user/12345'); // will print an error in case promise is rejected
 ```
 
-> Warning: since this feature implements unhandled rejections, it might terminate the process in certain node environments; if possible, you should use an interceptor instead.
+> Warning: since this feature implements unhandled rejections, it might terminate the process in certain node environments; if possible, you should use an interceptor instead, or explicit catch blocks.
+Works on browsers that support the unhandledrejection event.
 
 ## Cancellation
 

--- a/README.md
+++ b/README.md
@@ -483,8 +483,8 @@ These are the available config options for making requests. Only the `url` is re
   // `defaultReject`, when set to a function, is executed when your axios request is rejected
   // and you haven't explicitly used a catch block
   // it implements the unhandledRejection event
-  defaultReject: function (err) {
-    console.log(err.toJSON());
+  defaultReject: function (error) {
+    throw error;
   }
 }
 ```

--- a/index.d.ts
+++ b/index.d.ts
@@ -77,7 +77,9 @@ export interface AxiosRequestConfig<T = any> {
   proxy?: AxiosProxyConfig | false;
   cancelToken?: CancelToken;
   decompress?: boolean;
-  transitional?: TransitionalOptions
+  transitional?: TransitionalOptions;
+  readonly instanceId?: number;
+  defaultReject?: ((AxiosError) => any) | null;
 }
 
 export interface AxiosResponse<T = never>  {
@@ -136,6 +138,7 @@ export interface AxiosInterceptorManager<V> {
 
 export class Axios {
   constructor(config?: AxiosRequestConfig);
+  readonly instanceId: number;
   defaults: AxiosRequestConfig;
   interceptors: {
     request: AxiosInterceptorManager<AxiosRequestConfig>;

--- a/lib/axios.js
+++ b/lib/axios.js
@@ -4,6 +4,7 @@ var utils = require('./utils');
 var bind = require('./helpers/bind');
 var Axios = require('./core/Axios');
 var mergeConfig = require('./core/mergeConfig');
+var isAxiosError = require('./helpers/isAxiosError');
 var defaults = require('./defaults');
 
 /**
@@ -27,6 +28,35 @@ function createInstance(defaultConfig) {
     return createInstance(mergeConfig(defaultConfig, instanceConfig));
   };
 
+  // Listen to unhandled rejected axios promises
+  function useDefaultReject(axiosError, unhandledPromiseEvent, promise) {
+    if (
+      isAxiosError(axiosError) &&
+      typeof instance.defaults.defaultReject === 'function' &&
+      // Only execute the defaultReject of the axios instance that was used
+      axiosError.config._instanceId === instance._instanceId
+    ) {
+      promise.catch(function catchUnhandledPromise() {
+        instance.defaults.defaultReject(axiosError);
+        if (typeof unhandledPromiseEvent.preventDefault === 'function') {
+          unhandledPromiseEvent.preventDefault();
+        }
+      });
+    }
+  }
+
+  if (typeof process !== 'undefined' && Object.prototype.toString.call(process) === '[object process]') {
+    // For node use process.addListener
+    process.addListener('unhandledRejection', function handleServerSideUnhandledRejection(e, promise) {
+      useDefaultReject(e, e, promise);
+    });
+  } else if (typeof window !== 'undefined') {
+    // For browsers use window.addEventListener
+    window.addEventListener('unhandledrejection', function handleBrowserSideUnhandledRejection(e) {
+      useDefaultReject(e.reason, e, e.promise);
+    });
+  }
+
   return instance;
 }
 
@@ -48,7 +78,7 @@ axios.all = function all(promises) {
 axios.spread = require('./helpers/spread');
 
 // Expose isAxiosError
-axios.isAxiosError = require('./helpers/isAxiosError');
+axios.isAxiosError = isAxiosError;
 
 module.exports = axios;
 

--- a/lib/axios.js
+++ b/lib/axios.js
@@ -4,8 +4,8 @@ var utils = require('./utils');
 var bind = require('./helpers/bind');
 var Axios = require('./core/Axios');
 var mergeConfig = require('./core/mergeConfig');
-var isAxiosError = require('./helpers/isAxiosError');
 var defaults = require('./defaults');
+var configureDefaultReject = require('./core/configureDefaultReject');
 
 /**
  * Create an instance of Axios
@@ -28,34 +28,8 @@ function createInstance(defaultConfig) {
     return createInstance(mergeConfig(defaultConfig, instanceConfig));
   };
 
-  // Listen to unhandled rejected axios promises
-  function useDefaultReject(axiosError, unhandledPromiseEvent, promise) {
-    if (
-      isAxiosError(axiosError) &&
-      typeof instance.defaults.defaultReject === 'function' &&
-      // Only execute the defaultReject of the axios instance that was used
-      axiosError.config._instanceId === instance._instanceId
-    ) {
-      promise.catch(function catchUnhandledPromise() {
-        instance.defaults.defaultReject(axiosError);
-        if (typeof unhandledPromiseEvent.preventDefault === 'function') {
-          unhandledPromiseEvent.preventDefault();
-        }
-      });
-    }
-  }
-
-  if (utils.isNodeEnv()) {
-    // For node use process.addListener
-    process.addListener('unhandledRejection', function handleServerSideUnhandledRejection(e, promise) {
-      useDefaultReject(e, e, promise);
-    });
-  } else if (typeof window !== 'undefined') {
-    // For browsers use window.addEventListener
-    window.addEventListener('unhandledrejection', function handleBrowserSideUnhandledRejection(e) {
-      useDefaultReject(e.reason, e, e.promise);
-    });
-  }
+  // Configure defaultReject behaviour of this particular instance
+  configureDefaultReject(instance);
 
   return instance;
 }
@@ -78,7 +52,7 @@ axios.all = function all(promises) {
 axios.spread = require('./helpers/spread');
 
 // Expose isAxiosError
-axios.isAxiosError = isAxiosError;
+axios.isAxiosError = require('./helpers/isAxiosError');
 
 module.exports = axios;
 

--- a/lib/axios.js
+++ b/lib/axios.js
@@ -45,7 +45,7 @@ function createInstance(defaultConfig) {
     }
   }
 
-  if (typeof process !== 'undefined' && Object.prototype.toString.call(process) === '[object process]') {
+  if (utils.isNodeEnv()) {
     // For node use process.addListener
     process.addListener('unhandledRejection', function handleServerSideUnhandledRejection(e, promise) {
       useDefaultReject(e, e, promise);

--- a/lib/core/Axios.js
+++ b/lib/core/Axios.js
@@ -8,6 +8,8 @@ var mergeConfig = require('./mergeConfig');
 var validator = require('../helpers/validator');
 
 var validators = validator.validators;
+
+var lastInstanceId = 0;
 /**
  * Create a new instance of Axios
  *
@@ -19,6 +21,8 @@ function Axios(instanceConfig) {
     request: new InterceptorManager(),
     response: new InterceptorManager()
   };
+  // Give unique ID to instance of axios
+  this._instanceId = lastInstanceId++;
 }
 
 /**
@@ -37,6 +41,9 @@ Axios.prototype.request = function request(config) {
   }
 
   config = mergeConfig(this.defaults, config);
+
+  // Bind instance ID to request config
+  config._instanceId = this._instanceId;
 
   // Set config.method
   if (config.method) {

--- a/lib/core/configureDefaultReject.js
+++ b/lib/core/configureDefaultReject.js
@@ -1,0 +1,196 @@
+'use strict';
+
+var isAxiosError = require('../helpers/isAxiosError');
+var utils = require('./../utils');
+
+/**
+ * Call defaultReject function of axios instance if appropriate conditions are met
+ *
+ * @param {Object} instance The axios instance that owns defaultReject
+ * @param {Object} axiosError The axios error linked to the failed request
+ * @param {Object} unhandledPromiseEvent The whole unhandledPromise event
+ * @param {Promise} promise The rejected promise
+ */
+function useDefaultReject(
+  instance,
+  axiosError,
+  unhandledPromiseEvent,
+  promise
+) {
+  if (
+    isAxiosError(axiosError) &&
+	typeof instance.defaults.defaultReject === 'function' &&
+	// Only execute the defaultReject of the axios instance that was used
+	axiosError.config._instanceId === instance._instanceId
+  ) {
+    promise.catch(function catchUnhandledPromise() {
+      instance.defaults.defaultReject(axiosError);
+      if (typeof unhandledPromiseEvent.preventDefault === 'function') {
+        unhandledPromiseEvent.preventDefault();
+      }
+    });
+  }
+}
+
+/**
+ * @typedef EventHandlerReference
+ * @type {object}
+ * @property {Function} handler Function that is executed when event is triggered
+ * @property {string} eventType Type of the handled event
+ */
+var handlerReferences = [];
+
+/**
+ * @callback ListenerRemovalConditionCallback
+ * @param {EventHandlerReference} ref Reference to the handler that should be removed or not
+ * @param {number} index Index of the current ref in the handlerReferences array
+ * @param {Array} array Whole handlerReferences array
+ * @return {boolean} Whether we want to remove the handler or not
+ */
+
+/**
+ * Store references of added handlers in an Array and remove from that
+ *
+ * @param {boolean} attach Whether the listener needs to be added (true) or removed (false)
+ * @param {Function} handler The handler which will be added in case attach is true
+ * @param {Object} target The object on which listener is attached/removed
+ * @param {string} eventType The type of the event we want to listen to
+ * @param {ListenerRemovalConditionCallback} listenerRemovalCondition Callback executed during iteration of handlerReferences.
+ * - Returns a condition at which a listener should be removed
+ * - Removes all listeners by default
+ * @param {Object} [additionalHandlerRefProperties] Object to merge with EventHandlerReference
+ * @param {string} [attachMethodName=addEventListener] The method of target object used to attach a listener;
+ * @param {string} [detachMethodName=removeEventListener] The method of target object used to remove a listener;
+ */
+function listenWithCleanup(attach, handler, target, eventType, listenerRemovalCondition, additionalHandlerRefProperties, attachMethodName, detachMethodName) {
+  if (attach) {
+  	// Add listener
+    target[attachMethodName](eventType, handler);
+
+    // Register reference to handler
+    var refToAdd = { handler: handler, eventType: eventType };
+    if (utils.isPlainObject(additionalHandlerRefProperties)) {
+    	refToAdd = utils.merge(refToAdd, additionalHandlerRefProperties);
+    }
+    handlerReferences.push(refToAdd);
+  } else {
+    // Determine which listeners to remove
+    var toRemove = handlerReferences.filter(function filterRefs(ref, index, array) {
+      var shouldBeRemoved;
+      if (typeof listenerRemovalCondition !== 'function') {
+        shouldBeRemoved = true;
+      } else {
+        shouldBeRemoved = listenerRemovalCondition(ref, index, array);
+      }
+
+      if (shouldBeRemoved) {
+      	// Delete refs of removed event listeners
+      	handlerReferences.splice(index, 1);
+      }
+      return shouldBeRemoved;
+    });
+
+    // Remove listeners
+    utils.forEach(toRemove, function forEachRef(ref) {
+      target[detachMethodName](eventType, ref.handler);
+    });
+  }
+}
+
+/**
+ * Add or remove an unhandledRejection event listener from axios instance
+ * Calls listenWithCleanup with appropriate parameters
+ *
+ * @param {boolean} attach Whether the listener needs to be added (true) or removed (false)
+ * @param {object} instance The axios instance that owns defaultReject
+ */
+function toggleListener(attach, instance) {
+  var handler;
+  var target;
+  var attachMethodName;
+  var detachMethodName;
+  var eventType = 'unhandledrejection';
+
+  // Axios instance can only remove its own listeners
+  var additionalHandlerRefProperties = { _instanceId: instance._instanceId };
+  var listenerRemovalCondition = function listenerRemovalCondition(ref) {
+    return ref._instanceId === instance._instanceId;
+  };
+
+  if (utils.isNodeEnv()) {
+    // For node attach listener on process
+    target = process;
+    attachMethodName = 'addListener';
+    detachMethodName = 'removeListener';
+    handler = function handleServerSideUnhandledRejection(e, promise) {
+      useDefaultReject(instance, e, e, promise);
+    };
+  } else if (typeof window !== 'undefined') {
+    // For browsers attach listener on window
+    target = window;
+    attachMethodName = 'addEventListener';
+    detachMethodName = 'removeEventListener';
+    handler = function handleBrowserSideUnhandledRejection(e) {
+      useDefaultReject(instance, e.reason, e, e.promise);
+    };
+  } else { return; }
+
+  listenWithCleanup(attach, handler, target, eventType, listenerRemovalCondition, additionalHandlerRefProperties, attachMethodName, detachMethodName);
+}
+
+/**
+ * Call toggleListener with attach = true
+ * @param {Object} instance The axios instance
+ */
+function installListener(instance) {
+  toggleListener(true, instance);
+}
+
+/**
+ * Call toggleListener with attach = false
+ * @param {Object} instance The axios instance
+ */
+function ejectListener(instance) {
+  toggleListener(false, instance);
+}
+
+/**
+ * Configure defaultReject at instance creation
+ *
+ * @param {object} axiosInstance The axios instance whose default reject we configure
+ */
+module.exports = function configureDefaultReject(axiosInstance) {
+  // Attach initial event listener
+  if (typeof axiosInstance.defaults.defaultReject === 'function') {
+  	installListener(axiosInstance);
+  }
+
+  // Define setter/getter for defaultReject
+  Object.defineProperties(axiosInstance.defaults, {
+  	_defaultReject: {
+  		value: axiosInstance.defaults.defaultReject,
+  		writable: true, configurable: true
+  	},
+  	defaultReject: {
+	  	get: function getter() {
+	  		return this._defaultReject;
+	  	},
+	    set: function setter(handler) {
+	      if (typeof window !== 'undefined' && typeof window.onunhandledrejection === 'undefined') {
+	      	throw new Error('Your browser does not support the defaultReject feature of axios');
+	      }
+
+		    // Clear previous event listener
+		    ejectListener(axiosInstance);
+
+		    // Replace defaultReject
+		    this._defaultReject = handler;
+
+		    // Attach new listener
+		    if (typeof handler === 'function') {
+	        installListener(axiosInstance);
+		    }
+	    }
+	  }
+  });
+};

--- a/lib/core/mergeConfig.js
+++ b/lib/core/mergeConfig.js
@@ -22,7 +22,7 @@ module.exports = function mergeConfig(config1, config2) {
     'timeout', 'timeoutMessage', 'withCredentials', 'adapter', 'responseType', 'xsrfCookieName',
     'xsrfHeaderName', 'onUploadProgress', 'onDownloadProgress', 'decompress',
     'maxContentLength', 'maxBodyLength', 'maxRedirects', 'transport', 'httpAgent',
-    'httpsAgent', 'cancelToken', 'socketPath', 'responseEncoding'
+    'httpsAgent', 'cancelToken', 'socketPath', 'responseEncoding', 'defaultReject'
   ];
   var directMergeKeys = ['validateStatus'];
 

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -114,7 +114,9 @@ var defaults = {
 
   validateStatus: function validateStatus(status) {
     return status >= 200 && status < 300;
-  }
+  },
+
+  defaultReject: null
 };
 
 defaults.headers = {

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -19,7 +19,7 @@ function getDefaultAdapter() {
   if (typeof XMLHttpRequest !== 'undefined') {
     // For browsers use XHR adapter
     adapter = require('./adapters/xhr');
-  } else if (typeof process !== 'undefined' && Object.prototype.toString.call(process) === '[object process]') {
+  } else if (utils.isNodeEnv()) {
     // For node use HTTP adapter
     adapter = require('./adapters/http');
   }
@@ -116,7 +116,9 @@ var defaults = {
     return status >= 200 && status < 300;
   },
 
-  defaultReject: null
+  defaultReject: function defaultReject(error) {
+    throw error;
+  }
 };
 
 defaults.headers = {

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -116,9 +116,7 @@ var defaults = {
     return status >= 200 && status < 300;
   },
 
-  defaultReject: function defaultReject(error) {
-    throw error;
-  }
+  defaultReject: null
 };
 
 defaults.headers = {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -216,6 +216,16 @@ function isStandardBrowserEnv() {
 }
 
 /**
+ * Determine if we're running in a node environment
+ */
+function isNodeEnv() {
+  return (
+    typeof process !== 'undefined' &&
+    Object.prototype.toString.call(process) === '[object process]'
+  );
+}
+
+/**
  * Iterate over an Array or an Object invoking a function for each item.
  *
  * If `obj` is an Array callback will be called passing
@@ -341,6 +351,7 @@ module.exports = {
   isStream: isStream,
   isURLSearchParams: isURLSearchParams,
   isStandardBrowserEnv: isStandardBrowserEnv,
+  isNodeEnv: isNodeEnv,
   forEach: forEach,
   merge: merge,
   extend: extend,

--- a/test/specs/api.spec.js
+++ b/test/specs/api.spec.js
@@ -45,6 +45,10 @@ describe('static api', function () {
   it('should have isAxiosError properties', function () {
     expect(typeof axios.isAxiosError).toEqual('function');
   });
+
+  it('should have instance ID', function () {
+    expect(axios._instanceId).toEqual(0);
+  });
 });
 
 describe('instance api', function () {
@@ -64,5 +68,9 @@ describe('instance api', function () {
   it('should have interceptors', function () {
     expect(typeof instance.interceptors.request).toEqual('object');
     expect(typeof instance.interceptors.response).toEqual('object');
+  });
+
+  it('should increment instance ID', function () {
+    expect(instance._instanceId).toEqual(1);
   });
 });

--- a/test/specs/defaultReject.spec.js
+++ b/test/specs/defaultReject.spec.js
@@ -16,8 +16,12 @@ describe('defaultReject', function () {
     axios.defaults.defaultReject.calls.reset();
   });
 
-  it('should be null by default', function () {
-  	expect(instanceWithInitialDefaults.defaults.defaultReject).toBe(null);
+  it('should throw an error by default', function () {
+    var myError = new Error('Test error');
+    var myDefaultReject = function () {
+      instanceWithInitialDefaults.defaults.defaultReject(myError);
+    };
+  	expect(myDefaultReject).toThrow(myError);
   });
 
   it('should not be called if axios request was successful', function (done) {

--- a/test/specs/defaultReject.spec.js
+++ b/test/specs/defaultReject.spec.js
@@ -16,12 +16,40 @@ describe('defaultReject', function () {
     axios.defaults.defaultReject.calls.reset();
   });
 
-  it('should throw an error by default', function () {
-    var myError = new Error('Test error');
-    var myDefaultReject = function () {
-      instanceWithInitialDefaults.defaults.defaultReject(myError);
-    };
-  	expect(myDefaultReject).toThrow(myError);
+  it('should be null by default', function () {
+  	expect(instanceWithInitialDefaults.defaults.defaultReject).toBe(null);
+  });
+
+  describe('defaultReject setter', function () {
+    beforeEach(function () {
+      spyOn(window, 'addEventListener').and.callThrough();
+      spyOn(window, 'removeEventListener').and.callThrough();
+    });
+
+    afterEach(function () {
+      window.addEventListener.calls.reset();
+      window.removeEventListener.calls.reset();
+    });
+
+    it('should clear/add an unhandledrejection event listener when set to a function', function () {
+      instanceWithInitialDefaults.defaults.defaultReject = function () {
+        return 'Testing behaviour of defaultReject setter';
+      };
+      expect(window.addEventListener).toHaveBeenCalled();
+    });
+
+    it('should clear its event listener(s) when set to any other value', function () {
+      instanceWithInitialDefaults.defaults.defaultReject = null;
+      expect(window.removeEventListener).toHaveBeenCalled();
+    });
+
+    it('should throw an error if browser does not support the unhandledrejection event', function () {
+      spyOnProperty(window, 'onunhandledrejection', 'get').and.returnValue(undefined);
+      function setDefaultReject() {
+        instance.defaults.defaults = function () { return ('Setting this should throw an error'); }
+      }
+      expect(setDefaultReject).toThrow();
+    });
   });
 
   it('should not be called if axios request was successful', function (done) {

--- a/test/specs/defaultReject.spec.js
+++ b/test/specs/defaultReject.spec.js
@@ -1,0 +1,111 @@
+describe('defaultReject', function () {
+  var instanceWithInitialDefaults = axios.create();
+
+  axios.defaults.defaultReject = function (axiosError) {
+    expect(axiosError instanceof Error).toBe(true);
+    expect(axios.isAxiosError(axiosError)).toBe(true);
+  }
+
+  beforeEach(function () {
+    jasmine.Ajax.install();
+    spyOn(axios.defaults, 'defaultReject').and.callThrough();
+  });
+
+  afterEach(function () {
+    jasmine.Ajax.uninstall();
+    axios.defaults.defaultReject.calls.reset();
+  });
+
+  it('should be null by default', function () {
+  	expect(instanceWithInitialDefaults.defaults.defaultReject).toBe(null);
+  });
+
+  it('should not be called if axios request was successful', function (done) {
+  	axios.get('www.someurl.com/foo')
+
+  	getAjaxRequest().then(function (request) {
+      request.respondWith({
+        status: 200,
+        statusText: 'OK',
+        responseText: '{"foo": "bar"}',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      });
+
+      setTimeout(function () {
+        expect(axios.defaults.defaultReject).not.toHaveBeenCalled();
+        done();
+      }, 100);
+    });
+  });
+
+  it('should not be called if a catch block was set manually', function (done) {
+  	var manualCatch = jasmine.createSpy();
+  	axios.get('www.someurl.com/foo')
+  		.catch(manualCatch);
+
+  	getAjaxRequest().then(function (request) {
+      request.respondWith({
+        status: 404,
+        statusText: 'NOT FOUND',
+        responseText: 'Resource not found'
+      });
+
+      setTimeout(function () {
+        expect(axios.defaults.defaultReject).not.toHaveBeenCalled();
+        expect(manualCatch).toHaveBeenCalled();
+        done();
+      }, 100);
+    });
+  });
+
+
+  // Following specs should trigger an unhandledpromise event
+
+  /*it('should be called with AxiosError otherwise', function (done) {
+  	axios.get('www.someurl.com/foo');
+
+  	getAjaxRequest().then(function (request) {
+      request.respondWith({
+        status: 404,
+        statusText: 'NOT FOUND',
+        responseText: 'Resource not found'
+      });
+
+      setTimeout(function () {
+      	// Only instance2's default reject should have been called
+        expect(axios.defaults.defaultReject).toHaveBeenCalled();
+        done();
+      }, 100);
+    });
+  });*/
+
+  /*it('should only be called by the same instance that sent the request', function (done) {
+  	var instance1DefaultReject = jasmine.createSpy();
+  	var instance2DefaultReject = jasmine.createSpy();
+
+  	var instance1 = axios.create();
+  	instance1.defaults.defaultReject = instance1DefaultReject;
+  	var instance2 = axios.create();
+  	instance2.defaults.defaultReject = instance2DefaultReject;
+
+  	// instance2 sends the request
+  	instance2.get('www.someurl.com/foo');
+
+  	getAjaxRequest().then(function (request) {
+      request.respondWith({
+        status: 404,
+        statusText: 'NOT FOUND',
+        responseText: 'Resource not found'
+      });
+
+      setTimeout(function () {
+      	// Only instance2's default reject should have been called
+        expect(instance2.defaults.defaultReject).toHaveBeenCalled();
+        expect(instance1.defaults.defaultReject).not.toHaveBeenCalled();
+        done();
+      }, 100);
+    });
+  });*/
+});

--- a/test/specs/instance.spec.js
+++ b/test/specs/instance.spec.js
@@ -111,4 +111,17 @@ describe('instance', function () {
       }, 100);
     });
   });
+
+  it('should have its _instanceId incremented every time a new instance is created', function () {
+    var instance1 = axios.create();
+    var instance2 = axios.create();
+    var instance3 = axios.create();
+    var instance4 = axios.create();
+
+    var firstInstanceId = instance1._instanceId;
+
+    expect(instance2._instanceId).toEqual(firstInstanceId + 1);
+    expect(instance3._instanceId).toEqual(firstInstanceId + 2);
+    expect(instance4._instanceId).toEqual(firstInstanceId + 3);
+  });
 });


### PR DESCRIPTION
The only way I could find to implement this feature was by listening to the 'unhandledRejection' event.
I've added an _instanceId property to axios instances, that is incremented every time a new instance is created; this way, when the unhandledRejection event happens, only the defaultReject of the same instance that sent the request is executed.

However, I was unable to come up with a way to test this, as Jasmine does not accept unhandled promise rejections ...