### PR TITLE
fix problem with named export `axios`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -480,4 +480,5 @@ export interface AxiosStatic extends AxiosInstance {
 
 declare const axios: AxiosStatic;
 
+export { axios };
 export default axios;

--- a/index.js
+++ b/index.js
@@ -28,5 +28,6 @@ export {
   Cancel,
   isAxiosError,
   spread,
-  toFormData
+  toFormData,
+  axios
 }


### PR DESCRIPTION
#### Instructions

Fixes https://github.com/axios/axios/issues/5101

I also chucked in a small fix for the default export to work with `NodeNext`, a bit of context here

https://github.com/microsoft/TypeScript/issues/49298
https://github.com/microsoft/TypeScript/issues/50690

Basically, I will make it so people can import `axios` as a named import rather than having to do something like:

```ts
import { default as axios } from 'axios';
```

---

**UPDATE:** I saw you have already taken care of #5101 by updating `exports` in `package.json`, but the problem with named exports remains. Please see my repro here https://github.com/akphi/issue-repo/pull/12

I don't think `import { axios } from 'axios';` work at all.
