### PR TITLE
Fix: typescript set-cookie header type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -71,7 +71,7 @@ export type RawAxiosRequestHeaders = Partial<RawAxiosHeaders & MethodsHeaders & 
 export type AxiosRequestHeaders = Partial<RawAxiosHeaders & MethodsHeaders & CommonHeaders> & AxiosHeaders;
 
 export type RawAxiosResponseHeaders = Partial<Record<string, string> & {
-  "set-cookie"?: string[]
+  "set-cookie"?: string
 }>;
 
 export type AxiosResponseHeaders = RawAxiosResponseHeaders & AxiosHeaders;


### PR DESCRIPTION
<!-- Click "Preview" for a more readable version -->

#### Instructions

Since the release of axios 1.0, it now returns the set-cookie header as a string
