### PR TITLE
remove bind util file and use native JS bind instead

### DIFF
--- a/lib/axios.js
+++ b/lib/axios.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var utils = require('./utils');
-var bind = require('./helpers/bind');
 var Axios = require('./core/Axios');
 var mergeConfig = require('./core/mergeConfig');
 var defaults = require('./defaults');
@@ -14,7 +13,7 @@ var formDataToJSON = require('./helpers/formDataToJSON');
  */
 function createInstance(defaultConfig) {
   var context = new Axios(defaultConfig);
-  var instance = bind(Axios.prototype.request, context);
+  var instance = Axios.prototype.request.bind(context);
 
   // Copy axios.prototype to instance
   utils.extend(instance, Axios.prototype, context);

--- a/lib/helpers/bind.js
+++ b/lib/helpers/bind.js
@@ -1,7 +1,0 @@
-'use strict';
-
-module.exports = function bind(fn, thisArg) {
-  return function wrap() {
-    return fn.apply(thisArg, arguments);
-  };
-};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var bind = require('./helpers/bind');
-
 // utils is a library of generic helper functions non-specific to axios
 
 var toString = Object.prototype.toString;
@@ -328,7 +326,7 @@ function merge(/* obj1, obj2, obj3, ... */) {
 function extend(a, b, thisArg) {
   forEach(b, function assignValue(val, key) {
     if (thisArg && typeof val === 'function') {
-      a[key] = bind(val, thisArg);
+      a[key] = val.bind(thisArg);
     } else {
       a[key] = val;
     }


### PR DESCRIPTION
## Description

See issue, we don't really need the custom `bind` method, we can just remove that and make the library lighter since so many people use this library.

https://github.com/axios/axios/issues/5690