### PR TITLE
docs: enable syntax highlighting for a code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -879,7 +879,7 @@ You can also use the [`qs`](https://github.com/ljharb/qs) library.
 
 Axios will automatically serialize the data object to urlencoded format if the content-type header is set to "application/x-www-form-urlencoded".
 
-```
+```js
 const data = {
   x: 1,
   arr: [1, 2, 3],


### PR DESCRIPTION
Enables syntax highlighting for a code block in README.md.