### PR TITLE
Fixing type inference of return value

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -174,14 +174,14 @@ export class Axios {
     response: AxiosInterceptorManager<AxiosResponse>;
   };
   getUri(config?: AxiosRequestConfig): string;
-  request<T = any, R = AxiosResponse<T>, D = any>(config: AxiosRequestConfig<D>): Promise<R>;
-  get<T = any, R = AxiosResponse<T>, D = any>(url: string, config?: AxiosRequestConfig<D>): Promise<R>;
-  delete<T = any, R = AxiosResponse<T>, D = any>(url: string, config?: AxiosRequestConfig<D>): Promise<R>;
-  head<T = any, R = AxiosResponse<T>, D = any>(url: string, config?: AxiosRequestConfig<D>): Promise<R>;
-  options<T = any, R = AxiosResponse<T>, D = any>(url: string, config?: AxiosRequestConfig<D>): Promise<R>;
-  post<T = any, R = AxiosResponse<T>, D = any>(url: string, data?: D, config?: AxiosRequestConfig<D>): Promise<R>;
-  put<T = any, R = AxiosResponse<T>, D = any>(url: string, data?: D, config?: AxiosRequestConfig<D>): Promise<R>;
-  patch<T = any, R = AxiosResponse<T>, D = any>(url: string, data?: D, config?: AxiosRequestConfig<D>): Promise<R>;
+  request<T = any, R extends AxiosResponse = AxiosResponse<T>, D = any>(config: AxiosRequestConfig<D>): Promise<R>;
+  get<T = any, R extends AxiosResponse = AxiosResponse<T>, D = any>(url: string, config?: AxiosRequestConfig<D>): Promise<R>;
+  delete<T = any, R extends AxiosResponse = AxiosResponse<T>, D = any>(url: string, config?: AxiosRequestConfig<D>): Promise<R>;
+  head<T = any, R extends AxiosResponse = AxiosResponse<T>, D = any>(url: string, config?: AxiosRequestConfig<D>): Promise<R>;
+  options<T = any, R extends AxiosResponse = AxiosResponse<T>, D = any>(url: string, config?: AxiosRequestConfig<D>): Promise<R>;
+  post<T = any, R extends AxiosResponse = AxiosResponse<T>, D = any>(url: string, data?: D, config?: AxiosRequestConfig<D>): Promise<R>;
+  put<T = any, R extends AxiosResponse = AxiosResponse<T>, D = any>(url: string, data?: D, config?: AxiosRequestConfig<D>): Promise<R>;
+  patch<T = any, R extends AxiosResponse = AxiosResponse<T>, D = any>(url: string, data?: D, config?: AxiosRequestConfig<D>): Promise<R>;
 }
 
 export interface AxiosInstance extends Axios {

--- a/test/typescript/axios.ts
+++ b/test/typescript/axios.ts
@@ -1,13 +1,7 @@
 import axios, {
-  AxiosRequestConfig,
-  AxiosResponse,
-  AxiosError,
-  AxiosInstance,
-  AxiosAdapter,
-  Cancel,
-  CancelToken,
-  CancelTokenSource,
-  Canceler
+  AxiosAdapter, AxiosError,
+  AxiosInstance, AxiosRequestConfig,
+  AxiosResponse, Cancel, Canceler, CancelTokenSource
 } from 'axios';
 
 const config: AxiosRequestConfig = {
@@ -173,47 +167,57 @@ const handleStringResponse = (response: string) => {
   console.log(response);
 };
 
-axios.get<User, string>('/user?id=12345')
-  .then(handleStringResponse)
+axios.get<User, AxiosResponse<string>>('/user?id=12345')
+  .then(handleResponse)
   .catch(handleError);
 
-axios.get<User, string>('/user', { params: { id: 12345 } })
-  .then(handleStringResponse)
+axios.get<User, AxiosResponse<string>>('/user', { params: { id: 12345 } })
+  .then(handleResponse)
   .catch(handleError);
 
-axios.head<User, string>('/user')
-  .then(handleStringResponse)
+axios.head<User, AxiosResponse<string>>('/user')
+  .then(handleResponse)
   .catch(handleError);
 
-axios.options<User, string>('/user')
-  .then(handleStringResponse)
+axios.options<User, AxiosResponse<string>>('/user')
+  .then(handleResponse)
   .catch(handleError);
 
-axios.delete<User, string>('/user')
-  .then(handleStringResponse)
+axios.delete<User, AxiosResponse<string>>('/user')
+  .then(handleResponse)
   .catch(handleError);
 
-axios.post<Partial<UserCreationDef>, string>('/user', { name: 'foo' })
-  .then(handleStringResponse)
+axios.post<Partial<UserCreationDef>, AxiosResponse<string>>('/user', {
+    name: 'foo',
+  })
+  .then(handleResponse)
   .catch(handleError);
 
-axios.post<Partial<UserCreationDef>, string>('/user', { name: 'foo' }, { headers: { 'X-FOO': 'bar' } })
-  .then(handleStringResponse)
+axios.post<Partial<UserCreationDef>, AxiosResponse<string>>(
+    '/user',
+    { name: 'foo' },
+    { headers: { 'X-FOO': 'bar' } }
+  )
+  .then(handleResponse)
   .catch(handleError);
 
-axios.put<Partial<UserCreationDef>, string>('/user', { name: 'foo' })
-  .then(handleStringResponse)
+axios.put<Partial<UserCreationDef>, AxiosResponse<string>>('/user', {
+    name: 'foo',
+  })
+  .then(handleResponse)
   .catch(handleError);
 
-axios.patch<Partial<UserCreationDef>, string>('/user', { name: 'foo' })
-  .then(handleStringResponse)
+axios.patch<Partial<UserCreationDef>, AxiosResponse<string>>('/user', {
+    name: 'foo',
+  })
+  .then(handleResponse)
   .catch(handleError);
 
-axios.request<User, string>({
+axios.request<User, AxiosResponse<string>>({
   method: 'get',
-  url: '/user?id=12345'
+  url: '/user?id=12345',
 })
-  .then(handleStringResponse)
+  .then(handleResponse)
   .catch(handleError);
 
 // Instances


### PR DESCRIPTION
This is a breaking change.

I fixed to change the type definition of each method.
Now, It's not inferred as AxiosResponse because inference from the return value takes precedence. If the return value is a type other than the AxiosResponse type, to occur to compile error,  I extended generic type.

Fix #4253