### PR TITLE
Add `undefined` as a value in AxiosRequestConfig

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -334,7 +334,7 @@ export interface AxiosRequestConfig<D = any> {
   httpAgent?: any;
   httpsAgent?: any;
   proxy?: AxiosProxyConfig | false;
-  cancelToken?: CancelToken;
+  cancelToken?: CancelToken | undefined;
   decompress?: boolean;
   transitional?: TransitionalOptions;
   signal?: GenericAbortSignal;


### PR DESCRIPTION
Adds `undefined` as a valid value for `cancelToken` in `AxiosRequestConfig`.

Fixes #5559 

Note: I am not familiar with the repository but probably this fix could be added to other properties as well