### PR TITLE
update readme in the Handling Errors section - issue reference #5260

### DIFF
--- a/README.md
+++ b/README.md
@@ -763,6 +763,8 @@ Read [the interceptor tests](./test/specs/interceptors.spec.js) for seeing all t
 
 ## Handling Errors
 
+the default behavior is to reject every response that returns with a status code that falls out of the range of 2xx and treat it as an error.
+
 ```js
 axios.get('/user/12345')
   .catch(function (error) {
@@ -785,7 +787,7 @@ axios.get('/user/12345')
   });
 ```
 
-Using the `validateStatus` config option, you can define HTTP code(s) that should throw an error.
+Using the `validateStatus` config option, you can override the default condition (status >= 200 && status < 300) and define HTTP code(s) that should throw an error.
 
 ```js
 axios.get('/user/12345', {


### PR DESCRIPTION
Adding clarification to the Handling Errors section - issue reference #5260
----
add a sentence about the default behavior of the rejected status code.

"the default behavior is to reject every response that returns with a status code that falls out of the range of 2xx and treat it as an error."

and make a small addition to the validateStatus header, to explain what the default condition.

Using the validateStatus config option, you can override the default condition (status >= 200 && status < 300) and define HTTP code(s) that should throw an error.