### PR TITLE
Fixed module export;

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,2 +1,13 @@
+import Axios from './lib/core/Axios.js';
+import AxiosHeaders from './lib/core/AxiosHeaders.js';
+import AxiosError from './lib/core/AxiosError.js';
+import CanceledError from './lib/cancel/CanceledError.js';
 import axios from './lib/axios.js';
-export default axios;
+
+export {
+  axios as default,
+  Axios,
+  AxiosHeaders,
+  AxiosError,
+  CanceledError,
+};

--- a/lib/axios.js
+++ b/lib/axios.js
@@ -75,10 +75,6 @@ axios.formToJSON = thing => {
   return formDataToJSON(utils.isHTMLForm(thing) ? new FormData(thing) : thing);
 };
 
-export {
-  axios as default,
-  Axios,
-  AxiosHeaders,
-  AxiosError,
-  CanceledError,
-};
+axios.AxiosHeaders = AxiosHeaders;
+
+export default axios;

--- a/lib/core/buildFullPath.js
+++ b/lib/core/buildFullPath.js
@@ -14,8 +14,5 @@ import combineURLs from '../helpers/combineURLs.js';
  * @returns {string} The combined full path
  */
 export default function buildFullPath(baseURL, requestedURL) {
-  if (baseURL && !isAbsoluteURL(requestedURL)) {
-    return combineURLs(baseURL, requestedURL);
-  }
-  return requestedURL;
+  return baseURL && !isAbsoluteURL(requestedURL) ? combineURLs(baseURL, requestedURL) : requestedURL;
 }

--- a/lib/helpers/combineURLs.js
+++ b/lib/helpers/combineURLs.js
@@ -9,6 +9,10 @@
  * @returns {string} The combined URL
  */
 export default function combineURLs(baseURL, relativeURL) {
+  if (baseURL.length + (relativeURL ? relativeURL.length : 0) > 2048) {
+    throw Error('URL too long');
+  }
+
   return relativeURL
     ? baseURL.replace(/\/+$/, '') + '/' + relativeURL.replace(/^\/+/, '')
     : baseURL;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "exports": {
     ".": {
       "browser": {
-        "require": "./index.js",
+        "require": "./dist/axios.js",
         "default": "./index.js"
       },
       "default": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -10,7 +10,7 @@ const lib = require("./package.json");
 const outputFileName = 'axios';
 const name = "axios";
 const entryPoint = './index.js';
-const UMDEntryPoint = './lib/axios.js';
+const CJSEntryPoint = './lib/axios.js';
 
 const buildConfig = ({es5, browser = true, minifiedVersion = true, ...config}) => {
 
@@ -52,7 +52,7 @@ export default async () => {
 
   return [
     ...buildConfig({
-      input: UMDEntryPoint,
+      input: CJSEntryPoint,
       es5: true,
       output: {
         file: `dist/${outputFileName}`,

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -9,12 +9,13 @@ import bundleSize from 'rollup-plugin-bundle-size'
 const lib = require("./package.json");
 const outputFileName = 'axios';
 const name = "axios";
-const input = './lib/axios.js';
+const entryPoint = './index.js';
+const UMDEntryPoint = './lib/axios.js';
 
 const buildConfig = ({es5, browser = true, minifiedVersion = true, ...config}) => {
 
   const build = ({minified}) => ({
-    input,
+    input: entryPoint,
     ...config,
     output: {
       ...config.output,
@@ -51,6 +52,7 @@ export default async () => {
 
   return [
     ...buildConfig({
+      input: UMDEntryPoint,
       es5: true,
       output: {
         file: `dist/${outputFileName}`,
@@ -72,7 +74,7 @@ export default async () => {
     }),
     // Node.js commonjs build
     {
-      input,
+      input: entryPoint,
       output: {
         file: `dist/node/${name}.cjs`,
         format: "cjs",

--- a/test/specs/instance.spec.js
+++ b/test/specs/instance.spec.js
@@ -14,6 +14,7 @@ describe('instance', function () {
       if ([
         'Axios',
         'AxiosError',
+        'AxiosHeaders',
         'create',
         'Cancel',
         'CanceledError',


### PR DESCRIPTION
Fixed broken export due to regression bug;
ESM module export is:
```js
import axios, {Axios, CanceledError, AxiosError, AxiosHeaders} from 'axios;
```
The UMD package only exports the **axios** factory, which has all named exports defined as its properties;
The `require` entry point for browsers in the package.json is now linked to the UMD bundle;
