### PR TITLE
fix(adapters/http): remove repeated compression algorithm from header

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -311,7 +311,7 @@ export default function httpAdapter(config) {
       return reject(customErr);
     }
 
-    headers.set('Accept-Encoding', 'gzip, deflate, gzip, br', false);
+    headers.set('Accept-Encoding', 'gzip, deflate, br', false);
 
     const options = {
       path: buildURL(parsed.path, config.params, config.paramsSerializer).replace(/^\?/, ''),


### PR DESCRIPTION
Remove repeated compression algorithm from default `Accept-Encoding` header.
