### PR TITLE
docs(index.d.ts): add interceptor handles ts declare and customConfig…

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -107,6 +107,7 @@ export interface AxiosRequestConfig<D = any> {
   transitional?: TransitionalOptions;
   signal?: AbortSignal;
   insecureHTTPParser?: boolean;
+  customConfig?: Record<string, any>;
 }
 
 export interface HeadersDefaults {
@@ -203,9 +204,26 @@ export interface AxiosInterceptorOptions {
   runWhen?: (config: AxiosRequestConfig) => boolean;
 }
 
+export interface FulfilledHandler<T> {
+  (value: T): T | Promise<T>
+}
+
+export interface RejectedHandler {
+  (error: any): any
+}
+
+export interface AxiosInterceptorHandleItem<V> {
+  fulfilled: FulfilledHandler<V>;
+  rejected: RejectedHandler;
+  synchronous: boolean;
+  runWhen: (config: AxiosRequestConfig) => boolean | null;
+}
+
 export interface AxiosInterceptorManager<V> {
-  use<T = V>(onFulfilled?: (value: V) => T | Promise<T>, onRejected?: (error: any) => any, options?: AxiosInterceptorOptions): number;
+  use<T = V>(onFulfilled?: FulfilledHandler<T>, onRejected?: RejectedHandler, options?: AxiosInterceptorOptions): number;
   eject(id: number): void;
+  // interceptor handle item
+  handlers: AxiosInterceptorHandleItem<V>[];
 }
 
 export class Axios {


### PR DESCRIPTION
in my current case, i have to write unit test for my http-client lib base on axios;
and i found that, the `axiosInstance` interceptors will lose the `handlers` TS type declare
so, support to add this feature, feature issues #4573 