### PR TITLE
Fix deleting content-type in get request

### DIFF
--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -157,7 +157,7 @@ module.exports = function xhrAdapter(config) {
     // Add headers to the request
     if ('setRequestHeader' in request) {
       utils.forEach(requestHeaders, function setRequestHeader(val, key) {
-        if (typeof requestData === 'undefined' && key.toLowerCase() === 'content-type') {
+        if (typeof requestData === 'undefined' && key.toLowerCase() === 'content-type' && val === 'undefined') {
           // Remove Content-Type if data is undefined
           delete requestHeaders[key];
         } else {


### PR DESCRIPTION
This fixes an old issues https://github.com/axios/axios/issues/89 and https://github.com/axios/axios/issues/86, I faced this issue when I was working on a project when putting `content-type` in the `GET` request, it was not overridden, there is a custom solution is just to add `data: {}`, I was curious why this actually happens.

In the old version, it deleted the `request header` if the `data` is undefined check this code
```
    if (typeof requestData === 'undefined') {
      // Remove Content-Type if data is undefined
      delete requestHeaders[key];
   }
```

then to just remove the `content-type` header added this condition to the previous condition `key.toLowerCase() === 'content-type')` 

but it should also check if the `value` of the `content-type` if it is `undefined` or not to be able to override the `content-type` in headers otherwise delete it.


Thank you.

