### PR TITLE
Fix missing semicolon in typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -77,7 +77,7 @@ export interface AxiosRequestConfig<T = any> {
   proxy?: AxiosProxyConfig | false;
   cancelToken?: CancelToken;
   decompress?: boolean;
-  transitional?: TransitionalOptions
+  transitional?: TransitionalOptions;
   signal?: AbortSignal;
 }
 


### PR DESCRIPTION
Adds a missing semicolon in the type declaration for `AxiosRequestConfig`.