### PR TITLE
fix: exporting missing exports in type definition `index.d.ts`

### DIFF
--- a/lib/axios.js
+++ b/lib/axios.js
@@ -7,13 +7,15 @@ import mergeConfig from './core/mergeConfig.js';
 import defaults from './defaults/index.js';
 import formDataToJSON from './helpers/formDataToJSON.js';
 import CanceledError from './cancel/CanceledError.js';
-import CancelToken from'./cancel/CancelToken.js';
-import isCancel from'./cancel/isCancel.js';
+import CancelToken from './cancel/CancelToken.js';
+import isCancel from './cancel/isCancel.js';
 import {VERSION} from './env/data.js';
 import toFormData from './helpers/toFormData.js';
 import AxiosError from './core/AxiosError.js';
 import spread from './helpers/spread.js';
 import isAxiosError from './helpers/isAxiosError.js';
+import AxiosHeaders from './core/AxiosHeaders.js';
+
 
 /**
  * Create an instance of Axios
@@ -74,3 +76,11 @@ axios.formToJSON = thing => {
 };
 
 export default axios;
+
+export {
+  Axios,
+  AxiosHeaders,
+  AxiosError,
+  CanceledError,
+};
+


### PR DESCRIPTION
close https://github.com/axios/axios/issues/5001

`index.d.ts` exports class `Axios`, `AxiosHeaders`, `AxiosError`, `CanceledError`, but they are not exported in runtime code.