### PR TITLE
Add clear method to the type def of inteceptor manager

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -268,6 +268,7 @@ export interface AxiosInterceptorOptions {
 export interface AxiosInterceptorManager<V> {
   use<T = V>(onFulfilled?: (value: V) => T | Promise<T>, onRejected?: (error: any) => any, options?: AxiosInterceptorOptions): number;
   eject(id: number): void;
+  clear(): void;
 }
 
 export class Axios {


### PR DESCRIPTION
The `clear` method of AxiosInterceptorManager is missing in the type definition. This PR added the method to the `.d.ts` file.