### PR TITLE
Fixed app crash on passing null to axios.isAxiosError. Based on issue…

### DIFF
--- a/lib/helpers/isAxiosError.js
+++ b/lib/helpers/isAxiosError.js
@@ -7,5 +7,10 @@
  * @returns {boolean} True if the payload is an error thrown by Axios, otherwise false
  */
 module.exports = function isAxiosError(payload) {
-  return (typeof payload === 'object') && (payload.isAxiosError === true);
+  if(payload === null){
+    return false;
+  }
+  else{
+    return (typeof payload === 'object') && (payload.isAxiosError === true);
+  }
 };


### PR DESCRIPTION
… #4172

App crashed when null is passed to isAxiosError #4172. This issue was raised 2 days back, I did a quick fix by returning false in case null is passed.
