### PR TITLE
fix(bug): lib/helpers/isURLSameOrigin undefined urlParsingNode.pathname

### DIFF
--- a/lib/helpers/isURLSameOrigin.js
+++ b/lib/helpers/isURLSameOrigin.js
@@ -38,9 +38,10 @@ export default platform.isStandardBrowserEnv ?
         hash: urlParsingNode.hash ? urlParsingNode.hash.replace(/^#/, '') : '',
         hostname: urlParsingNode.hostname,
         port: urlParsingNode.port,
-        pathname: (urlParsingNode.pathname.charAt(0) === '/') ?
+        pathname: urlParsingNode.pathname ?
+          (urlParsingNode.pathname.charAt(0) === '/') ?
           urlParsingNode.pathname :
-          '/' + urlParsingNode.pathname
+          '/' + urlParsingNode.pathname : undefined
       };
     }
 


### PR DESCRIPTION
The `urlParsingNode.pathname` is `undefined` in the `resolveURL` function (`lib/helpers/isURLSameOrigin`) when axios is imported by a browser extension and injected as contentscript in `.svg` files (such as [1](https://upload.wikimedia.org/wikipedia/commons/e/e0/AdenosineTriphosphate.qutemol.svg), [2](https://upload.wikimedia.org/wikipedia/commons/0/07/Water_molecule.svg))

Added a check for undefined to prevent error.

<img width="501" alt="screenshot" src="https://github.com/axios/axios/assets/13864427/0b35d72a-1db7-4b9f-9ffb-02d2076c97b6">
