### PR TITLE
Fix: typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ axios.get('/user?ID=12345')
     // handle error
     console.log(error);
   })
-  .then(function () {
+  .finally(function () {
     // always executed
   });
 
@@ -155,7 +155,7 @@ axios.get('/user', {
   .catch(function (error) {
     console.log(error);
   })
-  .then(function () {
+  .finally(function () {
     // always executed
   });  
 


### PR DESCRIPTION
Fixed the [issue #4940]  by correcting the typo of `.then` method instead of `.finally` method.