### PR TITLE
Fix header type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -53,7 +53,7 @@ export interface AxiosRequestConfig<T = any> {
   baseURL?: string;
   transformRequest?: AxiosTransformer | AxiosTransformer[];
   transformResponse?: AxiosTransformer | AxiosTransformer[];
-  headers?: Record<string, string>;
+  headers?: Record<string, string | boolean | undefined>;
   params?: any;
   paramsSerializer?: (params: any) => string;
   data?: T;


### PR DESCRIPTION
The previous version of Axios allowed to put any object to request headers, but after switching to version 0.22.0 header types has been changed
![image](https://user-images.githubusercontent.com/7945837/135855955-3b573e48-8ce3-4324-8c99-a3a85f392b5b.png)

Current PR extends headers value type and comes back to the previous behavior of Axios.