### PR TITLE
Fixing getUri method for the Uncaught TypeError

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,20 @@ The available instance methods are listed below. The specified config will be me
 ##### axios#patch(url[, data[, config]])
 ##### axios#getUri([config])
 
+```js
+const config = {
+  method: 'post',
+  url: '/user/1199',
+  params: {
+    firstName: 'John',
+    lastName: 'Roe'
+  },
+  paramsSerializer: (params) => Object.keys(params).join(',') + '===' + Object.values(params).join(',')
+}
+axios.getUri(config);
+// outputs: '/user/1199?firstName,lastName===John,Roe'
+```
+
 ## Request Config
 
 These are the available config options for making requests. Only the `url` is required. Requests will default to `GET` if `method` is not specified.

--- a/index.d.ts
+++ b/index.d.ts
@@ -188,7 +188,7 @@ export class Axios {
     request: AxiosInterceptorManager<AxiosRequestConfig>;
     response: AxiosInterceptorManager<AxiosResponse>;
   };
-  getUri(config?: AxiosRequestConfig): string;
+  getUri(config?: AxiosRequestConfig): string | undefined;
   request<T = any, R = AxiosResponse<T>, D = any>(config: AxiosRequestConfig<D>): Promise<R>;
   get<T = any, R = AxiosResponse<T>, D = any>(url: string, config?: AxiosRequestConfig<D>): Promise<R>;
   delete<T = any, R = AxiosResponse<T>, D = any>(url: string, config?: AxiosRequestConfig<D>): Promise<R>;

--- a/lib/core/Axios.js
+++ b/lib/core/Axios.js
@@ -118,8 +118,8 @@ Axios.prototype.request = function request(configOrUrl, config) {
 };
 
 Axios.prototype.getUri = function getUri(config) {
-  config = mergeConfig(this.defaults, config);
-  return buildURL(config.url, config.params, config.paramsSerializer).replace(/^\?/, '');
+  config = Object.assign(this.defaults, config);
+  return config.url ? buildURL(config.url, config.params, config.paramsSerializer).replace(/^\?/, '') : undefined;
 };
 
 // Provide aliases for supported request methods


### PR DESCRIPTION
I have noted a bug with the **getUri** method, where it throws an uncaught type error.

Sample code to reproduce the issue:
```
const axios = require('axios');
const client = axios.create({ url: 'https://dev.to' });
client.getUri(); // <--- throws
```
The problem here was that the url defined on the instance was never picked up because of the merge over the configs, where the url is only picked up from **config2**.

I adjusted the function so that it does not throw an error, to instead return undefined if no url is present. Also changed the type definition along it.
