### PR TITLE
Fix typos (capitalization)

### DIFF
--- a/examples/get/index.html
+++ b/examples/get/index.html
@@ -18,7 +18,7 @@
                 '<img src="https://avatars.githubusercontent.com/u/' + person.avatar + '?s=50" class="col-md-1"/>' +
                 '<div class="col-md-3">' +
                   '<strong>' + person.name + '</strong>' +
-                  '<div>Github: <a href="https://github.com/' + person.github + '" target="_blank">' + person.github + '</a></div>' +
+                  '<div>GitHub: <a href="https://github.com/' + person.github + '" target="_blank">' + person.github + '</a></div>' +
                   '<div>Twitter: <a href="https://twitter.com/' + person.twitter + '" target="_blank">' + person.twitter + '</a></div>' +
                 '</div>' +
               '</li><br/>'

--- a/karma.conf.cjs
+++ b/karma.conf.cjs
@@ -129,7 +129,7 @@ module.exports = function(config) {
     );
     browsers = ['Firefox'];
   } else if (process.env.GITHUB_ACTIONS === 'true') {
-    console.log('Running ci on Github Actions.');
+    console.log('Running ci on GitHub Actions.');
     browsers = ['FirefoxHeadless', 'ChromeHeadless'];
   } else {
     browsers = browsers || ['Chrome'];


### PR DESCRIPTION
Just a couple of minor capitalization fixes: `Github` -> `GitHub`.