### PR TITLE
Added automatic payload serialization to `application/x-www-form-urlencoded`

### DIFF
--- a/lib/defaults/index.js
+++ b/lib/defaults/index.js
@@ -5,6 +5,7 @@ var normalizeHeaderName = require('../helpers/normalizeHeaderName');
 var AxiosError = require('../core/AxiosError');
 var transitionalDefaults = require('./transitional');
 var toFormData = require('../helpers/toFormData');
+var toURLEncodedForm = require('../helpers/toURLEncodedForm');
 
 var DEFAULT_CONTENT_TYPE = {
   'Content-Type': 'application/x-www-form-urlencoded'
@@ -71,18 +72,26 @@ var defaults = {
     }
 
     var isObjectPayload = utils.isObject(data);
-    var contentType = headers && headers['Content-Type'];
-
+    var contentType = headers && headers['Content-Type'] || '';
     var isFileList;
 
-    if ((isFileList = utils.isFileList(data)) || (isObjectPayload && contentType === 'multipart/form-data')) {
-      var _FormData = this.env && this.env.FormData;
-      return toFormData(
-        isFileList ? {'files[]': data} : data,
-        _FormData && new _FormData(),
-        this.formSerializer
-      );
-    } else if (isObjectPayload || contentType === 'application/json') {
+    if (isObjectPayload) {
+      if (contentType.indexOf('application/x-www-form-urlencoded') !== -1) {
+        return toURLEncodedForm(data).toString();
+      }
+
+      if ((isFileList = utils.isFileList(data)) || contentType.indexOf('multipart/form-data') !== -1) {
+        var _FormData = this.env && this.env.FormData;
+
+        return toFormData(
+          isFileList ? {'files[]': data} : data,
+          _FormData && new _FormData(),
+          this.formSerializer
+        );
+      }
+    }
+
+    if (isObjectPayload || contentType.indexOf('application/json') !== -1) {
       setContentTypeIfUnset(headers, 'application/json');
       return stringifySafely(data);
     }

--- a/lib/helpers/buildURL.js
+++ b/lib/helpers/buildURL.js
@@ -17,6 +17,7 @@ function encode(val) {
  *
  * @param {string} url The base of the url (e.g., http://www.google.com)
  * @param {object} [params] The params to be appended
+ * @param {?object} paramsSerializer
  * @returns {string} The formatted url
  */
 module.exports = function buildURL(url, params, paramsSerializer) {

--- a/lib/helpers/toFormData.js
+++ b/lib/helpers/toFormData.js
@@ -20,6 +20,20 @@ function renderKey(path, key, dots) {
   }).join(dots ? '.' : '');
 }
 
+function convertValue(value) {
+  if (value === null) return '';
+
+  if (utils.isDate(value)) {
+    return value.toISOString();
+  }
+
+  if (utils.isArrayBuffer(value) || utils.isTypedArray(value)) {
+    return typeof Blob === 'function' ? new Blob([value]) : Buffer.from(value);
+  }
+
+  return value;
+}
+
 function isFlatArray(arr) {
   return utils.isArray(arr) && !arr.some(isVisitable);
 }
@@ -64,21 +78,6 @@ function toFormData(obj, formData, options) {
     throw new TypeError('visitor must be a function');
   }
 
-  function convertValue(value) {
-    if (value === null) return '';
-
-    if (utils.isDate(value)) {
-      return value.toISOString();
-    }
-
-    if (utils.isArrayBuffer(value) || utils.isTypedArray(value)) {
-      return typeof Blob === 'function' ? new Blob([value]) : Buffer.from(value);
-    }
-
-    return value;
-  }
-
-
   /**
    *
    * @param {*} value
@@ -88,7 +87,7 @@ function toFormData(obj, formData, options) {
    * @returns {boolean} return true to visit the each prop of the value recursively
    */
   function defaultVisitor(value, key, path) {
-    var arr;
+    var arr = value;
 
     if (value && !path && typeof value === 'object') {
       if (utils.endsWith(key, '{}')) {
@@ -96,7 +95,10 @@ function toFormData(obj, formData, options) {
         key = metaTokens ? key : key.slice(0, -2);
         // eslint-disable-next-line no-param-reassign
         value = JSON.stringify(value);
-      } else if (!utils.isPlainObject(value) && (arr = utils.toArray(value)) && isFlatArray(arr)) {
+      } else if (
+        (utils.isArray(value) && isFlatArray(value)) ||
+        (utils.isFileList(value) || utils.endsWith(key, '[]') && (arr = utils.toArray(value))
+        )) {
         // eslint-disable-next-line no-param-reassign
         key = removeBrackets(key);
 
@@ -138,7 +140,7 @@ function toFormData(obj, formData, options) {
     stack.push(value);
 
     utils.forEach(value, function each(el, key) {
-      var result = !utils.isUndefined(el) && defaultVisitor.call(
+      var result = !utils.isUndefined(el) && visitor.call(
         formData, el, utils.isString(key) ? key.trim() : key, path, exposedHelpers
       );
 
@@ -150,8 +152,8 @@ function toFormData(obj, formData, options) {
     stack.pop();
   }
 
-  if (!utils.isPlainObject(obj)) {
-    throw new TypeError('data must be a plain object');
+  if (!utils.isObject(obj)) {
+    throw new TypeError('data must be an object');
   }
 
   build(obj);

--- a/lib/helpers/toURLEncodedForm.js
+++ b/lib/helpers/toURLEncodedForm.js
@@ -1,0 +1,18 @@
+'use strict';
+
+var utils = require('../utils');
+var toFormData = require('./toFormData');
+var platform = require('../platform/');
+
+module.exports = function toURLEncodedForm(data) {
+  return toFormData(data, new platform.classes.URLSearchParams(), {
+    visitor: function(value, key, path, helpers) {
+      if (platform.isNode && utils.isBuffer(value)) {
+        this.append(key, value.toString('base64'));
+        return false;
+      }
+
+      return helpers.defaultVisitor.apply(this, arguments);
+    }
+  });
+};

--- a/lib/platform/browser/classes/URLSearchParams.js
+++ b/lib/platform/browser/classes/URLSearchParams.js
@@ -1,0 +1,38 @@
+'use strict';
+
+module.exports = (function getURLSearchParams(nativeURLSearchParams) {
+  if (typeof nativeURLSearchParams === 'function') return nativeURLSearchParams;
+
+  function encode(str) {
+    var charMap = {
+      '!': '%21',
+      "'": '%27',
+      '(': '%28',
+      ')': '%29',
+      '~': '%7E',
+      '%20': '+',
+      '%00': '\x00'
+    };
+    return encodeURIComponent(str).replace(/[!'\(\)~]|%20|%00/g, function replacer(match) {
+      return charMap[match];
+    });
+  }
+
+  function URLSearchParams() {
+    this.pairs = [];
+  }
+
+  var prototype = URLSearchParams.prototype;
+
+  prototype.append = function append(name, value) {
+    this.pairs.push([name, value]);
+  };
+
+  prototype.toString = function toString() {
+    return this.pairs.map(function each(pair) {
+      return pair[0] + '=' + encode(pair[1]);
+    }, '').join('&');
+  };
+
+  return URLSearchParams;
+})(URLSearchParams);

--- a/lib/platform/browser/index.js
+++ b/lib/platform/browser/index.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = {
+  isBrowser: true,
+  classes: {
+    URLSearchParams: require('./classes/URLSearchParams')
+  }
+};

--- a/lib/platform/index.js
+++ b/lib/platform/index.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('./node/');

--- a/lib/platform/node/classes/URLSearchParams.js
+++ b/lib/platform/node/classes/URLSearchParams.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var url = require('url');
+
+module.exports = url.URLSearchParams;

--- a/lib/platform/node/index.js
+++ b/lib/platform/node/index.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = {
+  isNode: true,
+  classes: {
+    URLSearchParams: require('./classes/URLSearchParams')
+  }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.0",
-        "form-data": "^4.0.0"
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       },
       "devDependencies": {
         "@rollup/plugin-babel": "^5.3.0",
@@ -19,6 +20,7 @@
         "@rollup/plugin-multi-entry": "^4.0.0",
         "@rollup/plugin-node-resolve": "^9.0.0",
         "abortcontroller-polyfill": "^1.7.3",
+        "body-parser": "^1.20.0",
         "coveralls": "^3.1.1",
         "dtslint": "^4.2.1",
         "es6-promise": "^4.2.8",
@@ -11989,8 +11991,7 @@
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/prr": {
       "version": "1.0.1",
@@ -26801,8 +26802,7 @@
     "proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "prr": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@rollup/plugin-multi-entry": "^4.0.0",
     "@rollup/plugin-node-resolve": "^9.0.0",
     "abortcontroller-polyfill": "^1.7.3",
+    "body-parser": "^1.20.0",
     "coveralls": "^3.1.1",
     "dtslint": "^4.2.1",
     "es6-promise": "^4.2.8",
@@ -79,7 +80,8 @@
   },
   "browser": {
     "./lib/adapters/http.js": "./lib/adapters/xhr.js",
-    "./lib/defaults/env/FormData.js": "./lib/helpers/null.js"
+    "./lib/defaults/env/FormData.js": "./lib/helpers/null.js",
+    "./lib/platform/node/index.js": "./lib/platform/browser/index.js"
   },
   "jsdelivr": "dist/axios.min.js",
   "unpkg": "dist/axios.min.js",

--- a/test/unit/adapters/http.js
+++ b/test/unit/adapters/http.js
@@ -12,8 +12,9 @@ var server, proxy;
 var AxiosError = require('../../../lib/core/AxiosError');
 var FormData = require('form-data');
 var formidable = require('formidable');
-const express = require('express');
-const multer = require('multer');
+var express = require('express');
+var multer = require('multer');
+var bodyParser = require('body-parser');
 
 describe('supports http with nodejs', function () {
 
@@ -1287,9 +1288,11 @@ describe('supports http with nodejs', function () {
         }).catch(done);
       });
     });
+
     describe('toFormData helper', function () {
       it('should properly serialize nested objects for parsing with multer.js (express.js)', function (done) {
-        const app = express();
+        var app = express();
+
         var obj = {
           arr1: ['1', '2', '3'],
           arr2: ['1', ['2'], '3'],
@@ -1321,6 +1324,37 @@ describe('supports http with nodejs', function () {
             done();
           }, done)
         });
+      });
+    });
+  });
+
+  describe('URLEncoded Form', function () {
+    it('should post object data as url-encoded form if content-type is application/x-www-form-urlencoded', function (done) {
+      var app = express();
+
+      var obj = {
+        arr1: ['1', '2', '3'],
+        arr2: ['1', ['2'], '3'],
+        obj: {x: '1', y: {z: '1'}},
+        users: [{name: 'Peter', surname: 'griffin'}, {name: 'Thomas', surname: 'Anderson'}]
+      };
+
+      app.use(bodyParser.urlencoded({ extended: true }));
+
+      app.post('/', function (req, res, next) {
+        res.send(JSON.stringify(req.body));
+      });
+
+      server = app.listen(3001, function () {
+        return axios.post('http://localhost:3001/', obj, {
+          headers: {
+            'content-type': 'application/x-www-form-urlencoded'
+          }
+        })
+          .then(function (res) {
+            assert.deepStrictEqual(res.data, obj);
+            done();
+          }, done);
       });
     });
   });


### PR DESCRIPTION
- Fixed `toFormData` regression bug (unreleased) with Array-like objects serialization;
- Added `toURLEncodedForm` helper (it's a tiny wrapper around `toFormData` helper);
- Added automatic payload serialization to `application/x-www-form-urlencoded` to have parity with `multipart/form-data`;
- Added test of handling `application/x-www-form-urlencoded` body by express.js;
- Updated README.md;
- Added missed param in JSDoc;
- Fixed hrefs in README.md;

```js
const data = {
  x: 1,
  arr: [1, 2, 3],
  arr2: [1, [2], 3],
  users: [{name: 'Peter', surname: 'Griffin'}, {name: 'Thomas', surname: 'Anderson'}],
};

await axios.postForm('https://postman-echo.com/post', data,
  {headers: {'content-type': 'application/x-www-form-urlencoded'}}
);
```

can be handled by express out of the box:

```js
  var app = express();
  
  // support encoded bodies with extended params signatures
  app.use(bodyParser.urlencoded({ extended: true }));
  
  app.post('/', function (req, res, next) {
     res.send(JSON.stringify(req.body));
  });

  server = app.listen(3000);
```
