### PR TITLE
adding create instance config type as AxiosRequestConfig does not if always

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -112,6 +112,10 @@ export interface AxiosDefaults<D = any> extends Omit<AxiosRequestConfig<D>, 'hea
   headers: HeadersDefaults;
 }
 
+export interface AxiosInstanceConfig<D = any> extends Omit<AxiosRequestConfig<D>, 'headers'> {
+  headers?: Partial<HeadersDefaults> | AxiosRequestHeaders;
+}
+
 export interface AxiosResponse<T = unknown, D = any>  {
   data: T;
   status: number;
@@ -190,7 +194,7 @@ export interface AxiosInstance extends Axios {
 }
 
 export interface AxiosStatic extends AxiosInstance {
-  create(config?: AxiosRequestConfig): AxiosInstance;
+  create(config?: AxiosInstanceConfig): AxiosInstance;
   Cancel: CancelStatic;
   CancelToken: CancelTokenStatic;
   Axios: typeof Axios;


### PR DESCRIPTION
Fixes #4184

Allows to pass different type of axios config (modified AxiosRequestConfig) for axios.create. So code example below does not throw typescript error.

`axios.create({
  ...,
  headers: {
    get: { 'common-header-for-get': 'value' },
    'some-header-for-all-methods': 'value'
  },
});`

which works fine if using javascript lib version w/o typescript.

