### PR TITLE
feat: brower platform add `data` protocol.

### DIFF
--- a/lib/platform/browser/index.js
+++ b/lib/platform/browser/index.js
@@ -8,5 +8,5 @@ export default {
     FormData,
     Blob
   },
-  protocols: ['http', 'https', 'file', 'blob', 'url']
+  protocols: ['http', 'https', 'file', 'blob', 'url', 'data']
 };


### PR DESCRIPTION
```ts
export const useBase64ToFile = (
  src: string,
  name = "file.png",
  type = "image/png"
) => {
  return axios
    .get(`data:image/png;base64,${src}`, { responseType: "blob" })
    .then((res) => new File([res.data], name, { type }));
};

// now -> throw axiosError "Unsupported protocol data:"
// Since data is not currently supported, I have to

export const useBase64ToFile = (
  src: string,
  name = "file.png",
  type = "image/png"
) => {
  return fetch(`data:image/png;base64,${src}`)
    .then((res) => res.arrayBuffer())
    .then((res) => new File([res], name, { type }));
};
```

* [Scheme fetch](https://fetch.spec.whatwg.org/#scheme-fetch)
* [chromium/xml_http_request.cc#L1090](https://github.com/chromium/chromium/blob/main/third_party/blink/renderer/core/xmlhttprequest/xml_http_request.cc#L1090)

Fetch and XMLHttpRequest support data, so we have no reason to reject this scheme