### PR TITLE
fix: named export issue from proxy-from-env package

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -4,7 +4,7 @@ import utils from './../utils.js';
 import settle from './../core/settle.js';
 import buildFullPath from '../core/buildFullPath.js';
 import buildURL from './../helpers/buildURL.js';
-import {getProxyForUrl} from 'proxy-from-env';
+import proxyFromEnv from 'proxy-from-env';
 import http from 'http';
 import https from 'https';
 import followRedirects from 'follow-redirects';
@@ -59,7 +59,7 @@ function dispatchBeforeRedirect(options) {
 function setProxy(options, configProxy, location) {
   let proxy = configProxy;
   if (!proxy && proxy !== false) {
-    const proxyUrl = getProxyForUrl(location);
+    const proxyUrl = proxyFromEnv.getProxyForUrl(location);
     if (proxyUrl) {
       proxy = new URL(proxyUrl);
     }


### PR DESCRIPTION
I have a NextJs app with axios version 1.1.3 and recently i've updated webpack to version 5 from version 4.

I think with webpack 5, importing named exports from certain packages don't work. I thought it's only JSON modules. Anyhow, I picked this up from here https://webpack.js.org/blog/2020-10-10-webpack-5-release/

This issue seems to happen on my windows machine (Windows 10 Pro, version 22H2) and works fine on macOS for some reason.

This PR fixes named import issue from `proxy-from-env` package in `lib/adapters/http.js`

Closes #5221 