### PR TITLE
docs: remove README link to non-existent upgrade guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1297,7 +1297,6 @@ You can use Gitpod, an online IDE(which is free for Open Source) for contributin
 ## Resources
 
 * [Changelog](https://github.com/axios/axios/blob/v1.x/CHANGELOG.md)
-* [Upgrade Guide](https://github.com/axios/axios/blob/v1.x/UPGRADE_GUIDE.md)
 * [Ecosystem](https://github.com/axios/axios/blob/v1.x/ECOSYSTEM.md)
 * [Contributing Guide](https://github.com/axios/axios/blob/v1.x/CONTRIBUTING.md)
 * [Code of Conduct](https://github.com/axios/axios/blob/v1.x/CODE_OF_CONDUCT.md)


### PR DESCRIPTION
### Related Issues

* #5043
* #5014
* #3633
* #5087

### Description

This PR removes a broken `UPGRADE_GUIDE.md` link from the (1.x) README.

Really, the guide should be added/updated, but I think it may be better to just omit it until the doc is ready.
A broken link is worse than no link.

### Alternatives considered

1) **Write an upgrade guide**: I don't think I have the context
1) **Create a *stub* guide**:  Personally I think this is less good than just not having a link, but perhaps it'd make the eventual future addition of such a guide easier. If that's the preferred option, I can open a PR to do that instead.