### PR TITLE
Axios response headers may be `undefined`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -11,7 +11,7 @@ interface CommonHeaders  {
 
 export type AxiosRequestHeaders = Partial<AxiosHeaders & MethodsHeaders & CommonHeaders>;
 
-export type AxiosResponseHeaders = Record<string, string> & {
+export type AxiosResponseHeaders = Partial<Record<string, string>> & {
   "set-cookie"?: string[]
 };
 


### PR DESCRIPTION
This PR is to fix the `AxiosResponseHeaders` type on the `v0.x` branch, that currently does not reflect the fact that response headers can be `undefined`. This seems to be already fixed in the `RawAxiosResponseHeaders` type on the `v1.x` branch.

Fixes #4812