### PR TITLE
Update types to include newly added Interceptor Options

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -162,7 +162,7 @@ export interface CancelTokenSource {
 }
 
 export interface AxiosInterceptorOptions {
-  runWhen?: (config: HttpRequestConfig) => boolean | undefined;
+  runWhen?: (config: AxiosRequestConfig) => boolean | undefined;
   synchronous?: boolean;
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -161,8 +161,17 @@ export interface CancelTokenSource {
   cancel: Canceler;
 }
 
+export interface AxiosInterceptorOptions {
+  runWhen?: (config: HttpRequestConfig) => boolean | undefined;
+  synchronous?: boolean;
+}
+
 export interface AxiosInterceptorManager<V> {
-  use<T = V>(onFulfilled?: (value: V) => T | Promise<T>, onRejected?: (error: any) => any): number;
+  use<T = V>(
+    onFulfilled?: (value: V) => T | Promise<T>,
+    onRejected?: (error: any) => any,
+    options?: AxiosInterceptorOptions
+  ): number;
   eject(id: number): void;
 }
 


### PR DESCRIPTION
Updates Typescript definition file to include types for the interceptor options that were added in #2702 so that Typescript users are able to safely consume this feature.