### PR TITLE
Better implementation of inheritance for Axios error

### DIFF
--- a/lib/core/AxiosError.js
+++ b/lib/core/AxiosError.js
@@ -13,20 +13,19 @@ var utils = require('../utils');
  * @returns {Error} The created error.
  */
 function AxiosError(message, code, config, request, response) {
-  Error.call(this);
-
+  const Err = new Error();
+  //remove the current frame if captureStackTrace is supported
   if (Error.captureStackTrace) {
-    Error.captureStackTrace(this, this.constructor);
-  } else {
-    this.stack = (new Error()).stack;
-  }
-
-  this.message = message;
-  this.name = 'AxiosError';
-  code && (this.code = code);
-  config && (this.config = config);
-  request && (this.request = request);
-  response && (this.response = response);
+    Error.captureStackTrace(Err, this.constructor);
+  } 
+  Err.message = message;
+  Err.name = 'AxiosError';
+  code && (Err.code = code);
+  config && (Err.config = config);
+  request && (Err.request = request);
+  response && (Err.response = response);
+  Object.setPrototypeOf(Err, new.target.prototype)
+  return Err
 }
 
 utils.inherits(AxiosError, Error, {


### PR DESCRIPTION
## Description 

Use a better way to construct Axios error as a child of the native Error class.

This way will fix capturing stack issues #5321