### PR TITLE
Adding `Canceler` parameters config and request

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -210,7 +210,7 @@ export interface Cancel {
 }
 
 export interface Canceler {
-  (message?: string): void;
+  (message?: string, config?: AxiosRequestConfig, request?: any): void;
 }
 
 export interface CancelTokenStatic {

--- a/lib/cancel/CancelToken.js
+++ b/lib/cancel/CancelToken.js
@@ -49,13 +49,13 @@ function CancelToken(executor) {
     return promise;
   };
 
-  executor(function cancel(message) {
+  executor(function cancel(message, config, request) {
     if (token.reason) {
       // Cancellation has already been requested
       return;
     }
 
-    token.reason = new CanceledError(message);
+    token.reason = new CanceledError(message, config, request);
     resolvePromise(token.reason);
   });
 }


### PR DESCRIPTION
Supplement for #4659 .

`CancelToken`'s `Canceler` should allow passing `config` and `request` to `CanceledError`.