### PR TITLE
Fixing FormData content-type handling in XHR

### DIFF
--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -151,8 +151,12 @@ module.exports = function xhrAdapter(config) {
     // Add headers to the request
     if ('setRequestHeader' in request) {
       utils.forEach(requestHeaders, function setRequestHeader(val, key) {
-        if (typeof requestData === 'undefined' && key.toLowerCase() === 'content-type') {
-          // Remove Content-Type if data is undefined
+        if (
+          key.toLowerCase() === 'content-type' &&
+          (typeof requestData === 'undefined' ||
+            (utils.isFormData(requestData) && utils.isStandardBrowserEnv()))
+        ) {
+          // Remove Content-Type if data is undefined or FormData in a browser environment
           delete requestHeaders[key];
         } else {
           // Otherwise add header to the request

--- a/test/specs/headers.spec.js
+++ b/test/specs/headers.spec.js
@@ -112,4 +112,17 @@ describe('headers', function () {
       done();
     });
   });
+
+  it('should remove content-type if data is FormData', function (done) {
+    axios.post('/foo', new FormData(), {
+      headers: {
+        'Content-Type': 'multipart/form-data'
+      }
+    });
+
+    getAjaxRequest().then(function (request) {
+      testHeaderValue(request.requestHeaders, 'Content-Type', undefined);
+      done();
+    })
+  })
 });


### PR DESCRIPTION
<!-- Click "Preview" for a more readable version -->

Removes the content-type request header if the request body is FormData and the request is made from a standard browser environment.

Fixes https://github.com/axios/axios/issues/4638 and https://github.com/axios/axios/issues/4631
