### PR TITLE
Revert "Improved type-safety for AxiosRequestConfig (#2995)"

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -47,7 +47,7 @@ export interface TransitionalOptions{
   clarifyTimeoutError: boolean;
 }
 
-export interface AxiosRequestConfig<T = any> {
+export interface AxiosRequestConfig {
   url?: string;
   method?: Method;
   baseURL?: string;
@@ -56,7 +56,7 @@ export interface AxiosRequestConfig<T = any> {
   headers?: Record<string, string>;
   params?: any;
   paramsSerializer?: (params: any) => string;
-  data?: T;
+  data?: any;
   timeout?: number;
   timeoutErrorMessage?: string;
   withCredentials?: boolean;
@@ -86,7 +86,7 @@ export interface AxiosResponse<T = never>  {
   status: number;
   statusText: string;
   headers: Record<string, string>;
-  config: AxiosRequestConfig<T>;
+  config: AxiosRequestConfig;
   request?: any;
 }
 
@@ -143,14 +143,14 @@ export class Axios {
     response: AxiosInterceptorManager<AxiosResponse>;
   };
   getUri(config?: AxiosRequestConfig): string;
-  request<T = never, R = AxiosResponse<T>> (config: AxiosRequestConfig<T>): Promise<R>;
-  get<T = never, R = AxiosResponse<T>>(url: string, config?: AxiosRequestConfig<T>): Promise<R>;
-  delete<T = never, R = AxiosResponse<T>>(url: string, config?: AxiosRequestConfig<T>): Promise<R>;
-  head<T = never, R = AxiosResponse<T>>(url: string, config?: AxiosRequestConfig<T>): Promise<R>;
-  options<T = never, R = AxiosResponse<T>>(url: string, config?: AxiosRequestConfig<T>): Promise<R>;
-  post<T = never, R = AxiosResponse<T>>(url: string, data?: T, config?: AxiosRequestConfig<T>): Promise<R>;
-  put<T = never, R = AxiosResponse<T>>(url: string, data?: T, config?: AxiosRequestConfig<T>): Promise<R>;
-  patch<T = never, R = AxiosResponse<T>>(url: string, data?: T, config?: AxiosRequestConfig<T>): Promise<R>;
+  request<T = any, R = AxiosResponse<T>> (config: AxiosRequestConfig): Promise<R>;
+  get<T = any, R = AxiosResponse<T>>(url: string, config?: AxiosRequestConfig): Promise<R>;
+  delete<T = any, R = AxiosResponse<T>>(url: string, config?: AxiosRequestConfig): Promise<R>;
+  head<T = any, R = AxiosResponse<T>>(url: string, config?: AxiosRequestConfig): Promise<R>;
+  options<T = any, R = AxiosResponse<T>>(url: string, config?: AxiosRequestConfig): Promise<R>;
+  post<T = any, R = AxiosResponse<T>>(url: string, data?: any, config?: AxiosRequestConfig): Promise<R>;
+  put<T = any, R = AxiosResponse<T>>(url: string, data?: any, config?: AxiosRequestConfig): Promise<R>;
+  patch<T = any, R = AxiosResponse<T>>(url: string, data?: any, config?: AxiosRequestConfig): Promise<R>;
 }
 
 export interface AxiosInstance extends Axios {

--- a/test/typescript/axios.ts
+++ b/test/typescript/axios.ts
@@ -111,10 +111,6 @@ axios.patch('/user', { foo: 'bar' })
   .catch(handleError);
 
 // Typed methods
-interface UserCreationDef {
-    name: string;
-}
-
 interface User {
   id: number;
   name: string;
@@ -142,7 +138,7 @@ axios.get<User>('/user', { params: { id: 12345 } })
 axios.head<User>('/user')
 	.then(handleUserResponse)
     .catch(handleError);
-
+    
 axios.options<User>('/user')
 	.then(handleUserResponse)
 	.catch(handleError);
@@ -151,19 +147,19 @@ axios.delete<User>('/user')
 	.then(handleUserResponse)
 	.catch(handleError);
 
-axios.post<User>('/user', { name: 'foo', id: 1 })
+axios.post<User>('/user', { foo: 'bar' })
 	.then(handleUserResponse)
 	.catch(handleError);
 
-axios.post<User>('/user', { name: 'foo', id: 1 }, { headers: { 'X-FOO': 'bar' } })
+axios.post<User>('/user', { foo: 'bar' }, { headers: { 'X-FOO': 'bar' } })
 	.then(handleUserResponse)
 	.catch(handleError);
 
-axios.put<User>('/user', { name: 'foo', id: 1 })
+axios.put<User>('/user', { foo: 'bar' })
 	.then(handleUserResponse)
 	.catch(handleError);
 
-axios.patch<User>('/user', { name: 'foo', id: 1 })
+axios.patch<User>('/user', { foo: 'bar' })
 	.then(handleUserResponse)
   .catch(handleError);
 
@@ -193,19 +189,19 @@ axios.delete<User, string>('/user')
   .then(handleStringResponse)
   .catch(handleError);
 
-axios.post<Partial<UserCreationDef>, string>('/user', { name: 'foo' })
+axios.post<User, string>('/user', { foo: 'bar' })
   .then(handleStringResponse)
   .catch(handleError);
 
-axios.post<Partial<UserCreationDef>, string>('/user', { name: 'foo' }, { headers: { 'X-FOO': 'bar' } })
+axios.post<User, string>('/user', { foo: 'bar' }, { headers: { 'X-FOO': 'bar' } })
   .then(handleStringResponse)
   .catch(handleError);
 
-axios.put<Partial<UserCreationDef>, string>('/user', { name: 'foo' })
+axios.put<User, string>('/user', { foo: 'bar' })
   .then(handleStringResponse)
   .catch(handleError);
 
-axios.patch<Partial<UserCreationDef>, string>('/user', { name: 'foo' })
+axios.patch<User, string>('/user', { foo: 'bar' })
   .then(handleStringResponse)
   .catch(handleError);
 


### PR DESCRIPTION
This reverts commit 4eeb3b17e28581e6931ad7b78dcc025cf3f99bc8.

The reverted commit assumed the request and response body have to be of the same type. This makes axios 0.22.0 unusable with TypeScript.

Refs #2995
Closes #4109