### PR TITLE
Fixing instance.defaults.headers type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -229,6 +229,12 @@ export class Axios {
 export interface AxiosInstance extends Axios {
   (config: AxiosRequestConfig): AxiosPromise;
   (url: string, config?: AxiosRequestConfig): AxiosPromise;
+
+  defaults: Omit<AxiosDefaults, 'headers'> & {
+    headers: HeadersDefaults & {
+      [key: string]: string | number | boolean | undefined
+    }
+  };
 }
 
 export interface AxiosStatic extends AxiosInstance {

--- a/test/typescript/axios.ts
+++ b/test/typescript/axios.ts
@@ -251,6 +251,8 @@ instance1.post('/user', { foo: 'bar' }, { headers: { 'X-FOO': 'bar' } })
 
 // Defaults
 
+console.log(axios.defaults.headers['X-FOO']);
+
 axios.defaults.baseURL = 'https://api.example.com/';
 axios.defaults.headers.common['Authorization'] = 'token';
 axios.defaults.headers.post['X-FOO'] = 'bar';


### PR DESCRIPTION
When creating an Axios instance with `Axios.create()` the `headers` config (as described [in the README](https://github.com/axios/axios/blob/master/README.md#axioscreateconfig)) is merged into the root of `instance.default.headers`. These values are not accessible because the types for `instance.defaults.headers` do not include an index type to represent the arbitrary properties which are merged there.

This PR includes this index type in the `instance.defaults.headers` object and includes validation that this works in the `test/typescript/axios.ts` file. Without the change in `index.d.ts` this test shows the following error:

<img width="1616" alt="image" src="https://user-images.githubusercontent.com/1329312/160682788-6b381c7b-b603-4db1-b301-a13b66f6ad8f.png">
