### PR TITLE
Refactored module exports;

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ typings/
 coverage/
 test/typescript/axios.js*
 sauce_connect.log
+test/module/cjs/node_modules/
+test/module/cjs/package-lock.json
+backup/

--- a/.npmignore
+++ b/.npmignore
@@ -16,3 +16,4 @@ Gruntfile.js
 karma.conf.js
 webpack.*.js
 sauce_connect.log
+backup/

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@
   - [Features](#features)
   - [Browser Support](#browser-support)
   - [Installing](#installing)
+    - [Package manager](#package-manager)
+    - [CDN](#cdn)
   - [Example](#example)
   - [Axios API](#axios-api)
   - [Request method aliases](#request-method-aliases)
@@ -93,6 +95,8 @@ Latest ✔ | Latest ✔ | Latest ✔ | Latest ✔ | Latest ✔ | 11 ✔ |
 
 ## Installing
 
+### Package manager
+
 Using npm:
 
 ```bash
@@ -117,7 +121,39 @@ Using pnpm:
 $ pnpm add axios
 ```
 
-Using jsDelivr CDN:
+Once the package is installed, you can import the library using `import` or `require` approach:
+
+```js
+import axios, {isCancel, AxiosError} from 'axios';
+```
+
+You can also use the default export, since the named export is just a re-export from the Axios factory:
+
+```js
+import axios from 'axios';
+
+console.log(axios.isCancel('something'));
+````
+
+If you use `require` for importing, **only default export is available**:
+
+```js
+const axios = require('axios');
+
+console.log(axios.isCancel('something'));
+```
+
+For cases where something went wrong when trying to import a module into a custom or legacy environment,
+you can try importing the module package directly:
+
+```js
+const axios = require('axios/dist/browser/axios.cjs'); // browser commonJS bundle (ES2017)
+// const axios = require('axios/dist/node/axios.cjs'); // node commonJS bundle (ES2017)
+```
+
+### CDN
+
+Using jsDelivr CDN (ES5 UMD browser module):
 
 ```html
 <script src="https://cdn.jsdelivr.net/npm/axios@1.1.2/dist/axios.min.js"></script>
@@ -131,19 +167,11 @@ Using unpkg CDN:
 
 ## Example
 
-### note: CommonJS usage
-In order to gain the TypeScript typings (for intellisense / autocomplete) while using CommonJS imports with `require()` use the following approach:
-
-```js
-const axios = require('axios').default;
-
-// axios.<method> will now provide autocomplete and parameter typings
-```
-
 Performing a `GET` request
 
 ```js
-const axios = require('axios').default;
+import axios from 'axios';
+//const axios = require('axios'); // legacy way
 
 // Make a request for a user with a given ID
 axios.get('/user?ID=12345')

--- a/index.d.ts
+++ b/index.d.ts
@@ -463,6 +463,18 @@ export interface GenericHTMLFormElement {
   submit(): void;
 }
 
+export function toFormData(sourceObj: object, targetFormData?: GenericFormData, options?: FormSerializerOptions): GenericFormData;
+
+export function formToJSON(form: GenericFormData|GenericHTMLFormElement): object;
+
+export function isAxiosError<T = any, D = any>(payload: any): payload is AxiosError<T, D>;
+
+export function spread<T, R>(callback: (...args: T[]) => R): (array: T[]) => R;
+
+export function isCancel(value: any): value is Cancel;
+
+export function all<T>(values: Array<T | Promise<T>>): Promise<T[]>;
+
 export interface AxiosStatic extends AxiosInstance {
   create(config?: CreateAxiosDefaults): AxiosInstance;
   Cancel: CancelStatic;
@@ -470,12 +482,12 @@ export interface AxiosStatic extends AxiosInstance {
   Axios: typeof Axios;
   AxiosError: typeof AxiosError;
   readonly VERSION: string;
-  isCancel(value: any): value is Cancel;
-  all<T>(values: Array<T | Promise<T>>): Promise<T[]>;
-  spread<T, R>(callback: (...args: T[]) => R): (array: T[]) => R;
-  isAxiosError<T = any, D = any>(payload: any): payload is AxiosError<T, D>;
-  toFormData(sourceObj: object, targetFormData?: GenericFormData, options?: FormSerializerOptions): GenericFormData;
-  formToJSON(form: GenericFormData|GenericHTMLFormElement): object;
+  isCancel: typeof isCancel;
+  all: typeof all;
+  spread: typeof spread;
+  isAxiosError: typeof isAxiosError;
+  toFormData: typeof toFormData;
+  formToJSON: typeof formToJSON;
 }
 
 declare const axios: AxiosStatic;

--- a/index.d.ts
+++ b/index.d.ts
@@ -488,6 +488,8 @@ export interface AxiosStatic extends AxiosInstance {
   isAxiosError: typeof isAxiosError;
   toFormData: typeof toFormData;
   formToJSON: typeof formToJSON;
+  CanceledError: typeof CanceledError;
+  AxiosHeaders: typeof AxiosHeaders;
 }
 
 declare const axios: AxiosStatic;

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 import axios from './lib/axios.js';
 
+// This module is intended to unwrap Axios default export as named.
 // Keep top-level export same with static properties
 // so that it can keep same with es module or cjs
 const {
@@ -13,11 +14,13 @@ const {
   Cancel,
   isAxiosError,
   spread,
-  toFormData
+  toFormData,
+  AxiosHeaders,
+  formToJSON
 } = axios;
 
-export default axios;
 export {
+  axios as default,
   Axios,
   AxiosError,
   CanceledError,
@@ -28,5 +31,7 @@ export {
   Cancel,
   isAxiosError,
   spread,
-  toFormData
+  toFormData,
+  AxiosHeaders,
+  formToJSON
 }

--- a/lib/axios.js
+++ b/lib/axios.js
@@ -14,6 +14,7 @@ import toFormData from './helpers/toFormData.js';
 import AxiosError from './core/AxiosError.js';
 import spread from './helpers/spread.js';
 import isAxiosError from './helpers/isAxiosError.js';
+import AxiosHeaders from "./core/AxiosHeaders.js";
 
 /**
  * Create an instance of Axios
@@ -69,8 +70,9 @@ axios.spread = spread;
 // Expose isAxiosError
 axios.isAxiosError = isAxiosError;
 
-axios.formToJSON = thing => {
-  return formDataToJSON(utils.isHTMLForm(thing) ? new FormData(thing) : thing);
-};
+axios.AxiosHeaders = AxiosHeaders;
 
+axios.formToJSON = thing => formDataToJSON(utils.isHTMLForm(thing) ? new FormData(thing) : thing);
+
+// this module should only have a default export
 export default axios

--- a/package.json
+++ b/package.json
@@ -6,22 +6,24 @@
   "exports": {
     ".": {
       "browser": {
-        "require": "./dist/node/axios.cjs",
+        "require": "./dist/browser/axios.cjs",
         "default": "./index.js"
       },
       "default": {
         "require": "./dist/node/axios.cjs",
         "default": "./index.js"
       }
-    }
+    },
+    "./package.json": "./package.json"
   },
   "type": "module",
   "types": "index.d.ts",
   "scripts": {
-    "test": "npm run test:eslint && npm run test:mocha && npm run test:karma && npm run test:dtslint",
+    "test": "npm run test:eslint && npm run test:mocha && npm run test:karma && npm run test:exports && npm run test:dtslint",
     "test:eslint": "node bin/ssl_hotfix.js eslint lib/**/*.js",
     "test:dtslint": "node bin/ssl_hotfix.js dtslint",
     "test:mocha": "node bin/ssl_hotfix.js mocha test/unit/**/*.js --timeout 30000 --exit",
+    "test:exports": "node bin/ssl_hotfix.js mocha test/module/test.js --timeout 30000 --exit",
     "test:karma": "node bin/ssl_hotfix.js cross-env LISTEN_ADDR=:: karma start karma.conf.cjs --single-run",
     "test:karma:server": "node bin/ssl_hotfix.js cross-env karma start karma.conf.cjs",
     "start": "node ./sandbox/server.js",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,20 +5,28 @@ import json from '@rollup/plugin-json';
 import { babel } from '@rollup/plugin-babel';
 import autoExternal from 'rollup-plugin-auto-external';
 import bundleSize from 'rollup-plugin-bundle-size'
+import path from 'path';
 
 const lib = require("./package.json");
 const outputFileName = 'axios';
 const name = "axios";
-const input = './lib/axios.js';
+const namedInput = './index.js';
+const defaultInput = './lib/axios.js';
 
 const buildConfig = ({es5, browser = true, minifiedVersion = true, ...config}) => {
+  const {file} = config.output;
+  const ext = path.extname(file);
+  const basename = path.basename(file, ext);
+  const extArr = ext.split('.');
+  extArr.shift();
+
 
   const build = ({minified}) => ({
-    input,
+    input: namedInput,
     ...config,
     output: {
       ...config.output,
-      file: `${config.output.file}.${minified ? "min.js" : "js"}`
+      file: `${path.dirname(file)}/${basename}.${(minified ? ['min', ...extArr] : extArr).join('.')}`
     },
     plugins: [
       json(),
@@ -50,10 +58,24 @@ export default async () => {
   const banner = `// Axios v${lib.version} Copyright (c) ${year} ${lib.author} and contributors`;
 
   return [
+    // browser ESM bundle for CDN
     ...buildConfig({
+      input: namedInput,
+      output: {
+        file: `dist/esm/${outputFileName}.js`,
+        format: "esm",
+        preferConst: true,
+        exports: "named",
+        banner
+      }
+    }),
+
+    // Browser UMD bundle for CDN
+    ...buildConfig({
+      input: defaultInput,
       es5: true,
       output: {
-        file: `dist/${outputFileName}`,
+        file: `dist/${outputFileName}.js`,
         name,
         format: "umd",
         exports: "default",
@@ -61,18 +83,23 @@ export default async () => {
       }
     }),
 
+    // Browser CJS bundle
     ...buildConfig({
+      input: defaultInput,
+      es5: false,
+      minifiedVersion: false,
       output: {
-        file: `dist/esm/${outputFileName}`,
-        format: "esm",
-        preferConst: true,
-        exports: "named",
+        file: `dist/browser/${name}.cjs`,
+        name,
+        format: "cjs",
+        exports: "default",
         banner
       }
     }),
-    // Node.js commonjs build
+
+    // Node.js commonjs bundle
     {
-      input,
+      input: defaultInput,
       output: {
         file: `dist/node/${name}.cjs`,
         format: "cjs",

--- a/test/module/cjs/index.js
+++ b/test/module/cjs/index.js
@@ -1,0 +1,11 @@
+const axios = require('axios');
+const assert = require('assert');
+
+const {CanceledError, AxiosError, AxiosHeaders} = axios;
+
+assert.strictEqual(typeof axios, 'function');
+assert.strictEqual(typeof CanceledError, 'function');
+assert.strictEqual(typeof AxiosError, 'function');
+assert.strictEqual(typeof AxiosHeaders, 'function');
+
+console.log('CommonJS importing test passed');

--- a/test/module/cjs/package.json
+++ b/test/module/cjs/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "cjs-module-test",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "npm i --no-save --no-package-lock && node index.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "axios": "file:../../.."
+  }
+}

--- a/test/module/esm/index.js
+++ b/test/module/esm/index.js
@@ -1,0 +1,13 @@
+import assert from 'assert';
+import axios, {CanceledError, AxiosError, AxiosHeaders} from 'axios';
+
+assert.strictEqual(typeof axios, 'function');
+assert.strictEqual(typeof CanceledError, 'function');
+assert.strictEqual(typeof AxiosError, 'function');
+assert.strictEqual(typeof AxiosHeaders, 'function');
+
+assert.strictEqual(axios.CanceledError, CanceledError);
+assert.strictEqual(axios.AxiosError, AxiosError);
+assert.strictEqual(axios.AxiosHeaders, AxiosHeaders);
+
+console.log('ESM importing test passed');

--- a/test/module/esm/package.json
+++ b/test/module/esm/package.json
@@ -1,8 +1,9 @@
 {
-  "name": "cjs-entrypoint-test",
+  "name": "esm-entrypoint-test",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
+  "type": "module",
   "scripts": {
     "test": "npm i --no-save --no-package-lock && node index.js"
   },

--- a/test/module/test.js
+++ b/test/module/test.js
@@ -71,4 +71,18 @@ describe('module', function () {
     });
   });
 
+  describe('ESM', ()=> {
+    const pkgPath = path.join(__dirname, './esm');
+
+    after(async ()=> {
+      await remove(path.join(pkgPath, './node_modules'));
+    });
+
+    it('should be able to be loaded with import', async function () {
+      this.timeout(30000);
+
+      await exec(`npm test --prefix ${pkgPath}`);
+    });
+  });
+
 });

--- a/test/module/test.js
+++ b/test/module/test.js
@@ -19,9 +19,13 @@ const ignoreList = [];
 
 const instance = axiosFactory.create({});
 
-const remove = (file) => {
+const remove = async (file) => {
   console.log(`✓ Remove entry '${file}'...`);
-  return fs.remove(file);
+  try {
+    await fs.remove(file);
+  } catch (err) {
+    console.warn(err);
+  }
 }
 
 describe('module', function () {
@@ -82,6 +86,20 @@ describe('module', function () {
       this.timeout(30000);
 
       await exec(`npm test --prefix ${pkgPath}`);
+    });
+  });
+
+  describe('TS', ()=> {
+    const pkgPath = path.join(__dirname, './ts');
+
+    after(async ()=> {
+      await remove(path.join(pkgPath, './node_modules'));
+    });
+
+    it('should be able to be loaded with import', async function () {
+      this.timeout(30000);
+
+      await exec(`npm test --prefix ${pkgPath}`, {});
     });
   });
 

--- a/test/module/ts/index.ts
+++ b/test/module/ts/index.ts
@@ -1,0 +1,24 @@
+import assert from 'assert';
+import axios, {CanceledError, AxiosError, AxiosHeaders, formToJSON, spread, isAxiosError, isCancel, all, toFormData} from 'axios';
+
+assert.strictEqual(typeof axios, 'function');
+
+assert.strictEqual(typeof CanceledError, 'function');
+assert.strictEqual(typeof AxiosError, 'function');
+assert.strictEqual(typeof AxiosHeaders, 'function');
+assert.strictEqual(typeof formToJSON, 'function');
+assert.strictEqual(typeof spread, 'function');
+assert.strictEqual(typeof isAxiosError, 'function');
+assert.strictEqual(typeof isCancel, 'function');
+assert.strictEqual(typeof all, 'function');
+assert.strictEqual(typeof toFormData, 'function');
+
+assert.strictEqual(typeof axios.CanceledError, 'function');
+assert.strictEqual(typeof axios.AxiosError, 'function');
+assert.strictEqual(typeof axios.AxiosHeaders, 'function');
+assert.strictEqual(typeof axios.formToJSON, 'function');
+assert.strictEqual(typeof axios.spread, 'function');
+assert.strictEqual(typeof axios.isAxiosError, 'function');
+assert.strictEqual(typeof axios.isCancel, 'function');
+assert.strictEqual(typeof axios.all, 'function');
+assert.strictEqual(typeof axios.toFormData, 'function');

--- a/test/module/ts/package.json
+++ b/test/module/ts/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "ts-entrypoint-test",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "npm i --no-save --no-package-lock && npm run build && node index.js",
+    "build": "tsc"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "@types/node": "^18.11.3",
+    "axios": "file:../../.."
+  },
+  "devDependencies": {
+    "typescript": "^4.8.4"
+  }
+}

--- a/test/module/ts/tsconfig.json
+++ b/test/module/ts/tsconfig.json
@@ -1,0 +1,103 @@
+{
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig to read more about this file */
+
+    /* Projects */
+    // "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
+    // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
+    // "tsBuildInfoFile": "./.tsbuildinfo",              /* Specify the path to .tsbuildinfo incremental compilation file. */
+    // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
+    // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
+    // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
+
+    /* Language and Environment */
+    "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    // "jsx": "preserve",                                /* Specify what JSX code is generated. */
+    // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
+    // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
+    // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */
+    // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
+    // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using 'jsx: react-jsx*'. */
+    // "reactNamespace": "",                             /* Specify the object invoked for 'createElement'. This only applies when targeting 'react' JSX emit. */
+    // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
+    // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
+    // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
+
+    /* Modules */
+    "module": "commonjs",                                /* Specify what module code is generated. */
+    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
+    // "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
+    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
+    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+    // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
+    // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
+    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+    // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
+    // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
+    // "resolveJsonModule": true,                        /* Enable importing .json files. */
+    // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
+
+    /* JavaScript Support */
+    // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
+    // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
+    // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
+
+    /* Emit */
+    // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
+    // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
+    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+    // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
+    // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
+    // "removeComments": true,                           /* Disable emitting comments. */
+    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
+    // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
+    // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types. */
+    // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
+    // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
+    // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
+    // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
+    // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
+    // "newLine": "crlf",                                /* Set the newline character for emitting files. */
+    // "stripInternal": true,                            /* Disable emitting declarations that have '@internal' in their JSDoc comments. */
+    // "noEmitHelpers": true,                            /* Disable generating custom helper functions like '__extends' in compiled output. */
+    // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
+    // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
+    // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
+    // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
+
+    /* Interop Constraints */
+    // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
+    // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
+    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
+    // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
+    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
+
+    /* Type Checking */
+    "strict": true,                                      /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
+    // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
+    // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
+    // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
+    // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
+    // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
+    // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
+    // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
+    // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */
+    // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
+    // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
+    // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
+    // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
+    // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
+    // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
+    // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
+    // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
+
+    /* Completeness */
+    // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
+    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
+  }
+}

--- a/test/module/ts/tsconfig.json
+++ b/test/module/ts/tsconfig.json
@@ -27,7 +27,7 @@
     /* Modules */
     "module": "commonjs",                                /* Specify what module code is generated. */
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
-    // "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
+     "moduleResolution": "node",                         /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */

--- a/test/specs/instance.spec.js
+++ b/test/specs/instance.spec.js
@@ -26,7 +26,8 @@ describe('instance', function () {
         'VERSION',
         'default',
         'toFormData',
-        'formToJSON'
+        'formToJSON',
+        'AxiosHeaders'
       ].indexOf(prop) > -1) {
         continue;
       }

--- a/test/typescript/axios.ts
+++ b/test/typescript/axios.ts
@@ -6,7 +6,13 @@ import axios, {
   AxiosAdapter,
   Cancel,
   CancelTokenSource,
-  Canceler, AxiosProgressEvent, ParamsSerializerOptions
+  Canceler, AxiosProgressEvent, ParamsSerializerOptions,
+  toFormData,
+  formToJSON,
+  all,
+  isCancel,
+  isAxiosError,
+  spread
 } from 'axios';
 
 const config: AxiosRequestConfig = {
@@ -354,10 +360,27 @@ const promises = [
 
 const promise: Promise<number[]> = axios.all(promises);
 
+// axios.all named export
+
+(() => {
+  const promises = [
+    Promise.resolve(1),
+    Promise.resolve(2)
+  ];
+
+  const promise: Promise<number[]> = all(promises);
+})();
+
 // axios.spread
 
 const fn1 = (a: number, b: number, c: number) => `${a}-${b}-${c}`;
 const fn2: (arr: number[]) => string = axios.spread(fn1);
+
+// axios.spread named export
+(() => {
+  const fn1 = (a: number, b: number, c: number) => `${a}-${b}-${c}`;
+  const fn2: (arr: number[]) => string = spread(fn1);
+})();
 
 // Promises
 
@@ -396,6 +419,12 @@ axios.get('/user', {
     const cancel: Cancel = thrown;
     console.log(cancel.message);
   }
+
+  // named export
+  if (isCancel(thrown)) {
+    const cancel: Cancel = thrown;
+    console.log(cancel.message);
+  }
 });
 
 source.cancel('Operation has been canceled.');
@@ -407,11 +436,27 @@ axios.get('/user')
     if (axios.isAxiosError(error)) {
       const axiosError: AxiosError = error;
     }
+
+    // named export
+
+    if (isAxiosError(error)) {
+      const axiosError: AxiosError = error;
+    }
   });
 
 // FormData
 
 axios.toFormData({x: 1}, new FormData());
+
+// named export
+toFormData({x: 1}, new FormData());
+
+// formToJSON
+
+axios.toFormData(new FormData());
+
+// named export
+formToJSON(new FormData());
 
 // AbortSignal
 

--- a/tslint.json
+++ b/tslint.json
@@ -1,6 +1,11 @@
-{ 
+{
   "extends": "dtslint/dtslint.json",
   "rules": {
     "no-unnecessary-generics": false
+  },
+  "linterOptions": {
+    "exclude": [
+      "test/module/**"
+    ]
   }
 }


### PR DESCRIPTION
Brief description:
- `require` can only be used with `default` export as it was in 0.x versions;
- `import` can be used with both `default` & `named` exports;

Detailed:
- Added browser CommonJS bundle to the build pipeline;
- Fixed exports entry points;
- Added module exports tests;
- Added missing ESM export for parity with Axios factory; 
- Added `toFormData`, `formToJSON`, `isAxiosError`, `spread`, `isCancel`, `all` as named export to `index.d.ts`;

In an attempt to bring order, the package export has been refactored. The following rules were adopted:
- CommonJS module has only factory as default export, as it was before
- CommonJS entry point to build the cjs bundle is `./lib/axios.js`
- ESM entry provides both default (factory) and named exports;
- ESM entry point is `./index.js`. This module should expand Axios factory export as ESM named export. This module should not be used for purposes other than re-export features as a named export.
- Named export should be in parity with export provided by Axios factory
- The `./dist/axios.js` and `./dist/esm/axios.js` bundles are for CDN usage only.

Closes #5154; Closes #5164; Closes #5169; Closes #5091; Closes #5130; Closes #5118; Closes #5011; Closes #5031; Closes #5044; Closes #5082;
Related: #5101, #5026, #5088

Users that import the module with `require` will do it as it was before:

```js
const axios = require('axios');

console.log(axios.isCancel('something'));
console.log(new axios.AxiosError('oops'));
```
If the module is loaded with `import` statement you can use both named and factory exports:

```js
import axios from 'axios';

console.log(axios.isCancel('something'));
console.log(new axios.AxiosError('oops'));
```
OR
```js
import axios, {isCancel, AxiosError} from 'axios';

console.log(isCancel('something'));
console.log(new AxiosError('oops'));
```
If something goes wrong (custom/outdated environment), you can try to load CommonJS bundle directly:
```js
const axios = require('axios/dist/browser/axios.cjs'); // browser
// const axios = require('axios/dist/node/axios.cjs'); // node

console.log(axios.isCancel('something'));
console.log(new axios.AxiosError('oops'));
```