### PR TITLE
don't need to transform arguments to array

### DIFF
--- a/lib/helpers/bind.js
+++ b/lib/helpers/bind.js
@@ -2,10 +2,6 @@
 
 module.exports = function bind(fn, thisArg) {
   return function wrap() {
-    var args = new Array(arguments.length);
-    for (var i = 0; i < args.length; i++) {
-      args[i] = arguments[i];
-    }
-    return fn.apply(thisArg, args);
+    return fn.apply(thisArg, arguments);
   };
 };


### PR DESCRIPTION
The apply method's second arg can be an array-like object.

can see the MDN [Function.prototype.apply()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/apply)