### PR TITLE
Updated eslint config;

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -54,17 +54,17 @@ module.exports = {
     /**
  * Best practices
  */
-    'consistent-return': 2,          // http://eslint.org/docs/rules/consistent-return
+    'consistent-return': 0,          // http://eslint.org/docs/rules/consistent-return
     'curly': [2, 'multi-line'],      // http://eslint.org/docs/rules/curly
     'default-case': 2,               // http://eslint.org/docs/rules/default-case
     'dot-notation': [2, {            // http://eslint.org/docs/rules/dot-notation
       'allowKeywords': true
     }],
-    'eqeqeq': 2,                     // http://eslint.org/docs/rules/eqeqeq
+    'eqeqeq': [2, "smart"],          // http://eslint.org/docs/rules/eqeqeq
     'guard-for-in': 2,               // http://eslint.org/docs/rules/guard-for-in
     'no-caller': 2,                  // http://eslint.org/docs/rules/no-caller
     'no-else-return': 2,             // http://eslint.org/docs/rules/no-else-return
-    'no-eq-null': 2,                 // http://eslint.org/docs/rules/no-eq-null
+    'no-eq-null': 0,                 // http://eslint.org/docs/rules/no-eq-null
     'no-eval': 2,                    // http://eslint.org/docs/rules/no-eval
     'no-extend-native': 2,           // http://eslint.org/docs/rules/no-extend-native
     'no-extra-bind': 2,              // http://eslint.org/docs/rules/no-extra-bind
@@ -114,9 +114,7 @@ module.exports = {
     }],
     'comma-style': [2, 'last'],      // http://eslint.org/docs/rules/comma-style
     'eol-last': 2,                   // http://eslint.org/docs/rules/eol-last
-    'func-names': [
-      1, 'as-needed'
-    ],                               // http://eslint.org/docs/rules/func-names
+    'func-names': 0,                  // http://eslint.org/docs/rules/func-names
     'key-spacing': [2, {             // http://eslint.org/docs/rules/key-spacing
       'beforeColon': false,
       'afterColon': true


### PR DESCRIPTION
Since we should move to ES6 in the near future and the project is low-level lib, not a regular app, it would be nice to update `eslint` config to avoid pointless rules that we disable locally too often using `eslint-disable-next-line`:

Disabled:
- `consistent-return` - to avoid redundant return statements for functions whose logic does not require it, this increases the size of the code, which is important for client builds.
- `func-names` - arrow functions are widely used in es6, so there is not much point in writing the names of functions that will soon be removed.
- `no-eq-null` - disabled in favor of `eqeqeq`

Less strict:
- `eqeqeq` - at least non-strict comparison with null is a commonly used feature in JS.