### PR TITLE
test: HTTP GET response data decompression

### DIFF
--- a/test/unit/adapters/http.js
+++ b/test/unit/adapters/http.js
@@ -466,6 +466,27 @@ describe('supports http with nodejs', function () {
     })
   });
 
+    it('should support decompression of response data', function(done) {
+      var data = 'Test data';
+
+      zlib.gzip(data, function(err, zipped) {
+        server = http.createServer(function(req, res) {
+          res.setHeader('Content-Type', 'text/html;charset=utf-8');
+          res.setHeader('Content-Encoding', 'gzip');
+          res.end(zipped);
+        }).listen(4444, function() {
+          axios.get('http://localhost:4444/', {
+            decompress: true,
+            responseType: 'arraybuffer'
+
+          }).then(function(res) {
+            assert.equal(res.data, data);
+            done();
+          }).catch(done);
+        });
+      });
+    });
+
     it('should support disabling automatic decompression of response data', function(done) {
       var data = 'Test data';
 


### PR DESCRIPTION
Test HTTP GET response data decompression for https://github.com/axios/axios/issues/5296 and https://github.com/axios/axios/issues/5298

GET is one of the primary real-world use cases for this library, and production servers frequently compress response data.  Therefore, update this file to test what it claims to be testing (decompression, and disabling of decompression).