### PR TITLE
Typography: Corrected Placement of Commas in Axios Documentation for HTTP Methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,13 +248,13 @@ axios('/user/12345');
 For convenience, aliases have been provided for all common request methods.
 
 ##### axios.request(config)
-##### axios.get(url[, config])
-##### axios.delete(url[, config])
-##### axios.head(url[, config])
-##### axios.options(url[, config])
-##### axios.post(url[, data[, config]])
-##### axios.put(url[, data[, config]])
-##### axios.patch(url[, data[, config]])
+##### axios.get(url, [config])
+##### axios.delete(url, [config])
+##### axios.head(url, [config])
+##### axios.options(url, [config])
+##### axios.post(url, [data, [config]])
+##### axios.put(url, [data, [config]])
+##### axios.patch(url, [data, [config]])
 
 ###### NOTE
 When using the alias methods `url`, `method`, and `data` properties don't need to be specified in config.
@@ -286,13 +286,13 @@ const instance = axios.create({
 The available instance methods are listed below. The specified config will be merged with the instance config.
 
 ##### axios#request(config)
-##### axios#get(url[, config])
-##### axios#delete(url[, config])
-##### axios#head(url[, config])
-##### axios#options(url[, config])
-##### axios#post(url[, data[, config]])
-##### axios#put(url[, data[, config]])
-##### axios#patch(url[, data[, config]])
+##### axios#get(url, [config])
+##### axios#delete(url, [config])
+##### axios#head(url, [config])
+##### axios#options(url, [config])
+##### axios#post(url, [data, [config]])
+##### axios#put(url, [data, [config]])
+##### axios#patch(url, [data, [config]])
 ##### axios#getUri([config])
 
 ## Request Config


### PR DESCRIPTION
This pull request addresses an issue in the Axios documentation by correcting the placement of commas in the parameter syntax of the HTTP methods. The original documentation incorrectly placed the commas within the square brackets, which could cause confusion for users. 

```
axios.get(url[, config])
axios.delete(url[, config])
axios.head(url[, config])
axios.options(url[, config])
axios.post(url[, data[, config]])
axios.put(url[, data[, config]])
axios.patch(url[, data[, config]])
```

The corrected syntax now follows the standard JavaScript convention, with the commas placed outside the square brackets. 

```
axios.get(url, [config])
axios.delete(url, [config])
axios.head(url, [config])
axios.options(url, [config])
axios.post(url, [data, [config]])
axios.put(url, [data, [config]])
axios.patch(url, [data, [config]])
```

This modification improves the readability and clarity of the documentation, ensuring that users can easily understand the correct usage of parameters when making requests with Axios.