### PR TITLE
fix: modify log while request is aborted

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -458,7 +458,7 @@ export default function httpAdapter(config) {
           }
 
           const err = new AxiosError(
-            'maxContentLength size of ' + config.maxContentLength + ' exceeded',
+            'response stream aborted',
             AxiosError.ERR_BAD_RESPONSE,
             config,
             lastRequest


### PR DESCRIPTION
# What
Change a log sentence of "aborted response handling". 

# Why
The previous log sais 'maxContentLength size of {maxContentLength} exceeded', 
but it does not represent an actual error, because it is caused by **aborted response stream**.
