### PR TITLE
Add resource section

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -42,3 +42,19 @@ This is a list of axios related libraries and resources. If you have a suggestio
 * [axios-test-instance](https://github.com/remcohaszing/axios-test-instance) — Test NodeJS backends using Axios
 * [moxios](https://github.com/axios/moxios) - Mock axios requests for testing
 * [mocha-axios](https://github.com/jdrydn/mocha-axios) - Streamlined integration testing with Mocha & Axios
+
+## Resources
+
+### General
+
+* [Connection pooling with agentkeepalive](https://traveling-coderman.net/code/node-architecture/connection-pooling/)
+* [Error handling in Express.js](https://traveling-coderman.net/code/node-architecture/axios-error-handling/)
+* [Request authentication with JWT](https://traveling-coderman.net/code/node-architecture/http-auth/)
+
+### Logging and debugging
+
+* [Pino request logging](https://traveling-coderman.net/code/node-architecture/logging-http-requests/)
+
+### Unit testing
+
+* [Organizing and testing HTTP requests](https://traveling-coderman.net/code/node-architecture/sending-http-requests/)


### PR DESCRIPTION
The description mentions libraries and resources to be referenced on this page. 
The section for libraries already exists, I created the section for resources.
I am writing a series of articles about creating a full microservice with Node.js and I am using Axios for HTTP communication.
I have written five articles covering Axios topics so far with recipes to achieve specific outcomes, I think these are valuable for Axios users to discover.
I referenced these five blog posts in this resource section.

Let me know if you would like such blog posts with external documentation to be referenced differently.

You can find all the articles covering Axios topics on this page: https://traveling-coderman.net/tools/axios/ 