### PR TITLE
Adding connection timeout to http adapter

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -70,6 +70,7 @@ export interface AxiosRequestConfig<D = any> {
   paramsSerializer?: (params: any) => string;
   data?: D;
   timeout?: number;
+  connectionTimeout?: number;
   timeoutErrorMessage?: string;
   withCredentials?: boolean;
   adapter?: AxiosAdapter;

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -346,6 +346,36 @@ module.exports = function httpAdapter(config) {
       });
     }
 
+    if (config.connectionTimeout) {
+      var connectionTimeout = parseInt(config.connectionTimeout, 10);
+
+      if (isNaN(connectionTimeout)) {
+        reject(createError(
+          'error trying to parse `config.connectionTimeout` to int',
+          config,
+          'ERR_PARSE_CONNECTION_TIMEOUT',
+          req
+        ));
+
+        return;
+      }
+
+      var connectionTimeoutTimer = setTimeout(function handleRequestConnectionTimeout() {
+        req.abort();
+
+        reject(createError(
+          'connection timeout of ' + connectionTimeout + 'ms exceeded',
+          config,
+          'ETIMEDOUT',
+          req
+        ));
+      }, connectionTimeout);
+
+      req.on('connect', function handleRequestConnectionEvent() {
+        clearTimeout(connectionTimeoutTimer);
+      });
+    }
+
     if (config.cancelToken || config.signal) {
       // Handle cancellation
       // eslint-disable-next-line func-names

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -106,6 +106,12 @@ var defaults = {
    */
   timeout: 0,
 
+  /**
+   * A connection timeout in milliseconds to abort a request that fails to
+   * connect. If set to 0 (default) a timeout is not created.
+   */
+  connectionTimeout: 0,
+
   xsrfCookieName: 'XSRF-TOKEN',
   xsrfHeaderName: 'X-XSRF-TOKEN',
 

--- a/package.json
+++ b/package.json
@@ -75,7 +75,8 @@
   "unpkg": "dist/axios.min.js",
   "typings": "./index.d.ts",
   "dependencies": {
-    "follow-redirects": "^1.14.4"
+    "follow-redirects": "^1.14.4",
+    "nock": "13.2.1"
   },
   "bundlesize": [
     {


### PR DESCRIPTION
Fixes #4328

Adds an optional `connectionTimeout` config property with the same shape as the `timeout` property.

If a non-zero number is provided a vanilla `setTimeout` is created to abort the request.

The timeout is cleared once a `connect` event is fired by the request.

No change is made to the `xhr` adapter.