### PR TITLE
feat: added config for `maxHeaderSize`

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,6 +464,10 @@ These are the available config options for making requests. Only the `url` is re
   // `maxBodyLength` (Node only option) defines the max size of the http request content in bytes allowed
   maxBodyLength: 2000,
 
+  // `maxHeaderSize` optionally overrides the value of --max-http-header-size for requests received by this server, 
+  // i.e. the  maximum length of request headers in bytes. Default: 16384 (16 KiB).
+  maxHeaderSize: 20000
+
   // `validateStatus` defines whether to resolve or reject the promise for a given
   // HTTP response status code. If `validateStatus` returns `true` (or is set to `null`
   // or `undefined`), the promise will be resolved; otherwise, the promise will be

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -410,6 +410,10 @@ export default isHttpAdapterSupported && function httpAdapter(config) {
       options.insecureHTTPParser = config.insecureHTTPParser;
     }
 
+    if ( config.maxHeaderSize > -1 ) {
+      options.maxHeaderSize = config.maxHeaderSize
+    }
+
     // Create the request
     req = transport.request(options, function handleResponse(res) {
       if (req.destroyed) return;

--- a/test/unit/adapters/http.js
+++ b/test/unit/adapters/http.js
@@ -821,6 +821,34 @@ describe('supports http with nodejs', function () {
     });
   });
 
+  it('should support config.maxHeaderSize', function (done) {
+    server = http.createServer(function (req, res) {
+      setTimeout(function () {
+        res.end();
+      }, 1000);
+    }).listen(4444, function () {
+      axios.get('http://localhost:4444/', {maxHeaderSize: 1234})
+        .then(function (res) {
+          assert.equal(res.request?.maxHeaderSize, 1234, 'maxHeaderSize equals default')
+          done();
+        }).catch(done);
+    })
+  })
+
+  it('maxHeaderSize shoudl be undefined', function (done) {
+    server = http.createServer(function (req, res) {
+      setTimeout(function () {
+        res.end();
+      }, 1000);
+    }).listen(4444, function () {
+      axios.get('http://localhost:4444/')
+        .then(function (res) {
+          assert.equal(res.request?.maxHeaderSize, undefined, 'maxHeaderSize is undefined when not set')
+          done();
+        }).catch(done);
+    })
+  })
+
   describe('streams', function(){
     it('should support streams', function (done) {
       server = http.createServer(function (req, res) {


### PR DESCRIPTION
This pull request integrates [`http.maxHeaderSize`](https://nodejs.org/docs/latest-v16.x/api/http.html#httpmaxheadersize) support to axios http adapter, allowing users to overwrite nodejs `--max-http-header-size` programatically, from within axios config.

Code example:
```js
(async () => {
    const data = await axios({
        method: 'get',
        maxHeaderSize: <BYTES>
    })
})()
```