### PR TITLE
fix: turn AxiosError into a native error (#5394)

### DIFF
--- a/lib/core/AxiosError.js
+++ b/lib/core/AxiosError.js
@@ -14,20 +14,21 @@ import utils from '../utils.js';
  * @returns {Error} The created error.
  */
 function AxiosError(message, code, config, request, response) {
-  Error.call(this);
+  const instance = Error.call(this);
 
   if (Error.captureStackTrace) {
-    Error.captureStackTrace(this, this.constructor);
+    Error.captureStackTrace(this, instance.constructor);
   } else {
-    this.stack = (new Error()).stack;
+    instance.stack = (new Error()).stack;
   }
 
-  this.message = message;
-  this.name = 'AxiosError';
-  code && (this.code = code);
-  config && (this.config = config);
-  request && (this.request = request);
-  response && (this.response = response);
+  instance.message = message;
+  instance.name = 'AxiosError';
+  code && (instance.code = code);
+  config && (instance.config = config);
+  request && (instance.request = request);
+  response && (instance.response = response);
+  return instance;
 }
 
 utils.inherits(AxiosError, Error, {

--- a/test/specs/core/AxiosError.spec.js
+++ b/test/specs/core/AxiosError.spec.js
@@ -1,5 +1,6 @@
 import AxiosError from '../../../lib/core/AxiosError';
 
+
 describe('core::AxiosError', function() {
   it('should create an Error with message, config, code, request, response, stack and isAxiosError', function() {
     const request = { path: '/foo' };
@@ -47,5 +48,12 @@ describe('core::AxiosError', function() {
       const error = new Error('Boom!');
       expect(AxiosError.from(error, 'ESOMETHING', { foo: 'bar' }) instanceof AxiosError).toBeTruthy();
     });
+  });
+
+  it('should be a native error as checked by the NodeJS `isNativeError` function', async function (){
+    if((typeof process !== 'undefined') && (process.release.name === 'node')){
+      let {isNativeError} = require('node:util/types');
+      expect(isNativeError(new AxiosError("My Axios Error"))).toBeTruthy();
+    }
   });
 });


### PR DESCRIPTION
## Overview

This PR turns `AxiosError` into an instance of `Error` that returns true when checked with Node's [`utils.types.isNativeError`](https://nodejs.org/api/util.html#utiltypesisnativeerrorvalue).

Related Issue: #5394

## Why this PR?

This PR is useful if axios is used in Node.js and the user wants to check if an instance of  `AxiosError`, that moved  across [realms](https://tc39.es/ecma262/#sec-code-realms), is  an `Error`. In practice this might happen if Node.js [worker threads](https://nodejs.org/api/worker_threads.html)  or [vms](https://nodejs.org/api/vm.html) are used. 

A call to `X instanceof Error` compares X's prototype to the `Error` constructor in the **current** realm and thus returns `false` if the object was created in another realm. Node's [isNativeError](https://nodejs.org/api/util.html#utiltypesisnativeerrorvalue) can be used to address this:

```javascript
const assert = require('assert');
const vm = require('vm');
const {isNativeError} = require('util/types');

const context = vm.createContext({});
const differentRealmErr = vm.runInContext('new Error()', context);
assert(!(differentRealmErr instanceof Error)); // instanceof returns false
assert(isNativeError(differentRealmErr)); // isNativeError returns true

```

Node uses [`isNativeError(e) || e instanceof Error`](https://github.com/nodejs/node/blob/d96b1f330eb45a36a3de005e913738015d87b303/lib/internal/util.js#L95) internally to check for errors.

## What does the PR actually do?

Currently, the `AxiosError` constructor calls `Error.call(this)` but it does not return its result. With the change the result is returned. Here is a short illustration of the difference:

```javascript
const assert = require('assert');
const {isNativeError} = require('util/types');

function MyErr() {
    return Error.call(this);
}
assert(isNativeError new MyError()); // instances of `MyErr` are native errors

function MyBrokenErr() {
    Error.call(this);
}
assert(!isNativeError(new MyBrokenErr())); // instances of `MyBrokenErr` are _not_ native errors

```

## Testing
I wrote a test which should only run in NodeJS environments. Sadly, I could not get the tests under `test/specs` running. The contributing guidelines mention grunt but I did not get it working. (Is this still up to date?) When running `npm run test` on a freshly checked-out repo I had several failures. 






