### PR TITLE
Adding better error message when URL protocol is missing (#4244)

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -122,7 +122,7 @@ module.exports = function httpAdapter(config) {
     if (!config.socketPath) {
       if (!fullPath.match(/^[^:]+:\/\//i)) {
         reject(createError(
-          'URL is missing the protocol e.g. http://',
+          'URL is missing the protocol (e.g. http://)',
           config,
           'URL_PROTOCOL_MISSING'
         ));

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -117,6 +117,18 @@ module.exports = function httpAdapter(config) {
 
     // Parse url
     var fullPath = buildFullPath(config.baseURL, config.url);
+
+    // If we have a socket path we don't need to test for a protocol as we don't use the hostname
+    if (!config.socketPath) {
+      if (!fullPath.match(/^[^:]+:\/\//i)) {
+        reject(createError(
+          'URL is missing the protocol e.g. http://',
+          config,
+          'URL_PROTOCOL_MISSING'
+        ));
+      }
+    }
+
     var parsed = url.parse(fullPath);
     var protocol = parsed.protocol || 'http:';
 

--- a/test/unit/adapters/http.js
+++ b/test/unit/adapters/http.js
@@ -1034,5 +1034,16 @@ describe('supports http with nodejs', function () {
     });
   });
 
+  it('should not accept an URL without protocol', function (done) {
+    server = http.createServer(function (req, res) {
+      res.end();
+    }).listen(4444, function () {
+      axios.get('localhost:4444/').catch(function (error) {
+        assert.strictEqual(error.code, 'URL_PROTOCOL_MISSING');
+        done();
+      });
+    });
+  });
+
 });
 


### PR DESCRIPTION
As proposed in #4244 and requested by @jasonsaayman, we (@ElmarFrerichs and myself) added a test that provides a distinct error message if no protocol is defined in the URL.

A few side notes:
* We exclude sockets from the test as the parsed hostname is not used when a providing a socket path.
* We provided a new error code to distinguish the error in the unit test from the one thrown by `url.parse()`

Let us know if you have any comments.
