### PR TITLE
chore(docs): rename Angular to AngularJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -885,7 +885,7 @@ You can use Gitpod an online IDE(which is free for Open Source) for contributing
 
 ## Credits
 
-axios is heavily inspired by the [$http service](https://docs.angularjs.org/api/ng/service/$http) provided in [Angular](https://angularjs.org/). Ultimately axios is an effort to provide a standalone `$http`-like service for use outside of Angular.
+axios is heavily inspired by the [$http service](https://docs.angularjs.org/api/ng/service/$http) provided in [AngularJS](https://angularjs.org/). Ultimately axios is an effort to provide a standalone `$http`-like service for use outside of Angular.
 
 ## License
 


### PR DESCRIPTION
As we all know, Angular and AngularJS are separate, and now we often say Angular refers to Angular2+.