### PR TITLE
feat: export mergeConfig

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,8 @@ const {
   spread,
   toFormData,
   AxiosHeaders,
-  formToJSON
+  formToJSON,
+  mergeConfig
 } = axios;
 
 export {
@@ -33,5 +34,6 @@ export {
   spread,
   toFormData,
   AxiosHeaders,
-  formToJSON
+  formToJSON,
+  mergeConfig
 }

--- a/lib/axios.js
+++ b/lib/axios.js
@@ -70,6 +70,9 @@ axios.spread = spread;
 // Expose isAxiosError
 axios.isAxiosError = isAxiosError;
 
+// Expose mergeConfig
+axios.mergeConfig = mergeConfig;
+
 axios.AxiosHeaders = AxiosHeaders;
 
 axios.formToJSON = thing => formDataToJSON(utils.isHTMLForm(thing) ? new FormData(thing) : thing);

--- a/test/specs/api.spec.js
+++ b/test/specs/api.spec.js
@@ -50,6 +50,10 @@ describe('static api', function () {
   it('should have isAxiosError properties', function () {
     expect(typeof axios.isAxiosError).toEqual('function');
   });
+
+  it('should have mergeConfig properties', function () {
+    expect(typeof axios.mergeConfig).toEqual('function');
+  });
 });
 
 describe('instance api', function () {

--- a/test/specs/instance.spec.js
+++ b/test/specs/instance.spec.js
@@ -23,6 +23,7 @@ describe('instance', function () {
         'spread',
         'getUri',
         'isAxiosError',
+        'mergeConfig',
         'VERSION',
         'default',
         'toFormData',


### PR DESCRIPTION
Export the `mergeConfig` utility function, as has been previously requested [here](https://github.com/axios/axios/issues/3905).

I believe tacking `mergeConfig` directly on to the default export is the simplest and most flexible solution, since adding `lib/core/mergeConfig.js` to the `exports` of `package.json` would require additional work on the build step to support CJS – and it also seems like a bit of an anti-pattern to expose individual files like that.

I'm happy to discuss use-cases if anyone needs more convincing, but I think the author of #3905 already did a great job with that. The TL;DR is basically "the ability to merge configs within an interceptor is very useful, and trying to re-create that functionality is error-prone because `mergeConfig` has a ton of logic that's very specific to `axios` internals".
 