### PR TITLE
Feature: adding an adapter that supports HarmonyOS in axios

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -147,5 +147,5 @@ module.exports = {
     }]
   },
 
-  'ignorePatterns': ['**/env/data.js']
+  'ignorePatterns': ['**/env/data.js', '**/adapters/ohos.js']
 };

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -213,7 +213,7 @@ module.exports = function(config) {
       externals: [
         {
           './adapters/http': 'var undefined',
-          '@ohos.net.http': '@ohos.net.http'
+          './adapters/ohos': 'var undefined'
         }
       ]
     },

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -212,7 +212,8 @@ module.exports = function(config) {
       devtool: 'inline-source-map',
       externals: [
         {
-          './adapters/http': 'var undefined'
+          './adapters/http': 'var undefined',
+          '@ohos.net.http': '@ohos.net.http'
         }
       ]
     },

--- a/lib/adapters/ohos.js
+++ b/lib/adapters/ohos.js
@@ -22,10 +22,8 @@ module.exports = function ohosAdapter(config) {
       done();
       resolvePromise(value);
     };
-    var rejected = false;
     var reject = function reject(value) {
       done();
-      rejected = true;
       rejectPromise(value);
     };
     var headers = config.headers;
@@ -72,10 +70,11 @@ module.exports = function ohosAdapter(config) {
     }
 
     if (config.cancelToken || config.signal) {
+      // eslint-disable-next-line func-names
       onCanceled = function(cancel) {
         transport.destroy();
-        reject(!cancel || (cancel && cancel.type) ? new Cancel('canceled') : cancel)
-      }
+        reject(!cancel || (cancel && cancel.type) ? new Cancel('canceled') : cancel);
+      };
     }
 
     transport.request(fullPath, options, function handleResponse(err, res) {
@@ -85,8 +84,8 @@ module.exports = function ohosAdapter(config) {
         statusText: statusMap[res.responseCode],
         headers: res.header,
         config: config
-      }
+      };
       settle(resolve, reject, response);
-    })
-  })
+    });
+  });
 };

--- a/lib/adapters/ohos.js
+++ b/lib/adapters/ohos.js
@@ -1,0 +1,94 @@
+import http from '@ohos.net.http'
+import { statusMap } from '../helpers/statusMap';
+
+var settle = require('../core/settle');
+var buildFullPath = require('../core/buildFullPath');
+var VERSION = require('../env/data').version;
+var Cancel = require('../cancel/Cancel');
+
+/*eslint consistent-return:0*/
+module.exports = function ohosAdapter(config) {
+  return new Promise(function dispatchHttpRequest(resolvePromise, rejectPromise) {
+    var onCanceled;
+    function done() {
+      if (config.cancelToken) {
+        config.cancelToken.unsubscribe(onCanceled);
+      }
+
+      if (config.signal) {
+        config.signal.removeEventListener('abort', onCanceled);
+      }
+    }
+    var resolve = function resolve(value) {
+      done();
+      resolvePromise(value);
+    };
+    var rejected = false;
+    var reject = function reject(value) {
+      done();
+      rejected = true;
+      rejectPromise(value);
+    };
+    var data = config.data;
+    var headers = config.headers;
+    var headerNames = {};
+
+    Object.keys(headers).forEach(function storeLowerName(name) {
+      headerNames[name.toLowerCase()] = name;
+    });
+
+    // Set User-Agent (required by some servers)
+    // See https://github.com/axios/axios/issues/69
+    if ('user-agent' in headerNames) {
+      // User-Agent is specified; handle case where no UA header is desired
+      if (!headers[headerNames['user-agent']]) {
+        delete headers[headerNames['user-agent']];
+      }
+      // Otherwise, use specified value
+    } else {
+      // Only set header if it hasn't been set in config
+      headers['User-Agent'] = 'axios/' + VERSION;
+    }
+
+    // Parse url
+    var fullPath = buildFullPath(config.baseURL, config.url);
+
+    var options = {
+      method: config.method.toUpperCase(),
+      header: headers,
+      extraData: config.data
+    };
+
+    if (config.timeout) {
+      var timeout = parseInt(config.timeout, 10);
+      options.connectTimeout = timeout;
+      options.readTimeout = timeout;
+    }
+
+    var transport;
+    if (config.transport) {
+      transport = config.transport;
+    } else {
+      // Create a http request, it can't be reused
+      transport = http.createHttp();
+    }
+
+    if (config.cancelToken || config.signal) {
+      onCanceled = function(cancel) {
+        transport.destroy();
+        reject(!cancel || (cancel && cancel.type) ? new Cancel('canceled') : cancel)
+      }
+    }
+
+    transport.request(fullPath, options, function handleResponse(err, res) {
+      var response = {
+        data: res.result,
+        status: res.responseCode,
+        statusText: statusMap[res.responseCode],
+        headers: res.header,
+        config: config
+      }
+      settle(resolve, reject, response);
+    })
+  })
+};

--- a/lib/adapters/ohos.js
+++ b/lib/adapters/ohos.js
@@ -28,7 +28,6 @@ module.exports = function ohosAdapter(config) {
       rejected = true;
       rejectPromise(value);
     };
-    var data = config.data;
     var headers = config.headers;
     var headerNames = {};
 

--- a/lib/adapters/ohos.js
+++ b/lib/adapters/ohos.js
@@ -1,6 +1,5 @@
 import http from '@ohos.net.http'
-import { statusMap } from '../helpers/statusMap';
-
+var statusMap = require('../helpers/statusMap');
 var settle = require('../core/settle');
 var buildFullPath = require('../core/buildFullPath');
 var VERSION = require('../env/data').version;

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -22,6 +22,9 @@ function getDefaultAdapter() {
   } else if (typeof process !== 'undefined' && Object.prototype.toString.call(process) === '[object process]') {
     // For node use HTTP adapter
     adapter = require('./adapters/http');
+  } else if (global !== undefined && global.aceConsole !== undefined) {
+    // For OpenHarmony use OHOS adapater
+    adapter = require('./adapters/ohos');
   }
   return adapter;
 }

--- a/lib/helpers/statusMap.js
+++ b/lib/helpers/statusMap.js
@@ -1,0 +1,41 @@
+'use strict';
+
+var statusMap = {
+  '200': 'OK',
+  '201': 'CREATED',
+  '202': 'ACCEPTED',
+  '203': 'NOT_AUTHORITATIVE',
+  '204': 'NO_CONTENT',
+  '205': 'RESET',
+  '206': 'PARTIAL',
+  '300': 'MULT_CHOICE',
+  '301': 'MOVED_PERM',
+  '302': 'MOVED_TEMP',
+  '303': 'SEE_OTHER',
+  '304': 'NOT_MODIFIED',
+  '305': 'USE_PROXY',
+  '400': 'BAD_REQUEST',
+  '401': 'UNAUTHORIZED',
+  '402': 'PAYMENT_REQUIRED',
+  '403': 'FORBIDDEN',
+  '404': 'NOT_FOUND',
+  '405': 'BAD_METHOD',
+  '406': 'NOT_ACCEPTABLE',
+  '407': 'PROXY_AUTH',
+  '408': 'CLIENT_TIMEOUT',
+  '409': 'CONFLICT',
+  '410': 'GONE',
+  '411': 'LENGTH_REQUIRED',
+  '412': 'PRECON_FAILED',
+  '413': 'ENTITY_TOO_LARGE',
+  '414': 'REQ_TOO_LONG',
+  '415': 'UNSUPPORTED_TYPE',
+  '500': 'INTERNAL_ERROR',
+  '501': 'NOT_IMPLEMENTED',
+  '502': 'BAD_GATEWAY',
+  '503': 'UNAVAILABLE',
+  '504': 'GATEWAY_TIMEOUT',
+  '505': 'VERSION'
+};
+
+module.exports = statusMap;

--- a/lib/helpers/statusMap.js
+++ b/lib/helpers/statusMap.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var statusMap = {
+module.exports = {
   '200': 'OK',
   '201': 'CREATED',
   '202': 'ACCEPTED',
@@ -37,5 +37,3 @@ var statusMap = {
   '504': 'GATEWAY_TIMEOUT',
   '505': 'VERSION'
 };
-
-module.exports = statusMap;

--- a/package.json
+++ b/package.json
@@ -69,7 +69,8 @@
     "webpack-dev-server": "^3.11.0"
   },
   "browser": {
-    "./lib/adapters/http.js": "./lib/adapters/xhr.js"
+    "./lib/adapters/http.js": "./lib/adapters/xhr.js",
+    "./lib/adapters/ohos.js": "./lib/adapters/xhr.js"
   },
   "jsdelivr": "dist/axios.min.js",
   "unpkg": "dist/axios.min.js",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,7 +18,10 @@ function generateConfig(name) {
       process: false
     },
     devtool: 'source-map',
-    mode: compress ? 'production' : 'development'
+    mode: compress ? 'production' : 'development',
+    externals: {
+      '@ohos.net.http': '@ohos.net.http'
+    }
   };
   return config;
 }


### PR DESCRIPTION
Adding an adapter that supports HarmonyOS in Axios. Although this feature can be implemented through a custom adapter, considering that axios will be frequently used when developing Apps in HarmonyOS, it will be more convenient if it can be integrated into axios. The newly added HarmonyOS adapter will not have a negative impact on the existing functions.

PS. HarmonyOS is an innovative, distributed operating system for the Internet of everything (IoE) era. And we could use JavaScript or TypeScript to develop Apps in HarmonyOS. More info see: https://www.harmonyos.com/en/
