### PR TITLE
Allow null indexes on formSerializer and paramsSerializer v0.x

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -109,7 +109,7 @@ export interface SerializerOptions {
   visitor?: SerializerVisitor;
   dots?: boolean;
   metaTokens?: boolean;
-  indexes?: boolean;
+  indexes?: boolean | null;
 }
 
 // tslint:disable-next-line

--- a/test/typescript/axios.ts
+++ b/test/typescript/axios.ts
@@ -270,6 +270,17 @@ instance1.defaults.timeout = 2500;
 
 axios.create({ headers: { foo: 'bar' } });
 axios.create({ headers: { common: { foo: 'bar' } } });
+axios.create({
+  headers: {
+    'Content-Type': 'application/json',
+  },
+  formSerializer: {
+    indexes: null,
+  },
+  paramsSerializer: {
+    indexes: null,
+  },
+});
 
 // Interceptors
 


### PR DESCRIPTION
Fixes [#4959](https://github.com/axios/axios/issues/4959)
Docs: [automatic-serialization-to-formdata](https://github.com/axios/axios#-automatic-serialization-to-formdata)

Allow indexes to receive null value.

```js
axios.create({
  headers: {
    'Content-Type': 'application/json',
  },
  formSerializer: {
    indexes: null,
  },
  paramsSerializer: {
    indexes: null,
  },
});
```

Axios Version: v0.x