### PR TITLE
#4998 Fix strict mode properties access issue.

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ import axios from './lib/axios.js';
 
 // Keep top-level export same with static properties
 // so that it can keep same with es module or cjs
-const {
+export const {
   Axios,
   AxiosError,
   CanceledError,
@@ -17,16 +17,3 @@ const {
 } = axios;
 
 export default axios;
-export {
-  Axios,
-  AxiosError,
-  CanceledError,
-  isCancel,
-  CancelToken,
-  VERSION,
-  all,
-  Cancel,
-  isAxiosError,
-  spread,
-  toFormData
-}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -512,7 +512,12 @@ const reduceDescriptors = (obj, reducer) => {
   const reducedDescriptors = {};
 
   forEach(descriptors, (descriptor, name) => {
-    if (reducer(descriptor, name, obj) !== false) {
+    if (
+      name !== 'caller' &&
+      name !== 'callee' &&
+      name !== 'arguments' &&
+      reducer(descriptor, name, obj) !== false
+    ) {
       reducedDescriptors[name] = descriptor;
     }
   });


### PR DESCRIPTION
freezeMethods run reduceDescriptors method with reducer that is trying to access restricted properties for the strict mode.
Code was crashing on importing following  line:
`const value = obj[name]; `
where this restricted properties access was made.

This commit fix restricted access in strict mode for 'caller', 'callee', and 'arguments' properties. 
`TypeError: 'caller', 'callee', and 'arguments' properties may not be accessed on strict mode.`
Also simplify named export. 

Should fix #4998, #5005 and #5006.
