### PR TITLE
feat: export `AxiosHeaderValue` type.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 // TypeScript Version: 4.7
-type AxiosHeaderValue = AxiosHeaders | string | string[] | number | boolean | null;
+export type AxiosHeaderValue = AxiosHeaders | string | string[] | number | boolean | null;
 
 interface RawAxiosHeaders {
   [key: string]: AxiosHeaderValue;


### PR DESCRIPTION
`AxiosHeaderValue` is such a important type that allows you to reproduce a lot of other header related typings, but hardcoding its current value is error prone.