### PR TITLE
Fix brotli decompression

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -427,7 +427,7 @@ export default isHttpAdapterSupported && function httpAdapter(config) {
           break;
         case 'br':
           if (isBrotliSupported) {
-            streams.push(zlib.createBrotliDecompress(zlibOptions));
+            streams.push(zlib.createBrotliDecompress());
             delete res.headers['content-encoding'];
           }
         }


### PR DESCRIPTION
Fixes: https://github.com/axios/axios/issues/5346

In axios v1.2.1 brotli decompression was broken in NodeJS, this pr fixes the issue
