### PR TITLE
fix: [Types] Type of header in AxiosRequestConfig / for Axios.create is incorrect

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,11 @@
 // TypeScript Version: 4.1
-type AxiosHeaders = Record<string, string | string[] | number | boolean>;
+type JSONValue = string | string[] | number | boolean;
+
+interface JSONObject {
+  [x: string]: JSONValue;
+}
+
+type AxiosHeaders = Record<string, JSONValue | JSONObject>;
 
 type MethodsHeaders = {
   [Key in Method as Lowercase<Key>]: AxiosHeaders;

--- a/index.d.ts
+++ b/index.d.ts
@@ -9,7 +9,7 @@ interface CommonHeaders  {
   common: AxiosHeaders;
 }
 
-export type AxiosRequestHeaders = Partial<AxiosHeaders & MethodsHeaders & CommonHeaders>;
+export type AxiosRequestHeaders = Partial<AxiosHeaders | MethodsHeaders | CommonHeaders>;
 
 export type AxiosResponseHeaders = Partial<Record<string, string>> & {
   "set-cookie"?: string[]

--- a/test/typescript/axios.ts
+++ b/test/typescript/axios.ts
@@ -162,6 +162,10 @@ axios.post<User>('/user', { name: 'foo', id: 1 }, { headers: { 'X-FOO': 'bar' } 
 	.then(handleUserResponse)
 	.catch(handleError);
 
+axios.post<User>('/user', { name: 'foo', id: 1 }, { headers: { get: { 'X-FOO': 'bar' }} })
+	.then(handleUserResponse) 
+	.catch(handleError);
+
 axios.put<User>('/user', { name: 'foo', id: 1 })
 	.then(handleUserResponse)
 	.catch(handleError);


### PR DESCRIPTION
Adding a new Type for AxiosHeaders.