### PR TITLE
Fix node version on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,6 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node }}
+          node-version: ${{ matrix.node-version }}
       - run: npm install
       - run: npm test


### PR DESCRIPTION
Fixes https://github.com/axios/axios/pull/3938#issuecomment-920732901

Tested in a different repo, as I was unsure about the `matrix.node-version` syntax, but it works as expected.