### PR TITLE
types: improve interceptors axios response type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -178,19 +178,25 @@ export interface AxiosResponse<T = any, D = any>  {
   request?: any;
 }
 
-export class AxiosError<T = unknown, D = any> extends Error {
+interface AxiosResponseDataProperty {
+  code: string;
+  error: boolean;
+  message: string;
+}
+
+export class AxiosError<D = any> extends Error {
   constructor(
     message?: string,
     code?: string,
     config?: AxiosRequestConfig<D>,
     request?: any,
-    response?: AxiosResponse<T, D>
+    response?: AxiosResponse<AxiosResponseDataProperty, D>
   );
 
   config?: AxiosRequestConfig<D>;
   code?: string;
   request?: any;
-  response?: AxiosResponse<T, D>;
+  response?: AxiosResponse<AxiosResponseDataProperty, D>;
   isAxiosError: boolean;
   status?: number;
   toJSON: () => object;
@@ -298,7 +304,7 @@ export interface AxiosStatic extends AxiosInstance {
   isCancel(value: any): value is Cancel;
   all<T>(values: Array<T | Promise<T>>): Promise<T[]>;
   spread<T, R>(callback: (...args: T[]) => R): (array: T[]) => R;
-  isAxiosError<T = any, D = any>(payload: any): payload is AxiosError<T, D>;
+  isAxiosError<D = any>(payload: any): payload is AxiosError<D>;
   toFormData(sourceObj: object, targetFormData?: GenericFormData, options?: FormSerializerOptions): GenericFormData;
 }
 


### PR DESCRIPTION
Improved response type for AxiosError.
Previously, the Data property was typed with a generic any. And to use other properties that come inside the Data property, it was necessary to type the error with any because it didn't recognize the properties that come inside it.

<img width="475" alt="Screen Shot 2022-05-24 at 9 28 55 AM" src="https://user-images.githubusercontent.com/58401291/170034876-30709e68-350f-413e-98a3-4188738459b8.png">
<img width="629" alt="Screen Shot 2022-05-24 at 9 30 12 AM" src="https://user-images.githubusercontent.com/58401291/170035123-afdb1a5b-990a-467b-9524-21fcb5de09d0.png">
<img width="661" alt="Screen Shot 2022-05-24 at 9 12 21 PM" src="https://user-images.githubusercontent.com/58401291/170152025-f8ee1b3d-fa16-4832-aafe-27a00add7c6f.png">

After the changes we have greater coverage of the AxiosError type: 

<img width="653" alt="Screen Shot 2022-05-24 at 9 07 40 PM" src="https://user-images.githubusercontent.com/58401291/170152152-465381d4-fd21-4f33-b301-8b817cdd658b.png">
<img width="507" alt="Screen Shot 2022-05-24 at 9 08 04 PM" src="https://user-images.githubusercontent.com/58401291/170151887-6e251d2e-0307-4df7-ae77-2e782c386800.png">
>