### PR TITLE
revert: change type of AxiosResponse to any

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -15,7 +15,7 @@ export interface AxiosResponseTransformer {
 }
 
 export interface AxiosAdapter {
-  (config: AxiosRequestConfig): AxiosPromise<any>;
+  (config: AxiosRequestConfig): AxiosPromise;
 }
 
 export interface AxiosBasicCredentials {

--- a/test/typescript/axios.ts
+++ b/test/typescript/axios.ts
@@ -296,7 +296,7 @@ axios.interceptors.response.use((response: AxiosResponse) => Promise.resolve(res
 // Adapters
 
 const adapter: AxiosAdapter = (config: AxiosRequestConfig) => {
-  const response: AxiosResponse<any> = {
+  const response: AxiosResponse = {
     data: { foo: 'bar' },
     status: 200,
     statusText: 'OK',


### PR DESCRIPTION
This pull request fixes #4141 by reverting the change implemented in #3002 (changed the type of AxiosResponse to any).