### PR TITLE
Only accept brotli if we can decode it

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -318,7 +318,11 @@ export default function httpAdapter(config) {
       return reject(customErr);
     }
 
-    headers.set('Accept-Encoding', 'gzip, deflate, br', false);
+    let acceptEncoding = 'gzip, deflate';
+    if (isBrotliSupported) {
+      acceptEncoding += ', br';
+    }
+    headers.set('Accept-Encoding', acceptEncoding, false);
 
     const options = {
       path,


### PR DESCRIPTION
Previously, on Node versions without brotli support, axios might have arbitrarily presented the library user with a brotli-encoded response they didn’t ask for.

Resolves #5258.