### PR TITLE
fix axios config headers

### DIFF
--- a/lib/core/Axios.js
+++ b/lib/core/Axios.js
@@ -68,19 +68,21 @@ class Axios {
     config.method = (config.method || this.defaults.method || 'get').toLowerCase();
 
     // Flatten headers
-    const defaultHeaders = config.headers && utils.merge(
-      config.headers.common,
-      config.headers[config.method]
-    );
+    if (!(config.headers instanceof AxiosHeaders)) {
+      const defaultHeaders = config.headers && utils.merge(
+          config.headers.common,
+          config.headers[config.method]
+      );
 
-    defaultHeaders && utils.forEach(
-      ['delete', 'get', 'head', 'post', 'put', 'patch', 'common'],
-      function cleanHeaderConfig(method) {
-        delete config.headers[method];
-      }
-    );
+      defaultHeaders && utils.forEach(
+          ['delete', 'get', 'head', 'post', 'put', 'patch', 'common'],
+          function cleanHeaderConfig(method) {
+            delete config.headers[method];
+          }
+      );
 
-    config.headers = new AxiosHeaders(config.headers, defaultHeaders);
+      config.headers = new AxiosHeaders(config.headers, defaultHeaders);
+    }
 
     // filter out skipped interceptors
     const requestInterceptorChain = [];


### PR DESCRIPTION
Hi, I faced this problem in version 1.0+

After refreshing the token, I was returning a request with the old configurations. When I looked in the network, after updating the token, the getUserInfo method was not displayed.

Solution: need to check if config.headers is not instance of AxiosHeaders

```jsx
 if (!(config.headers instanceof AxiosHeaders)) {
      const defaultHeaders = config.headers && utils.merge(
          config.headers.common,
          config.headers[config.method]
      );

      defaultHeaders && utils.forEach(
          ['delete', 'get', 'head', 'post', 'put', 'patch', 'common'],
          function cleanHeaderConfig(method) {
            delete config.headers[method];
          }
      );

      config.headers = new AxiosHeaders(config.headers, defaultHeaders);
    }
```

Hope you fix it soon. Thanks
