### PR TITLE
export Adapters

### DIFF
--- a/lib/adapters/adapters.d.ts
+++ b/lib/adapters/adapters.d.ts
@@ -1,0 +1,12 @@
+import { AxiosAdapterConfig } from "../../index.cjs";
+
+interface AdapterModule {
+  getAdapter(adapters?: AxiosAdapterConfig[]): AxiosAdapterConfig;
+  adapters: {
+    http: AxiosAdapterConfig;
+    xhr: AxiosAdapterConfig;
+  };
+}
+
+declare const adapters: AdapterModule;
+export default adapters;

--- a/package.json
+++ b/package.json
@@ -18,6 +18,10 @@
         "default": "./index.js"
       }
     },
+    "./adapters": {
+      "types": "./lib/adapters/adapters.d.ts",
+      "default": "./lib/adapters/adapters.js"
+    },
     "./package.json": "./package.json"
   },
   "type": "module",

--- a/test/module/adapters-esm/index.js
+++ b/test/module/adapters-esm/index.js
@@ -1,0 +1,7 @@
+import assert from 'assert';
+import adapters from 'axios/adapters';
+
+assert.strictEqual(typeof adapters.getAdapter, 'function');
+assert.strictEqual(typeof adapters.adapters, 'object');
+
+console.log('Adapters ESM importing test passed');

--- a/test/module/adapters-esm/package.json
+++ b/test/module/adapters-esm/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "esm-entrypoint-test",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "test": "npm i --no-save --no-package-lock && node index.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "axios": "file:../../.."
+  }
+}

--- a/test/module/test.js
+++ b/test/module/test.js
@@ -146,6 +146,20 @@ describe('module', function () {
         await exec(`npm test --prefix ${pkgPath}`, {});
       });
     });
+
+    describe('Adapters ESM', () => {
+      const pkgPath = path.join(__dirname, './adapters-esm');
+
+      after(async () => {
+        await remove(path.join(pkgPath, './node_modules'));
+      });
+
+      it('should be able to be loaded with import', async function () {
+        this.timeout(30000);
+
+        await exec(`npm test --prefix ${pkgPath}`);
+      });
+    });
   });
 
   describe('typings', () => {


### PR DESCRIPTION
#### Instructions

Export adapters.js as `axios/adapters`.

exporting from cjs is not added because the code is not transpiled to cjs as individual files.


Fixes #5474

