### PR TITLE
fix AxiosRequestConfig generic

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -325,7 +325,7 @@ export interface RawAxiosRequestConfig<D = any> {
   formSerializer?: FormSerializerOptions;
 }
 
-export interface AxiosRequestConfig<D = any> extends RawAxiosRequestConfig {
+export interface AxiosRequestConfig<D = any> extends RawAxiosRequestConfig<D> {
   headers: AxiosRequestHeaders;
 }
 


### PR DESCRIPTION
pass `AxiosRequestConfig` generic `D` to `RawAxiosRequestConfig` in order to describe types of config data object.

Added a comment about this in [the commit](https://github.com/axios/axios/commit/08119634a22f1d5b19f5c9ea0adccb6d3eebc3bc#r96601607).