### PR TITLE
Added the ability for the `url-encoded-form` serializer to respect the `formSerializer` config;

### DIFF
--- a/lib/defaults/index.js
+++ b/lib/defaults/index.js
@@ -77,7 +77,7 @@ var defaults = {
 
     if (isObjectPayload) {
       if (contentType.indexOf('application/x-www-form-urlencoded') !== -1) {
-        return toURLEncodedForm(data).toString();
+        return toURLEncodedForm(data, this.formSerializer).toString();
       }
 
       if ((isFileList = utils.isFileList(data)) || contentType.indexOf('multipart/form-data') !== -1) {

--- a/lib/helpers/toURLEncodedForm.js
+++ b/lib/helpers/toURLEncodedForm.js
@@ -4,8 +4,8 @@ var utils = require('../utils');
 var toFormData = require('./toFormData');
 var platform = require('../platform/');
 
-module.exports = function toURLEncodedForm(data) {
-  return toFormData(data, new platform.classes.URLSearchParams(), {
+module.exports = function toURLEncodedForm(data, options) {
+  return toFormData(data, new platform.classes.URLSearchParams(), Object.assign({
     visitor: function(value, key, path, helpers) {
       if (platform.isNode && utils.isBuffer(value)) {
         this.append(key, value.toString('base64'));
@@ -14,5 +14,5 @@ module.exports = function toURLEncodedForm(data) {
 
       return helpers.defaultVisitor.apply(this, arguments);
     }
-  });
+  }, options));
 };

--- a/lib/platform/browser/classes/URLSearchParams.js
+++ b/lib/platform/browser/classes/URLSearchParams.js
@@ -1,8 +1,6 @@
 'use strict';
 
-module.exports = (function getURLSearchParams(nativeURLSearchParams) {
-  if (typeof nativeURLSearchParams === 'function') return nativeURLSearchParams;
-
+module.exports = typeof URLSearchParams !== 'undefined' ? URLSearchParams : (function defineURLSearchParams() {
   function encode(str) {
     var charMap = {
       '!': '%21',
@@ -35,4 +33,4 @@ module.exports = (function getURLSearchParams(nativeURLSearchParams) {
   };
 
   return URLSearchParams;
-})(URLSearchParams);
+})();

--- a/test/unit/adapters/http.js
+++ b/test/unit/adapters/http.js
@@ -1404,8 +1404,42 @@ describe('supports http with nodejs', function () {
           .then(function (res) {
             assert.deepStrictEqual(res.data, obj);
             done();
-          }, done);
+          }).catch(done);
       });
+    });
+  });
+
+  it('should respect formSerializer config', function (done) {
+    const obj = {
+      arr1: ['1', '2', '3'],
+      arr2: ['1', ['2'], '3'],
+    };
+
+    const form = new URLSearchParams();
+
+    form.append('arr1[0]', '1');
+    form.append('arr1[1]', '2');
+    form.append('arr1[2]', '3');
+
+    form.append('arr2[0]', '1');
+    form.append('arr2[1][0]', '2');
+    form.append('arr2[2]', '3');
+
+    server = http.createServer(function (req, res) {
+      req.pipe(res);
+    }).listen(3001, () => {
+      return axios.post('http://localhost:3001/', obj, {
+        headers: {
+          'content-type': 'application/x-www-form-urlencoded'
+        },
+        formSerializer: {
+          indexes: true
+        }
+      })
+        .then(function (res) {
+          assert.strictEqual(res.data, form.toString());
+          done();
+        }).catch(done);
     });
   });
 });


### PR DESCRIPTION
Now the same `formSerializer` config will be used for both form encodings- `multipart/form-data` and `application/x-www-form-urlencoded`