### PR TITLE
Disabled WebPack auto importing plugin to avoid unnecessary imports;

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,9 +14,7 @@ function generateConfig(name) {
       libraryTarget: 'umd',
       globalObject: 'this'
     },
-    node: {
-      process: false
-    },
+    node: false,
     devtool: 'source-map',
     mode: compress ? 'production' : 'development'
   };


### PR DESCRIPTION
It seems the new WebPack uses some magic with auto-importing of node js builtins, so this PR turns it off. 
Currently, the build consists unnecessary Buffer module and is-array util.
This PR is not needed if we are going to move to Rollup by merging #4596.
Closes #4629