### PR TITLE
fix: default exports for browser points to browser esm build

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
       },
       "browser": {
         "require": "./dist/browser/axios.cjs",
-        "default": "./index.js"
+        "default": "./dist/esm/axios.js"
       },
       "default": {
         "require": "./dist/node/axios.cjs",


### PR DESCRIPTION
Fixes #5495 

This makes the module resolved for browser code being imported in ES modules to point to the bundled ESM code, rather than the root `.index.js` which requires additional tooling to actually make work in the browser.