### PR TITLE
fix: exception to sending formdata in webworker

### DIFF
--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -29,7 +29,7 @@ module.exports = function xhrAdapter(config) {
       }
     }
 
-    if (utils.isFormData(requestData) && utils.isStandardBrowserEnv()) {
+    if (utils.isFormData(requestData) && (utils.isStandardBrowserEnv() || utils.isStandardBrowserWebWorkerEnv())) {
       delete requestHeaders['Content-Type']; // Let the browser set it
     }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -242,6 +242,19 @@ function isStandardBrowserEnv() {
 }
 
 /**
+ * Determine if we're running in a standard browser webWorker environment
+ *
+ * Although the `isStandardBrowserEnv` method indicates that
+ * `allows axios to run in a web worker`, the WebWorker will still be
+ * filtered out due to its judgment standard
+ * `typeof window !== 'undefined' && typeof document !== 'undefined'`.
+ * This leads to a problem when axios post `FormData` in webWorker
+ */
+function isStandardBrowserWebWorkerEnv() {
+  return typeof WorkerGlobalScope !== 'undefined' && self instanceof WorkerGlobalScope && typeof self.importScripts === 'function';
+}
+
+/**
  * Iterate over an Array or an Object invoking a function for each item.
  *
  * If `obj` is an Array callback will be called passing
@@ -491,6 +504,7 @@ module.exports = {
   isStream: isStream,
   isURLSearchParams: isURLSearchParams,
   isStandardBrowserEnv: isStandardBrowserEnv,
+  isStandardBrowserWebWorkerEnv: isStandardBrowserWebWorkerEnv,
   forEach: forEach,
   merge: merge,
   extend: extend,


### PR DESCRIPTION
The following code is a request to send fromdata through axios and xhr at the same time

```js
// create formdata
const file = new File(
  [Uint8Array.from(atob(btoa("abc")), (c) => c.charCodeAt(0)).buffer],
  "a.png",
  { type: "image/png" }
);

const form = new FormData();
form.append("file", file);

// axios send
axios.request({ method: "post", url: "/api_axios", data: form });

// xhr send
const xhr = new XMLHttpRequest();
xhr.open("POST", "api_xhr");
xhr.send(form);
```

Put the above methods into `browser` to run and `web worker` to run respectively

**browser axios Request Header abstract**

```
Content-Type: multipart/form-data; boundary=----WebKitFormBoundary6OBbVuvmtQJTBd6D
```

**browser xhr  Request Header abstract**

```
Content-Type: multipart/form-data; boundary=----WebKitFormBoundaryLY8kGoWmnvspdjMs
```

The above is no problem, of course, when you put the code into `web worker` to run, it will appear

**web worker axios Request Header abstract**

```
Content-Type: application/x-www-form-urlencoded
```

**web worker xhr Request Header abstract**

```
Content-Type: multipart/form-data; boundary=----WebKitFormBoundary6trgIn70ilzcBsuh
```

At this time, the performance of xhr is normal, but axios has an exception.

To solve this problem I made the following changes. As for why not directly modify the `isStandardBrowserEnv` method, but create a new `isStandardBrowserWebWorkerEnv` method, the main reason is that many methods that rely on `isStandardBrowserEnv` use `document` in the follow-up.