### PR TITLE
Move response type generic to last

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -225,17 +225,17 @@ export class Axios {
     response: AxiosInterceptorManager<AxiosResponse>;
   };
   getUri(config?: AxiosRequestConfig): string;
-  request<T = any, D = any, R = AxiosResponse<T, D>> (config: AxiosRequestConfig<D>): Promise<R>;
-  get<T = any, D = any, R = AxiosResponse<T, D>>(url: string, config?: AxiosRequestConfig<D>): Promise<R>;
-  delete<T = any, D = any, R = AxiosResponse<T, D>>(url: string, config?: AxiosRequestConfig<D>): Promise<R>;
-  head<T = any, D = any, R = AxiosResponse<T, D>>(url: string, config?: AxiosRequestConfig<D>): Promise<R>;
-  options<T = any, D = any, R = AxiosResponse<T, D>>(url: string, config?: AxiosRequestConfig<D>): Promise<R>;
-  post<T = any, D = any, R = AxiosResponse<T, D>>(url: string, data?: D, config?: AxiosRequestConfig<D>): Promise<R>;
-  put<T = any, D = any, R = AxiosResponse<T, D>>(url: string, data?: D, config?: AxiosRequestConfig<D>): Promise<R>;
-  patch<T = any, D = any, R = AxiosResponse<T, D>>(url: string, data?: D, config?: AxiosRequestConfig<D>): Promise<R>;
-  postForm<T = any, D = any, R = AxiosResponse<T, D>>(url: string, data?: D, config?: AxiosRequestConfig<D>): Promise<R>;
-  putForm<T = any, D = any, R = AxiosResponse<T, D>>(url: string, data?: D, config?: AxiosRequestConfig<D>): Promise<R>;
-  patchForm<T = any, D = any, R = AxiosResponse<T, D>>(url: string, data?: D, config?: AxiosRequestConfig<D>): Promise<R>;
+  request<T = any, D = any, R = AxiosResponse<T>>(config: AxiosRequestConfig<D>): Promise<R>;
+  get<T = any, D = any, R = AxiosResponse<T>>(url: string, config?: AxiosRequestConfig<D>): Promise<R>;
+  delete<T = any, D = any, R = AxiosResponse<T>>(url: string, config?: AxiosRequestConfig<D>): Promise<R>;
+  head<T = any, D = any, R = AxiosResponse<T>>(url: string, config?: AxiosRequestConfig<D>): Promise<R>;
+  options<T = any, D = any, R = AxiosResponse<T>>(url: string, config?: AxiosRequestConfig<D>): Promise<R>;
+  post<T = any, D = any, R = AxiosResponse<T>>(url: string, data?: D, config?: AxiosRequestConfig<D>): Promise<R>;
+  put<T = any, D = any, R = AxiosResponse<T>>(url: string, data?: D, config?: AxiosRequestConfig<D>): Promise<R>;
+  patch<T = any, D = any, R = AxiosResponse<T>>(url: string, data?: D, config?: AxiosRequestConfig<D>): Promise<R>;
+  postForm<T = any, D = any, R = AxiosResponse<T>>(url: string, data?: D, config?: AxiosRequestConfig<D>): Promise<R>;
+  putForm<T = any, D = any, R = AxiosResponse<T>>(url: string, data?: D, config?: AxiosRequestConfig<D>): Promise<R>;
+  patchForm<T = any, D = any, R = AxiosResponse<T>>(url: string, data?: D, config?: AxiosRequestConfig<D>): Promise<R>;
 }
 
 export interface AxiosInstance extends Axios {


### PR DESCRIPTION
This is breaking change.

current implementation
```ts
post<T = never, R = AxiosResponse<T>, D = any>(url: string, data?: D, config?: AxiosRequestConfig<D>): Promise<R>;
```

user who want to type its request data need to fill second generic
```ts
axios.post<ResponseData, AxiosResponse<ResponseData>, RequestData>(...)
```

it should be
```ts
axios.post<ResponseData, RequestData>(...)
```

or if they change response object
```ts
axios.post<ResponseData, RequestData, CustomResponse>(...)
```

people rarely changing response object (from interceptor),  so `R = AxiosResponse` should placed on last.

Follow up https://github.com/axios/axios/pull/4116