### PR TITLE
Enhance + Types for AxiosInterceptorOptions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -179,13 +179,13 @@ export interface CancelTokenSource {
   cancel: Canceler;
 }
 
-export interface AxiosInterceptorOptions<V> {
-  runWhen?(value: V): boolean
+export interface AxiosInterceptorOptions {
+  runWhen?(config: AxiosRequestConfig): boolean
   synchronous?: boolean
 }
 
 export interface AxiosInterceptorManager<V> {
-  use<T = V>(onFulfilled?: (value: V) => T | Promise<T>, onRejected?: (error: any) => any, options?: AxiosInterceptorOptions<V>): number;
+  use<T = V>(onFulfilled?: (value: V) => T | Promise<T>, onRejected?: (error: any) => any, options?: AxiosInterceptorOptions): number;
   eject(id: number): void;
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -179,8 +179,13 @@ export interface CancelTokenSource {
   cancel: Canceler;
 }
 
+export interface AxiosInterceptorOptions<V> {
+  runWhen?(value: V): boolean
+  synchronous?: boolean
+}
+
 export interface AxiosInterceptorManager<V> {
-  use<T = V>(onFulfilled?: (value: V) => T | Promise<T>, onRejected?: (error: any) => any): number;
+  use<T = V>(onFulfilled?: (value: V) => T | Promise<T>, onRejected?: (error: any) => any, options?: AxiosInterceptorOptions<V>): number;
   eject(id: number): void;
 }
 

--- a/lib/core/Axios.js
+++ b/lib/core/Axios.js
@@ -72,6 +72,10 @@ Axios.prototype.request = function request(configOrUrl, config) {
 
   var responseInterceptorChain = [];
   this.interceptors.response.forEach(function pushResponseInterceptors(interceptor) {
+    if (typeof interceptor.runWhen === 'function' && interceptor.runWhen(config) === false) {
+      return;
+    }
+
     responseInterceptorChain.push(interceptor.fulfilled, interceptor.rejected);
   });
 


### PR DESCRIPTION
This enhances the PR #2702 by doing:

- Add the `runWhen` check for response interceptor (previously was only for requests)
- Adds the missing types on the interceptor options

```ts
interface AxiosInterceptorOptions {
  runWhen?(config: AxiosRequestConfig): boolean
  synchronous?: boolean
}

interface AxiosInterceptorManager<V> {
  use<T = V>(onFulfilled?: (value: V) => T | Promise<T>, onRejected?: (error: any) => any, options?: AxiosInterceptorOptions): number;
  eject(id: number): void;
}
```
