### PR TITLE
fix:  error of importing files in lib directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
         "require": "./dist/node/axios.cjs",
         "default": "./index.js"
       }
-    }
+    },
+    "./lib/*": "./lib/*.js"
   },
   "type": "module",
   "types": "index.d.ts",


### PR DESCRIPTION
<!-- Click "Preview" for a more readable version -->

#### Instructions

Fixes [issue:#5072](https://github.com/axios/axios/issues/5072)
Fixes [issue:#5080](https://github.com/axios/axios/issues/5080)


Avoid [ERR_PACKAGE_PATH_NOT_EXPORTED](https://nodejs.org/api/errors.html#err_package_path_not_exported) when importing files which are in the lib directory.