### PR TITLE
Updating follow-redirects to version 1.14.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   "unpkg": "dist/axios.min.js",
   "typings": "./index.d.ts",
   "dependencies": {
-    "follow-redirects": "^1.14.4"
+    "follow-redirects": "^1.14.7"
   },
   "bundlesize": [
     {


### PR DESCRIPTION
I notice the current version of `axios@0.24.0` is using the `follow-redirects@1.14.6` and recently was discovered a security vulnerability that was fixed on `follow-redirects@1.14.7`.

The overview of error is:

> _Affected versions of this package are vulnerable to Information Exposure by leaking the cookie header to a third party site in the process of fetching a remote URL with the cookie in the request body. If the response contains a location header, it will follow the redirect to another URL of a potentially malicious actor, to which the cookie would be exposed._

Here is the from `follow-redirects` commit with the fix that is currently on version `1.14.7`: https://github.com/follow-redirects/follow-redirects/commit/8b347cbcef7c7b72a6e9be20f5710c17d6163c22.