### PR TITLE
Add the `responseEncoding` type to `AxiosRequestConfig`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -53,6 +53,16 @@ export type ResponseType =
   | 'text'
   | 'stream';
 
+export type ResponseEncoding =
+  | 'utf8'
+  | 'utf16le'
+  | 'latin1'
+  | 'base64'
+  | 'hex'
+  | 'ascii'
+  | 'binary'
+  | 'usc2';
+
 export interface TransitionalOptions {
   silentJSONParsing?: boolean;
   forcedJSONParsing?: boolean;
@@ -75,6 +85,7 @@ export interface AxiosRequestConfig<D = any> {
   adapter?: AxiosAdapter;
   auth?: AxiosBasicCredentials;
   responseType?: ResponseType;
+  responseEncoding?: ResponseEncoding;
   xsrfCookieName?: string;
   xsrfHeaderName?: string;
   onUploadProgress?: (progressEvent: any) => void;


### PR DESCRIPTION
issue: https://github.com/axios/axios/issues/4285
 
Used this https://nodejs.org/api/buffer.html#buffers-and-character-encodings to identify which NodeJS encodings to list.