### PR TITLE
refactor(dns): remove unnecessary async function check

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -154,7 +154,7 @@ export default isHttpAdapterSupported && function httpAdapter(config) {
     let rejected = false;
     let req;
 
-    if (lookup && utils.isAsyncFn(lookup)) {
+    if (lookup) {
       lookup = callbackify(lookup, (entry) => {
         if(utils.isString(entry)) {
           entry = [entry, entry.indexOf('.') < 0 ? 6 : 4]


### PR DESCRIPTION
Calling `utils.isAsyncFn` before calling `callbackify` is unnecessary because `utils.isAsyncFn` will be called in `callbackify` to check `lookup`.