### PR TITLE
fix: dispatchBeforeRedirect

### DIFF
--- a/dist/node/axios.cjs
+++ b/dist/node/axios.cjs
@@ -2474,12 +2474,12 @@ const supportedProtocols = platform.protocols.map(protocol => {
  *
  * @returns {Object<string, any>}
  */
-function dispatchBeforeRedirect(options) {
+function dispatchBeforeRedirect(options, responseDetails, requestDetails) {
   if (options.beforeRedirects.proxy) {
     options.beforeRedirects.proxy(options);
   }
   if (options.beforeRedirects.config) {
-    options.beforeRedirects.config(options);
+    options.beforeRedirects.config(options, responseDetails, requestDetails);
   }
 }
 

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -53,12 +53,12 @@ const supportedProtocols = platform.protocols.map(protocol => {
  *
  * @returns {Object<string, any>}
  */
-function dispatchBeforeRedirect(options) {
+function dispatchBeforeRedirect(options, responseDetails, requestDetails) {
   if (options.beforeRedirects.proxy) {
     options.beforeRedirects.proxy(options);
   }
   if (options.beforeRedirects.config) {
-    options.beforeRedirects.config(options);
+    options.beforeRedirects.config(options, responseDetails, requestDetails);
   }
 }
 


### PR DESCRIPTION
the problem with **beforeRedirect** was described in the topic https://github.com/axios/axios/issues/5365
arguments _responseDetails_ and _requestDetails_ were lost in older versions of axios,

my fix returns them and we can use this:
`beforeRedirect: (options, responseDetails, requestDetails)`

regards, tish 💜
