### PR TITLE
Make AxiosError.config optional in the type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -148,7 +148,7 @@ export class AxiosError<T = unknown, D = any> extends Error {
     response?: AxiosResponse<T, D>
   );
 
-  config: AxiosRequestConfig<D>;
+  config?: AxiosRequestConfig<D>;
   code?: string;
   request?: any;
   response?: AxiosResponse<T, D>;


### PR DESCRIPTION
In the source, the JSdoc for `config` is the following:

```js
 * @param {Object} [config] The config.
```

It is assigned as such:

```js
config && (this.config = config);
```

The type in `index.d.ts` is thus incorrect and needs to be optional.