### PR TITLE
Fix #4440, #3549 - Request ignores false, 0 and '' as body values

### DIFF
--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -205,7 +205,8 @@ module.exports = function xhrAdapter(config) {
       }
     }
 
-    if (!requestData) {
+    // false, 0 (zero number), and '' (empty string) are valid JSON values
+    if (!requestData && requestData !== false && requestData !== 0 && requestData !== '') {
       requestData = null;
     }
 


### PR DESCRIPTION
Axios is frequently used to make requests to REST APIs that are under client's control.

There are APIs that expect boolean values like `false`, or number values `0` as both are valid JSON values.

I see no reason why it shouldn't work. If there are, please point me to it.

If the authors will approve this PR, I can make the same changes to 0.x and 1.x branches.

Thank you.

---
Related issues: 

- https://github.com/axios/axios/issues/4440
- https://github.com/axios/axios/issues/3549
