### PR TITLE
fix: loosing request header (#4858)

### DIFF
--- a/lib/core/mergeConfig.js
+++ b/lib/core/mergeConfig.js
@@ -18,6 +18,8 @@ module.exports = function mergeConfig(config1, config2) {
   function getMergedValue(target, source) {
     if (utils.isPlainObject(target) && utils.isPlainObject(source)) {
       return utils.merge(target, source);
+    } else if (utils.isEmptyObject(source)) {
+      return utils.merge({}, target);
     } else if (utils.isPlainObject(source)) {
       return utils.merge({}, source);
     } else if (utils.isArray(source)) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -125,6 +125,16 @@ function isPlainObject(val) {
 }
 
 /**
+ * Determine if a value is a empty Object
+ *
+ * @param {Object} val The value to test
+ * @return {boolean} True if value is a empty Object, otherwise false
+ */
+function isEmptyObject(val) {
+  return val && Object.keys(val).length === 0 && Object.getPrototypeOf(val) === Object.prototype;
+}
+
+/**
  * Determine if a value is a Date
  *
  * @function
@@ -483,6 +493,7 @@ module.exports = {
   isNumber: isNumber,
   isObject: isObject,
   isPlainObject: isPlainObject,
+  isEmptyObject: isEmptyObject,
   isUndefined: isUndefined,
   isDate: isDate,
   isFile: isFile,

--- a/test/specs/core/mergeConfig.spec.js
+++ b/test/specs/core/mergeConfig.spec.js
@@ -257,6 +257,22 @@ describe('core::mergeConfig', function() {
         .toEqual({validateStatus: {a: 1, b: 2, c: 2}});
     });
 
+    it('should merge if config1 is class object', function() {
+      class Header {};
+      var validateStatus = new Header();
+      validateStatus["X-Foo"] = "bar";
+      var merged = mergeConfig({validateStatus: validateStatus}, {validateStatus: {}});
+      expect(JSON.stringify(merged.validateStatus)).toBe(JSON.stringify(validateStatus));
+    });
+
+    it('should merge if config2 is class object', function() {
+      class Header {};
+      var validateStatus = new Header();
+      validateStatus["X-Foo"] = "bar";
+      var merged = mergeConfig({validateStatus: {}}, {validateStatus: validateStatus});
+      expect(JSON.stringify(merged.validateStatus)).toBe(JSON.stringify(validateStatus));
+    });
+
     it('should clone config2 if is plain object', function() {
       var config1 = {validateStatus: [1, 2, 3]};
       var config2 = {validateStatus: {a: 1, b: 2}};


### PR DESCRIPTION
Fixes https://github.com/axios/axios/issues/4858

As described by https://github.com/axios/axios/issues/4858 there are problems that was loosing request headers.

Fix the error when pass headers parameters from class.

```js
class Header {};
let myHeaders = new Header();
myHeaders["X-Foo"] = "bar";
myHeaders["X-Test"] = "test";
myHeaders["X-Time"] = Date.now();
  
axios.post('http://cors-test.appspot.com/test', { name: 'foo' }, { headers: myHeaders })
.then((res) => {
       console.log('res---',res.config.headers);
 })
```

