### PR TITLE
fix: delete redundant code

### DIFF
--- a/lib/defaults/index.js
+++ b/lib/defaults/index.js
@@ -96,7 +96,7 @@ var defaults = {
       if (!hasJSONContentType) {
         return data;
       }
-      return hasJSONContentType ? JSON.stringify(formDataToJSON(data)) : data;
+      return JSON.stringify(formDataToJSON(data))
     }
 
     if (utils.isArrayBuffer(data) ||

--- a/lib/defaults/index.js
+++ b/lib/defaults/index.js
@@ -96,7 +96,7 @@ var defaults = {
       if (!hasJSONContentType) {
         return data;
       }
-      return JSON.stringify(formDataToJSON(data))
+      return JSON.stringify(formDataToJSON(data));
     }
 
     if (utils.isArrayBuffer(data) ||


### PR DESCRIPTION
The hasJSONContentType judged above is false，So we don't use the trinocular operator here。