### PR TITLE
Remove unnecessary checks in default transformRequest

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -8,8 +8,9 @@ var DEFAULT_CONTENT_TYPE = {
   'Content-Type': 'application/x-www-form-urlencoded'
 };
 
-function setContentTypeIfUnset(headers, value) {
-  if (!utils.isUndefined(headers) && utils.isUndefined(headers['Content-Type'])) {
+function setContentTypeIfUnset(
+, value) {
+  if (utils.isUndefined(headers['Content-Type'])) {
     headers['Content-Type'] = value;
   }
 }
@@ -71,7 +72,7 @@ var defaults = {
       setContentTypeIfUnset(headers, 'application/x-www-form-urlencoded;charset=utf-8');
       return data.toString();
     }
-    if (utils.isObject(data) || (headers && headers['Content-Type'] === 'application/json')) {
+    if (utils.isObject(data) || (headers['Content-Type'] === 'application/json')) {
       setContentTypeIfUnset(headers, 'application/json');
       return stringifySafely(data);
     }


### PR DESCRIPTION
`transformRequest` callbacks can always expect their `headers`
parameter to be defined. This is ensured immediately before the callback
is made.
See: https://github.com/axios/axios/blob/1025d1231a7747503188459dd5a6d1effdcea928/lib/core/dispatchRequest.js#L32-L40

Accordingly, checking whether `headers` is `undefined` is unnecessary.

This is related to #4201.