### PR TITLE
Improve typing of timeout in index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -200,6 +200,8 @@ export interface AxiosProgressEvent {
   download?: boolean;
 }
 
+type Milliseconds = number;
+
 export interface AxiosRequestConfig<D = any> {
   url?: string;
   method?: Method | string;
@@ -210,7 +212,7 @@ export interface AxiosRequestConfig<D = any> {
   params?: any;
   paramsSerializer?: ParamsSerializerOptions;
   data?: D;
-  timeout?: number;
+  timeout?: Milliseconds;
   timeoutErrorMessage?: string;
   withCredentials?: boolean;
   adapter?: AxiosAdapter;


### PR DESCRIPTION
I was wondering if the timeout in the configuration has to be seconds or milliseconds. I had to dig into the documentation to find the unit. 

therefore I introduced a [Type Alias](https://www.typescriptlang.org/docs/handbook/advanced-types.html#type-aliases) in the index.d.ts to improve the interface definition. now you're able to use your IDE to get the unit of the `timeout` field