### PR TITLE
Use WHATWG URL API instead of url.parse()

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -8,7 +8,6 @@ import {getProxyForUrl} from 'proxy-from-env';
 import http from 'http';
 import https from 'https';
 import followRedirects from 'follow-redirects';
-import url from 'url';
 import zlib from 'zlib';
 import {VERSION} from '../env/data.js';
 import transitionalDefaults from '../defaults/transitional.js';
@@ -62,13 +61,15 @@ function setProxy(options, configProxy, location) {
   if (!proxy && proxy !== false) {
     const proxyUrl = getProxyForUrl(location);
     if (proxyUrl) {
-      proxy = url.parse(proxyUrl);
-      // replace 'host' since the proxy object is not a URL object
-      proxy.host = proxy.hostname;
+      proxy = new URL(proxyUrl);
     }
   }
   if (proxy) {
     // Basic proxy authorization
+    if (proxy.username) {
+      proxy.auth = (proxy.username || '') + ':' + (proxy.password || '');
+    }
+
     if (proxy.auth) {
       // Support proxy auth object form
       if (proxy.auth.username || proxy.auth.password) {
@@ -81,8 +82,9 @@ function setProxy(options, configProxy, location) {
     }
 
     options.headers.host = options.hostname + (options.port ? ':' + options.port : '');
-    options.hostname = proxy.host;
-    options.host = proxy.host;
+    options.hostname = proxy.hostname;
+    // Replace 'host' since options is not a URL object
+    options.host = proxy.hostname;
     options.port = proxy.port;
     options.path = location;
     if (proxy.protocol) {
@@ -164,7 +166,7 @@ export default function httpAdapter(config) {
 
     // Parse url
     const fullPath = buildFullPath(config.baseURL, config.url);
-    const parsed = url.parse(fullPath);
+    const parsed = new URL(fullPath);
     const protocol = parsed.protocol || supportedProtocols[0];
 
     if (protocol === 'data:') {
@@ -292,17 +294,18 @@ export default function httpAdapter(config) {
       auth = username + ':' + password;
     }
 
-    if (!auth && parsed.auth) {
-      const urlAuth = parsed.auth.split(':');
-      const urlUsername = urlAuth[0] || '';
-      const urlPassword = urlAuth[1] || '';
+    if (!auth && parsed.username) {
+      var urlUsername = parsed.username;
+      var urlPassword = parsed.password;
       auth = urlUsername + ':' + urlPassword;
     }
 
     auth && headers.delete('authorization');
 
+    // parsed.path no longer exists (path = pathname + searchParams)
+    var path = parsed.pathname.concat(parsed.searchParams);
     try {
-      buildURL(parsed.path, config.params, config.paramsSerializer).replace(/^\?/, '');
+      buildURL(path, config.params, config.paramsSerializer).replace(/^\?/, '');
     } catch (err) {
       const customErr = new Error(err.message);
       customErr.config = config;
@@ -314,8 +317,9 @@ export default function httpAdapter(config) {
     headers.set('Accept-Encoding', 'gzip, deflate, gzip, br', false);
 
     const options = {
-      path: buildURL(parsed.path, config.params, config.paramsSerializer).replace(/^\?/, ''),
-      method,
+      // parsed.path no longer exists (path = pathname + searchParams)
+      path: buildURL(path, config.params, config.paramsSerializer).replace(/^\?/, ''),
+      method: method,
       headers: headers.toJSON(),
       agents: { http: config.httpAgent, https: config.httpsAgent },
       auth,

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -302,7 +302,6 @@ export default function httpAdapter(config) {
 
     auth && headers.delete('authorization');
 
-    // parsed.path no longer exists (path = pathname + searchParams)
     var path = parsed.pathname.concat(parsed.searchParams);
     try {
       buildURL(path, config.params, config.paramsSerializer).replace(/^\?/, '');
@@ -317,7 +316,6 @@ export default function httpAdapter(config) {
     headers.set('Accept-Encoding', 'gzip, deflate, gzip, br', false);
 
     const options = {
-      // parsed.path no longer exists (path = pathname + searchParams)
       path: buildURL(path, config.params, config.paramsSerializer).replace(/^\?/, ''),
       method: method,
       headers: headers.toJSON(),

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -295,14 +295,14 @@ export default function httpAdapter(config) {
     }
 
     if (!auth && parsed.username) {
-      var urlUsername = parsed.username;
-      var urlPassword = parsed.password;
+      const urlUsername = parsed.username;
+      const urlPassword = parsed.password;
       auth = urlUsername + ':' + urlPassword;
     }
 
     auth && headers.delete('authorization');
 
-    var path = parsed.pathname.concat(parsed.searchParams);
+    const path = parsed.pathname.concat(parsed.searchParams);
     try {
       buildURL(path, config.params, config.paramsSerializer).replace(/^\?/, '');
     } catch (err) {

--- a/test/unit/adapters/http.js
+++ b/test/unit/adapters/http.js
@@ -706,7 +706,7 @@ describe('supports http with nodejs', function () {
     }).listen(socketName, function () {
       axios({
         socketPath: socketName,
-        url: '/'
+        url: 'http://localhost:4444/socket'
       })
         .then(function (resp) {
           assert.equal(resp.status, 200);


### PR DESCRIPTION
As described by #4022 there are problems when parsing URLs using the deprecated API.

This PR aims to fix this by using the [WHATWG URL API](https://nodejs.org/api/url.html#the-whatwg-url-api). Minor changes were also made because the legacy URL object is not identical to the new one.

The same fix was made to v0.x and v2.x, only waiting to see if there is a request for changes on this PR so I can add them to other versions as well before creating their PRs, mainly because I'd like an opinion about the change made for the "should support sockets" test.