### PR TITLE
Fix commonjs & umd exports

### DIFF
--- a/lib/axios.js
+++ b/lib/axios.js
@@ -75,12 +75,10 @@ axios.formToJSON = thing => {
   return formDataToJSON(utils.isHTMLForm(thing) ? new FormData(thing) : thing);
 };
 
-export default axios;
-
 export {
+  axios as default,
   Axios,
   AxiosHeaders,
   AxiosError,
   CanceledError,
 };
-

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -56,7 +56,7 @@ export default async () => {
         file: `dist/${outputFileName}`,
         name,
         format: "umd",
-        exports: "default",
+        exports: "named",
         banner
       }
     }),
@@ -77,7 +77,7 @@ export default async () => {
         file: `dist/node/${name}.cjs`,
         format: "cjs",
         preferConst: true,
-        exports: "default",
+        exports: "named",
         banner
       },
       plugins: [


### PR DESCRIPTION
Fixes the following issues (missing `default` export):
- ~#5000~
- #5008
- #5011 

Also fixes rollup build, an issue introduced in d61dbed. After these exports were added, rollup could not produce builds with `exports: "default"`, as it is not able to conclude what to do in this case (see [here](https://github.com/rollup/rollup/blob/69ff4181e701a0fe0026d0ba147f31bc86beffa8/src/utils/getExportMode.ts#L19-L22)).

Exporting a member named `default` and changing rollup configuration resolves all of the mentioned issues and successfully creates production builds. 
