### PR TITLE
fix: ts AxiosRequestConfig - cancelToken optional, url required

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -125,7 +125,7 @@ export interface ParamsSerializerOptions extends SerializerOptions {
 }
 
 export interface AxiosRequestConfig<D = any> {
-  url?: string;
+  url: string;
   method?: Method | string;
   baseURL?: string;
   transformRequest?: AxiosRequestTransformer | AxiosRequestTransformer[];
@@ -154,7 +154,7 @@ export interface AxiosRequestConfig<D = any> {
   httpAgent?: any;
   httpsAgent?: any;
   proxy?: AxiosProxyConfig | false;
-  cancelToken?: CancelToken;
+  cancelToken?: CancelToken | undefined;
   decompress?: boolean;
   transitional?: TransitionalOptions;
   signal?: GenericAbortSignal;


### PR DESCRIPTION
Issue: can't have optional `cancelToken` func param for axios.

Receiving next error:

> Argument of type '{ cancelToken: CancelToken | undefined; }' is not assignable to parameter of type 'AxiosRequestConfig' with 'exactOptionalPropertyTypes: true'.
> 
> Consider adding 'undefined' to the types of the target's properties.
> 
> Types of property 'cancelToken' are incompatible. Type 'CancelToken | undefined' is not assignable to type 'CancelToken'.

Example:
```javascript
interface RequestParamsFetch {
  url: AxiosRequestConfig['url'];
  cancelToken?: AxiosRequestConfig['cancelToken'];
}

const fetchExample = ({ url, cancelToken }: RequestParamsFetch) =>
  axios({
    url,
    cancelToken,
  });

fetchExample({
  url: 'example',
  cancelToken: axios.CancelToken.source().token,
});
```

<img width="668" alt="Знімок екрана 2022-08-04 о 20 55 19" src="https://user-images.githubusercontent.com/5191620/182918316-7f3c4466-9a80-4cb3-bbf9-792f060a3871.png">

