### PR TITLE
export lib dir

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
       }
     },
     "./lib/*": {
-      "import": "./lib/*"
+      "require": "./lib/*",
+      "default": "./lib/*"
     },
     "./package.json": "./package.json"
   },

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
         "default": "./index.js"
       }
     },
+    "./lib/*": {
+      "import": "./lib/*"
+    },
     "./package.json": "./package.json"
   },
   "type": "module",


### PR DESCRIPTION
this is the real fix of https://github.com/axios/axios/issues/5000

It's the basic config to let user `import` or `require` contents in `lib/` dir.



