### PR TITLE
export bundles.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
         "default": "./index.js"
       }
     },
+    "./axios.js": "./dist/axios.js",
+    "./axios.min.js": "./dist/axios.min.js",
     "./package.json": "./package.json"
   },
   "type": "module",


### PR DESCRIPTION
Allows to get bundles location using node.

Fixes https://github.com/axios/axios/issues/5301.