### PR TITLE
Fixing proxy beforeRedirect regression

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -20,6 +20,15 @@ var isHttps = /https:?/;
 
 var supportedProtocols = [ 'http:', 'https:', 'file:' ];
 
+function dispatchBeforeRedirect(options) {
+  if (options.beforeRedirects.proxy) {
+    options.beforeRedirects.proxy(options);
+  }
+  if (options.beforeRedirects.config) {
+    options.beforeRedirects.config(options);
+  }
+}
+
 /**
  *
  * @param {http.ClientRequestArgs} options
@@ -59,7 +68,7 @@ function setProxy(options, configProxy, location) {
     }
   }
 
-  options.beforeRedirect = function beforeRedirect(redirectOptions) {
+  options.beforeRedirects.proxy = function beforeRedirect(redirectOptions) {
     // Configure proxy for redirected request, passing the original config proxy to apply
     // the exact same logic as if the redirected request was performed by axios directly.
     setProxy(redirectOptions, configProxy, redirectOptions.href);
@@ -190,7 +199,9 @@ module.exports = function httpAdapter(config) {
       headers: headers,
       agents: { http: config.httpAgent, https: config.httpsAgent },
       auth: auth,
-      protocol: protocol
+      protocol: protocol,
+      beforeRedirect: dispatchBeforeRedirect,
+      beforeRedirects: {}
     };
 
     if (config.socketPath) {
@@ -213,7 +224,7 @@ module.exports = function httpAdapter(config) {
         options.maxRedirects = config.maxRedirects;
       }
       if (config.beforeRedirect) {
-        options.beforeRedirect = config.beforeRedirect;
+        options.beforeRedirects.config = config.beforeRedirect;
       }
       transport = isHttpsRequest ? httpsFollow : httpFollow;
     }


### PR DESCRIPTION
PR https://github.com/axios/axios/pull/3852 introduced support for `config.beforeRedirect` but introduced the regression of https://github.com/axios/axios/issues/3369 for requests that are used with both a proxy and the `config.beforeRedirect` property.

This PR fixes the regression. It includes the test that proves the existence of the bug and verifies the fix. 

The idea of the fix is to always provide `follow-redirects` with a `beforeRedirect` function, but which invokes either (or both) of the proxy `beforeRedirect` and the user's `beforeRedirect` configs. I also implemented this in a way that deterministically always executes the `proxy` callback first, before the user's `config` callback.

Fixes https://github.com/axios/axios/issues/4703