### PR TITLE
Fixed isFormData predicate;

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -107,6 +107,9 @@ export interface AxiosRequestConfig<D = any> {
   transitional?: TransitionalOptions;
   signal?: AbortSignal;
   insecureHTTPParser?: boolean;
+  env?: {
+    FormData?: new (...args: any[]) => object;
+  };
 }
 
 export interface HeadersDefaults {

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -87,7 +87,9 @@ module.exports = function httpAdapter(config) {
       headers['User-Agent'] = 'axios/' + VERSION;
     }
 
-    if (data && !utils.isStream(data)) {
+    if (utils.isFormData(data) && utils.isFunction(data.getHeaders)) {
+      Object.assign(headers, data.getHeaders());
+    } else if (data && !utils.isStream(data)) {
       if (Buffer.isBuffer(data)) {
         // Nothing to do...
       } else if (utils.isArrayBuffer(data)) {

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -3,6 +3,7 @@
 var utils = require('./utils');
 var normalizeHeaderName = require('./helpers/normalizeHeaderName');
 var enhanceError = require('./core/enhanceError');
+var toFormData = require('./helpers/toFormData');
 
 var DEFAULT_CONTENT_TYPE = {
   'Content-Type': 'application/x-www-form-urlencoded'
@@ -71,10 +72,17 @@ var defaults = {
       setContentTypeIfUnset(headers, 'application/x-www-form-urlencoded;charset=utf-8');
       return data.toString();
     }
-    if (utils.isObject(data) || (headers && headers['Content-Type'] === 'application/json')) {
+
+    var isObjectPayload = utils.isObject(data);
+    var contentType = headers && headers['Content-Type'];
+
+    if ( isObjectPayload && contentType === 'multipart/form-data' ) {
+      return toFormData(data,  new (this.env && this.env.FormData || FormData));
+    } else if ( isObjectPayload || contentType === 'application/json' ) {
       setContentTypeIfUnset(headers, 'application/json');
       return stringifySafely(data);
     }
+
     return data;
   }],
 
@@ -111,6 +119,8 @@ var defaults = {
 
   maxContentLength: -1,
   maxBodyLength: -1,
+
+  env: {},
 
   validateStatus: function validateStatus(status) {
     return status >= 200 && status < 300;

--- a/lib/helpers/toFormData.js
+++ b/lib/helpers/toFormData.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var utils = require('../utils');
+
 function combinedKey(parentKey, elKey) {
   return parentKey + '.' + elKey;
 }
@@ -11,7 +13,7 @@ function buildFormData(formData, data, parentKey) {
     });
   } else if (
     typeof data === 'object' &&
-    !(data instanceof File || data === null)
+    !(utils.isFile(data) || data === null)
   ) {
     Object.keys(data).forEach(function buildObject(key) {
       buildFormData(
@@ -44,10 +46,12 @@ function buildFormData(formData, data, parentKey) {
  * type FormVal = FormDataNest | FormDataPrimitive
  *
  * @param {FormVal} data
+ * @param {?Object} formData
  */
 
-module.exports = function getFormData(data) {
-  var formData = new FormData();
+module.exports = function getFormData(data, formData) {
+  // eslint-disable-next-line no-param-reassign
+  formData = formData || new FormData();
 
   buildFormData(formData, data);
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -47,15 +47,6 @@ function isArrayBuffer(val) {
   return toString.call(val) === '[object ArrayBuffer]';
 }
 
-/**
- * Determine if a value is a FormData
- *
- * @param {Object} val The value to test
- * @returns {boolean} True if value is an FormData, otherwise false
- */
-function isFormData(val) {
-  return toString.call(val) === '[object FormData]';
-}
 
 /**
  * Determine if a value is a view on an ArrayBuffer
@@ -166,6 +157,21 @@ function isFunction(val) {
  */
 function isStream(val) {
   return isObject(val) && isFunction(val.pipe);
+}
+
+/**
+ * Determine if a value is a FormData
+ *
+ * @param {Object} thing The value to test
+ * @returns {boolean} True if value is an FormData, otherwise false
+ */
+function isFormData(thing) {
+  var pattern = '[object FormData]';
+  return thing && (
+    (typeof FormData === 'function' && thing instanceof FormData) ||
+    toString.call(thing) === pattern ||
+    (isFunction(thing.toString) && thing.toString() === pattern)
+  );
 }
 
 /**

--- a/test/specs/helpers/toFormData.spec.js
+++ b/test/specs/helpers/toFormData.spec.js
@@ -1,7 +1,7 @@
 var toFormData = require("../../../lib/helpers/toFormData");
 
 describe("toFormData", function () {
-  it("Convert nested data object to FormDAta", function () {
+  it("Convert nested data object to FormData", function () {
     var o = {
       val: 123,
       nested: {


### PR DESCRIPTION
- Fixed `isFormData` util; (possibly related to #4412, #4406). It can detect (at least) native FormData instance, [form-data](https://www.npmjs.com/package/form-data), [formdata-node](https://www.npmjs.com/package/formdata-node)
- Added support for automatic object serialization to FormData if `Content-Type` is `multipart/form-data`; (#3757)
- Added support for FormData to be overloaded using `config.env.FormData` option (for node.js environment);
- Added support for FormData in node.js environment through `form-data` package (the package is not a dependency);

Browser example:
```js
const axios= require('axios');

axios.post('https://postman-echo.com/post', {x: 1}, {
  headers: {
    'Content-Type': 'multipart/form-data'
  }
}).then(({data})=> console.log(data));
```
Node.js example
```js
const axios= require('axios');
var FormData = require('form-data');

// OR
// axios.defaults.env.FormData= FormData;

axios.post('https://postman-echo.com/post', {x: 1}, {
  headers: {
    'Content-Type': 'multipart/form-data'
  },

  env: {  // OR
    FormData
  }
}).then(({data})=> console.log(data));
```
Response:
```js
{
  args: {},
  data: {},
  files: {},
  form: { x: '1' },
  headers: {
    'x-forwarded-proto': 'https',
    'x-forwarded-port': '443',
    host: 'postman-echo.com',
    'x-amzn-trace-id': 'Root=1-61eb41dc-5eb39a192efeea3a65d9e624',
    'content-length': '157',
    accept: 'application/json, text/plain, */*',
    'content-type': 'multipart/form-data; boundary=--------------------------086549356411608332106674',
    'user-agent': 'axios/0.25.0'
  },
  json: null,
  url: 'https://postman-echo.com/post'
}
```