### PR TITLE
expand AxiosInstance types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -200,8 +200,8 @@ export class Axios {
 }
 
 export interface AxiosInstance extends Axios {
-  (config: AxiosRequestConfig): AxiosPromise;
-  (url: string, config?: AxiosRequestConfig): AxiosPromise;
+  <T = any>(config: AxiosRequestConfig): AxiosPromise<T>;
+  <T = any>(url: string, config?: AxiosRequestConfig): AxiosPromise<T>;
 }
 
 export interface AxiosStatic extends AxiosInstance {


### PR DESCRIPTION
This change allows to pass generic params
``` typescript
interface ApiData {
  code: number,
  data: any
}
let ins = axios.create({})
// has type inference
ins.request<ApiData>({}).then(res => {})
//no type inference
ins({}).then(res => {})
//after change, has type inference
inis<ApiData>({}).then(res => {})
```