### PR TITLE
pin CDN install instructions to a specific version

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,13 +115,13 @@ $ pnpm add axios
 Using jsDelivr CDN:
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/axios@1.1.2/dist/axios.min.js"></script>
 ```
 
 Using unpkg CDN:
 
 ```html
-<script src="https://unpkg.com/axios/dist/axios.min.js"></script>
+<script src="https://unpkg.com/axios@1.1.2/dist/axios.min.js"></script>
 ```
 
 ## Example


### PR DESCRIPTION
I guess the current chaos around #5038 shows that people should be encouraged to link their CDN usage against specific versions and not just against `latest`. 

Of course this will add the additional chore of updating `README.md` on every release, but it's probably worth doing.

If you don't like the idea, feel free to close this PR into oblivion, I just thought it's more productive to open a PR proactively instead of writing in that other thread ;)