### PR TITLE
fix: Unable to access response headers when using axios 1.x with jest #5017

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -132,7 +132,7 @@ const isPlainObject = (val) => {
   }
 
   const prototype = getPrototypeOf(val);
-  return prototype === null || prototype === Object.prototype;
+  return (prototype === null || prototype === Object.prototype || Object.getPrototypeOf(prototype) === null) && !(Symbol.toStringTag in val) && !(Symbol.iterator in val);
 }
 
 /**


### PR DESCRIPTION
When axios 1.0.0 runs under jest, it fails to set headers on the response object properly.

For a detailed description please see here: https://github.com/axios/axios/issues/5017

The problem in the plainObject check function, where 

```prototype === null || prototype === Object.prototype;```

Is false for response.headers under jest, as jest seems to modify prototype of objects.

The fix is inspired by the is plain module https://github.com/sindresorhus/is-plain-obj, mainly their checking logic:

https://github.com/sindresorhus/is-plain-obj/blob/68e8cc77bb1bbd0bf7d629d3574b6ca70289b2cc/index.js#L7

Edit: I do now know how to write a test for this, as it manifests only under a different test framework than the project uses. 