### PR TITLE
fix: rename types responseEncoding to ResponseEncoding

### DIFF
--- a/index.d.cts
+++ b/index.d.cts
@@ -271,7 +271,7 @@ declare namespace axios {
     | 'text'
     | 'stream';
 
-  type responseEncoding =
+  type ResponseEncoding =
     | 'ascii' | 'ASCII'
     | 'ansi' | 'ANSI'
     | 'binary' | 'BINARY'
@@ -378,7 +378,7 @@ declare namespace axios {
     adapter?: AxiosAdapterConfig | AxiosAdapterConfig[];
     auth?: AxiosBasicCredentials;
     responseType?: ResponseType;
-    responseEncoding?: responseEncoding | string;
+    responseEncoding?: ResponseEncoding | string;
     xsrfCookieName?: string;
     xsrfHeaderName?: string;
     onUploadProgress?: (progressEvent: AxiosProgressEvent) => void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -212,7 +212,7 @@ export type ResponseType =
     | 'text'
     | 'stream';
 
-export type responseEncoding =
+export type ResponseEncoding =
     | 'ascii' | 'ASCII'
     | 'ansi' | 'ANSI'
     | 'binary' | 'BINARY'
@@ -319,7 +319,7 @@ export interface AxiosRequestConfig<D = any> {
   adapter?: AxiosAdapterConfig | AxiosAdapterConfig[];
   auth?: AxiosBasicCredentials;
   responseType?: ResponseType;
-  responseEncoding?: responseEncoding | string;
+  responseEncoding?: ResponseEncoding | string;
   xsrfCookieName?: string;
   xsrfHeaderName?: string;
   onUploadProgress?: (progressEvent: AxiosProgressEvent) => void;


### PR DESCRIPTION
Renaming the type `responseEncoding` to the correct typescript convention for a type `ResponseEncoding` name

```diff
-  type responseEncoding =
+  type ResponseEncoding =
    | 'ascii' | 'ASCII'
...



  interface AxiosRequestConfig<D = any> {
...
-    responseEncoding?: responseEncoding | string;
+    responseEncoding?: ResponseEncoding | string;

```