### PR TITLE
Add types for AxiosError.from-method

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -371,6 +371,14 @@ export class AxiosError<T = unknown, D = any> extends Error {
   status?: number;
   toJSON: () => object;
   cause?: Error;
+  static from<T = unknown, D = any>(
+    error: Error | unknown,
+    code?: string,
+    config?: AxiosRequestConfig<D>,
+    request?: any,
+    response?: AxiosResponse<T, D>,
+    customProps?: object,
+): AxiosError<T, D>;
   static readonly ERR_FR_TOO_MANY_REDIRECTS = "ERR_FR_TOO_MANY_REDIRECTS";
   static readonly ERR_BAD_OPTION_VALUE = "ERR_BAD_OPTION_VALUE";
   static readonly ERR_BAD_OPTION = "ERR_BAD_OPTION";


### PR DESCRIPTION
Adds the method signature for the static method `AxiosError.from` (https://github.com/axios/axios/blob/v0.x/lib/core/AxiosError.js#L79). 

Is there a reason it was not exposed so far?

I am not sure which base branch to choose :thinking:. As `AxiosError.from` is also present in the latest 0.x versions would it make more sense to make it the base branch or even main?
