### PR TITLE
Adding Generics to AxiosInstance

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -233,8 +233,8 @@ export class Axios {
 }
 
 export interface AxiosInstance extends Axios {
-  (config: AxiosRequestConfig): AxiosPromise;
-  (url: string, config?: AxiosRequestConfig): AxiosPromise;
+  <T = any>(config: AxiosRequestConfig): AxiosPromise<T>;
+  <T = any>(url: string, config?: AxiosRequestConfig): AxiosPromise<T>;
 }
 
 export interface AxiosStatic extends AxiosInstance {


### PR DESCRIPTION
allow to use AxiosInstance with Typescript like this：
`
interface CustomType {};
`
`
const instance = axios.create();
`
`
instance<CustomType>('url', {}).then((res: CustomType) => {
  console.log(res);
});
`