### PR TITLE
chore:  fix example access exception

### DIFF
--- a/examples/server.js
+++ b/examples/server.js
@@ -128,7 +128,9 @@ server = http.createServer(function (req, res) {
   // Process server request
   else if (new RegExp('(' + dirs.join('|') + ')\/server').test(url)) {
     if (fs.existsSync(path.join(__dirname, url + '.js'))) {
-      require(path.join(__dirname, url + '.js'))(req, res);
+      import(path.join(__dirname, url + '.js')).then(({default: send}) => {
+        send(req, res)
+      })
     } else {
       send404(res);
     }


### PR DESCRIPTION
#### Instructions

fix example access exception:

```
➜  axios git:(v1.x) ✗ npm run examples

> axios@1.0.0-alpha.1 examples
> node ./examples/server.js

Examples running on 3000
file:///Users/dongwang/code/hope/http-labs/axios/examples/server.js:133
      require(path.join(__dirname, url + '.js'))(req, res);
```
