### PR TITLE
fix: fix types of paramsSerializer

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -170,7 +170,7 @@ export interface SerializerOptions {
   visitor?: SerializerVisitor;
   dots?: boolean;
   metaTokens?: boolean;
-  indexes?: boolean;
+  indexes?: boolean | null;
 }
 
 // tslint:disable-next-line


### PR DESCRIPTION
<!-- Click "Preview" for a more readable version -->

#### Instructions

According to the source code and docs, the `paramsSerializer.indexes` could be set to `null`, so the types should be updated.

https://github.com/axios/axios/blob/cd8989a987f994c79148bb0cacfca3379ca27414/README.md?plain=1#L343-L346

https://github.com/axios/axios/blob/cd8989a987f994c79148bb0cacfca3379ca27414/lib/helpers/toFormData.js#L173

