### PR TITLE
refactor: implement CanceledError as a class

### DIFF
--- a/lib/cancel/CanceledError.js
+++ b/lib/cancel/CanceledError.js
@@ -1,25 +1,22 @@
 'use strict';
 
 import AxiosError from '../core/AxiosError.js';
-import utils from '../utils.js';
 
-/**
- * A `CanceledError` is an object that is thrown when an operation is canceled.
- *
- * @param {string=} message The message.
- * @param {Object=} config The config.
- * @param {Object=} request The request.
- *
- * @returns {CanceledError} The created error.
- */
-function CanceledError(message, config, request) {
-  // eslint-disable-next-line no-eq-null,eqeqeq
-  AxiosError.call(this, message == null ? 'canceled' : message, AxiosError.ERR_CANCELED, config, request);
-  this.name = 'CanceledError';
+class CanceledError extends AxiosError {
+  /**
+   * A `CanceledError` is an object that is thrown when an operation is canceled.
+   *
+   * @param {string=} message The message.
+   * @param {Object=} config The config.
+   * @param {Object=} request The request.
+   *
+   * @returns {CanceledError} The created error.
+   */
+  constructor(message, config, request) {
+    super(message == null ? 'canceled' : message, AxiosError.ERR_CANCELED, config, request);
+    this.name = 'CanceledError';
+    this.__CANCEL__ = true;
+  }
 }
-
-utils.inherits(CanceledError, AxiosError, {
-  __CANCEL__: true
-});
 
 export default CanceledError;

--- a/test/specs/cancel/CanceledError.spec.js
+++ b/test/specs/cancel/CanceledError.spec.js
@@ -12,4 +12,10 @@ describe('Cancel', function() {
       expect(cancel.toString()).toBe('CanceledError: Operation has been canceled.');
     });
   });
+  it('should be a native error as checked by the NodeJS `isNativeError` function', async function (){
+    if((typeof process !== 'undefined') && (process.release.name === 'node')){
+      let {isNativeError} = require('node:util/types');
+      expect(isNativeError(new CanceledError("My Cancelled Error"))).toBeTruthy();
+    }
+  });
 });


### PR DESCRIPTION
This PR turns `CanceledError` into an instance of `AxiosError` that returns `true` when checked with Node's [utils.types.isNativeError](https://nodejs.org/api/util.html#utiltypesisnativeerrorvalue).

Related PR for `AxiosError` with more explanation: #5558
Related Issue: [5394](https://github.com/axios/axios/issues/5394)


## Testing
I ran all the tests in `CanceledError.spec.js` and added my own to check for native errors.
