### PR TITLE
Fix TOC and more issues in README

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "markdown.extension.toc.levels": "1..3",
+  "markdown.extension.toc.updateOnSave": true,
+  "markdown.extension.toc.omittedFromToc": {
+    "README.md": ["## Table of Contents"]
+  }
+}

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ You can also use the default export, since the named export is just a re-export 
 import axios from 'axios';
 
 console.log(axios.isCancel('something'));
-````
+```
 
 If you use `require` for importing, **only default export is available**:
 
@@ -214,8 +214,8 @@ async function getUser() {
 }
 ```
 
-> **Note** `async/await` is part of ECMAScript 2017 and is not supported in Internet
-> Explorer and older browsers, so use with caution.
+> **Note**
+> `async/await` is part of ECMAScript 2017 and is not supported in Internet Explorer and older browsers, so use with caution.
 
 Performing a `POST` request
 
@@ -252,9 +252,14 @@ Promise.all([getUserAccount(), getUserPermissions()])
 
 ## axios API
 
-Requests can be made by passing the relevant config to `axios`.
+Requests can be made with `axios(url[, config])`.
 
-##### axios(config)
+```js
+// Send a GET request (default method)
+axios('/user/12345');
+```
+
+The URL can also be passed as part of the config to `axios(config)`.
 
 ```js
 // Send a POST request
@@ -280,36 +285,23 @@ axios({
   });
 ```
 
-##### axios(url[, config])
-
-```js
-// Send a GET request (default method)
-axios('/user/12345');
-```
-
 ### Request method aliases
 
 For convenience, aliases have been provided for all common request methods.
 
-##### axios.request(config)
+```js
+axios.request(config)
+axios.get(url[, config])
+axios.delete(url[, config])
+axios.head(url[, config])
+axios.options(url[, config])
+axios.post(url[, data[, config]])
+axios.put(url[, data[, config]])
+axios.patch(url[, data[, config]])
+```
 
-##### axios.get(url[, config])
-
-##### axios.delete(url[, config])
-
-##### axios.head(url[, config])
-
-##### axios.options(url[, config])
-
-##### axios.post(url[, data[, config]])
-
-##### axios.put(url[, data[, config]])
-
-##### axios.patch(url[, data[, config]])
-
-###### NOTE
-
-When using the alias methods `url`, `method`, and `data` properties don't need to be specified in config.
+> **Note**
+> When using the alias methods `url`, `method`, and `data` properties don't need to be specified in config.
 
 ### Concurrency (👎 deprecated)
 
@@ -317,14 +309,16 @@ Please use `Promise.all` to replace the below functions.
 
 Helper functions for dealing with concurrent requests.
 
+```js
 axios.all(iterable)
 axios.spread(callback)
+```
 
 ### Creating an instance
 
 You can create a new instance of axios with a custom config.
 
-##### axios.create([config])
+#### axios.create([config])
 
 ```js
 const instance = axios.create({
@@ -338,23 +332,17 @@ const instance = axios.create({
 
 The available instance methods are listed below. The specified config will be merged with the instance config.
 
-##### axios#request(config)
-
-##### axios#get(url[, config])
-
-##### axios#delete(url[, config])
-
-##### axios#head(url[, config])
-
-##### axios#options(url[, config])
-
-##### axios#post(url[, data[, config]])
-
-##### axios#put(url[, data[, config]])
-
-##### axios#patch(url[, data[, config]])
-
-##### axios#getUri([config])
+```js
+axios#request(config)
+axios#get(url[, config])
+axios#delete(url[, config])
+axios#head(url[, config])
+axios#options(url[, config])
+axios#post(url[, data[, config]])
+axios#put(url[, data[, config]])
+axios#patch(url[, data[, config]])
+axios#getUri([config])
+```
 
 ## Request Config
 
@@ -508,7 +496,7 @@ These are the available config options for making requests. Only the `url` is re
   // Only either `socketPath` or `proxy` can be specified.
   // If both are specified, `socketPath` is used.
   socketPath: null, // default
-  
+
   // `transport` determines the transport method that will be used to make the request. If defined, it will be used. Otherwise, if `maxRedirects` is 0, the default `http` or `https` library will be used, depending on the protocol specified in `protocol`. Otherwise, the `httpFollow` or `httpsFollow` library will be used, again depending on the protocol, which can handle redirects.
   transport: undefined, // default
 
@@ -552,7 +540,7 @@ These are the available config options for making requests. Only the `url` is re
   // automatically. If set to `true` will also remove the 'content-encoding' header
   // from the responses objects of all decompressed responses
   // - Node only (XHR cannot turn off decompression)
-  decompress: true // default
+  decompress: true, // default
 
   // `insecureHTTPParser` boolean.
   // Indicates where to use an insecure HTTP parser that accepts invalid HTTP headers.
@@ -560,7 +548,7 @@ These are the available config options for making requests. Only the `url` is re
   // Using the insecure parser should be avoided.
   // see options https://nodejs.org/dist/latest-v12.x/docs/api/http.html#http_http_request_url_options_callback
   // see also https://nodejs.org/en/blog/vulnerability/february-2020-security-releases/#strict-http-header-parsing-none
-  insecureHTTPParser: undefined // default
+  insecureHTTPParser: undefined, // default
 
   // transitional options for backward compatibility that may be removed in the newer versions
   transitional: {
@@ -850,7 +838,7 @@ controller.abort()
 You can also cancel a request using a *CancelToken*.
 
 > The axios cancel token API is based on the withdrawn [cancellable promises proposal](https://github.com/tc39/proposal-cancelable-promises).
-
+>
 > This API is deprecated since v0.22.0 and shouldn't be used in new projects
 
 You can create a cancel token using the `CancelToken.source` factory as shown below:
@@ -896,16 +884,17 @@ axios.get('/user/12345', {
 cancel();
 ```
 
-> **Note:** you can cancel several requests with the same cancel token/abort controller.
+> **Note**
+> You can cancel several requests with the same cancel token/abort controller.
 > If a cancellation token is already cancelled at the moment of starting an Axios request, then the request is cancelled immediately, without any attempts to make a real request.
-
+>
 > During the transition period, you can use both cancellation APIs, even for the same request:
 
 ## Using `application/x-www-form-urlencoded` format
 
 ### URLSearchParams
 
-By default, axios serializes JavaScript objects to `JSON`. To send data in the [`application/x-www-form-urlencoded` format](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/POST) instead, you can use the [`URLSearchParams`](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) API, which is [supported](http://www.caniuse.com/#feat=urlsearchparams) in the vast majority of browsers,and [Node](https://nodejs.org/api/url.html#url_class_urlsearchparams) starting with v10 (released in 2018).
+By default, axios serializes JavaScript objects to `JSON`. To send data in the [`application/x-www-form-urlencoded` format](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/POST) instead, you can use the [`URLSearchParams`](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) API, which is [supported](http://www.caniuse.com/#feat=urlsearchparams) in the vast majority of browsers, and [Node](https://nodejs.org/api/url.html#url_class_urlsearchparams) starting with v10 (released in 2018).
 
 ```js
 const params = new URLSearchParams({ foo: 'bar' });
@@ -984,7 +973,7 @@ The server will handle it as:
     'users[1][name]': 'Thomas',
     'users[1][surname]': 'Anderson'
   }
-````
+```
 
 If your backend body-parser (like `body-parser` of `express.js`) supports nested objects decoding, you will get the same object on the server-side automatically
 
@@ -1071,16 +1060,11 @@ Axios FormData serializer supports some special endings to perform the following
 
 FormData serializer supports additional options via `config.formSerializer: object` property to handle rare cases:
 
-- `visitor: Function` - user-defined visitor function that will be called recursively to serialize the data object
-to a `FormData` object by following custom rules.
-
+- `visitor: Function` - user-defined visitor function that will be called recursively to serialize the data object to a `FormData` object by following custom rules.
 - `dots: boolean = false` - use dot notation instead of brackets to serialize arrays and objects;
-
 - `metaTokens: boolean = true` - add the special ending (e.g `user{}: '{"name": "John"}'`) in the FormData key.
-The back-end body-parser could potentially use this meta-information to automatically parse the value as JSON.
-
+  The back-end body-parser could potentially use this meta-information to automatically parse the value as JSON.
 - `indexes: null|false|true = false` - controls how indexes will be added to unwrapped keys of `flat` array-like objects
-
   - `null` - don't add brackets (`arr: 1`, `arr: 2`, `arr: 3`)
   - `false`(default) - add empty brackets (`arr[]: 1`, `arr[]: 2`, `arr[]: 3`)
   - `true` - add brackets with indexes  (`arr[0]: 1`, `arr[1]: 2`, `arr[2]: 3`)
@@ -1201,7 +1185,7 @@ will be submitted as the following JSON object:
     "age": "value2"
   }
 }
-````
+```
 
 Sending `Blobs`/`Files` as JSON (`base64`) is not currently supported.
 
@@ -1228,13 +1212,13 @@ await axios.post(url, data, {
       loaded: number;
       total?: number;
       progress?: number;
-      bytes: number; 
+      bytes: number;
       estimated?: number;
       rate?: number; // download speed in bytes
       download: true; // download sign
     }*/
   }
-});  
+});
 ```
 
 You can also track stream upload/download progress in node.js:
@@ -1244,18 +1228,18 @@ const {data} = await axios.post(SERVER_URL, readableStream, {
    onUploadProgress: ({progress}) => {
      console.log((progress * 100).toFixed(2));
    },
-  
+
    headers: {
     'Content-Length': contentLength
    },
 
    maxRedirects: 0 // avoid buffering the entire stream
 });
-````
+```
 
-> **Note:**
+> **Note**
 > Capturing FormData upload progress is currently not currently supported in node.js environments.
-
+>
 > **⚠️ Warning**
 > It is recommended to disable redirects by setting maxRedirects: 0 to upload the stream in the **node.js** environment,
 > as follow-redirects package will buffer the entire stream in RAM without following the "backpressure" algorithm.
@@ -1269,14 +1253,14 @@ const {data} = await axios.post(LOCAL_SERVER_URL, myBuffer, {
   onUploadProgress: ({progress, rate}) => {
     console.log(`Upload [${(progress*100).toFixed(2)}%]: ${(rate / 1024).toFixed(2)}KB/s`)
   },
-   
+
   maxRate: [100 * 1024], // 100KB/s limit
 });
 ```
 
 ## SemVer
 
-Until axios reaches a `1.0` release, breaking changes will be released with a new minor version. For example `0.5.1`, and `0.5.4` will have the same API, but `0.6.0` will have breaking changes.
+axios follows the [Semantic Versioning Specification](https://semver.org/). Until it reaches a `1.0` release, breaking changes will be released with a new minor version. For example `0.5.1`, and `0.5.4` will have the same API, but `0.6.0` will have breaking changes.
 
 ## Promises
 

--- a/README.md
+++ b/README.md
@@ -99,25 +99,25 @@ Latest ✔ | Latest ✔ | Latest ✔ | Latest ✔ | Latest ✔ | 11 ✔ |
 Using npm:
 
 ```bash
-$ npm install axios
+npm install axios
 ```
 
 Using bower:
 
 ```bash
-$ bower install axios
+bower install axios
 ```
 
 Using yarn:
 
 ```bash
-$ yarn add axios
+yarn add axios
 ```
 
 Using pnpm:
 
 ```bash
-$ pnpm add axios
+pnpm add axios
 ```
 
 Once the package is installed, you can import the library using `import` or `require` approach:
@@ -292,18 +292,27 @@ axios('/user/12345');
 For convenience, aliases have been provided for all common request methods.
 
 ##### axios.request(config)
+
 ##### axios.get(url[, config])
+
 ##### axios.delete(url[, config])
+
 ##### axios.head(url[, config])
+
 ##### axios.options(url[, config])
+
 ##### axios.post(url[, data[, config]])
+
 ##### axios.put(url[, data[, config]])
+
 ##### axios.patch(url[, data[, config]])
 
 ###### NOTE
+
 When using the alias methods `url`, `method`, and `data` properties don't need to be specified in config.
 
 ### Concurrency (👎 deprecated)
+
 Please use `Promise.all` to replace the below functions.
 
 Helper functions for dealing with concurrent requests.
@@ -330,13 +339,21 @@ const instance = axios.create({
 The available instance methods are listed below. The specified config will be merged with the instance config.
 
 ##### axios#request(config)
+
 ##### axios#get(url[, config])
+
 ##### axios#delete(url[, config])
+
 ##### axios#head(url[, config])
+
 ##### axios#options(url[, config])
+
 ##### axios#post(url[, data[, config]])
+
 ##### axios#put(url[, data[, config]])
+
 ##### axios#patch(url[, data[, config]])
+
 ##### axios#getUri([config])
 
 ## Request Config
@@ -705,6 +722,7 @@ axios.interceptors.request.eject(myInterceptor);
 ```
 
 You can also clear all interceptors for requests or responses.
+
 ```js
 const instance = axios.create();
 instance.interceptors.request.use(function () {/*...*/});
@@ -752,14 +770,15 @@ axios.interceptors.request.use(function (config) {
 
 Given you add multiple response interceptors
 and when the response was fulfilled
+
 - then each interceptor is executed
 - then they are executed in the order they were added
 - then only the last interceptor's result is returned
 - then every interceptor receives the result of its predecessor
 - and when the fulfillment-interceptor throws
-    - then the following fulfillment-interceptor is not called
-    - then the following rejection-interceptor is called
-    - once caught, another following fulfill-interceptor is called again (just like in a promise chain).
+  - then the following fulfillment-interceptor is not called
+  - then the following rejection-interceptor is called
+  - once caught, another following fulfill-interceptor is called again (just like in a promise chain).
 
 Read [the interceptor tests](./test/specs/interceptors.spec.js) for seeing all this in code.
 
@@ -886,7 +905,7 @@ cancel();
 
 ### URLSearchParams
 
-By default, axios serializes JavaScript objects to `JSON`. To send data in the [`application/x-www-form-urlencoded` format](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/POST) instead, you can use the [`URLSearchParams`](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) API, which is [supported](http://www.caniuse.com/#feat=urlsearchparams) in the vast majority of browsers,and [ Node](https://nodejs.org/api/url.html#url_class_urlsearchparams) starting with v10 (released in 2018).
+By default, axios serializes JavaScript objects to `JSON`. To send data in the [`application/x-www-form-urlencoded` format](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/POST) instead, you can use the [`URLSearchParams`](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) API, which is [supported](http://www.caniuse.com/#feat=urlsearchparams) in the vast majority of browsers,and [Node](https://nodejs.org/api/url.html#url_class_urlsearchparams) starting with v10 (released in 2018).
 
 ```js
 const params = new URLSearchParams({ foo: 'bar' });
@@ -1062,9 +1081,9 @@ The back-end body-parser could potentially use this meta-information to automati
 
 - `indexes: null|false|true = false` - controls how indexes will be added to unwrapped keys of `flat` array-like objects
 
-    - `null` - don't add brackets (`arr: 1`, `arr: 2`, `arr: 3`)
-    - `false`(default) - add empty brackets (`arr[]: 1`, `arr[]: 2`, `arr[]: 3`)
-    - `true` - add brackets with indexes  (`arr[0]: 1`, `arr[1]: 2`, `arr[2]: 3`)
+  - `null` - don't add brackets (`arr: 1`, `arr: 2`, `arr: 3`)
+  - `false`(default) - add empty brackets (`arr[]: 1`, `arr[]: 2`, `arr[]: 3`)
+  - `true` - add brackets with indexes  (`arr[0]: 1`, `arr[1]: 2`, `arr[2]: 3`)
 
 Let's say we have an object like this one:
 
@@ -1190,7 +1209,7 @@ Sending `Blobs`/`Files` as JSON (`base64`) is not currently supported.
 
 Axios supports both browser and node environments to capture request upload/download progress.
 
-```js    
+```js
 await axios.post(url, data, {
   onUploadProgress: function (axiosProgressEvent) {
     /*{
@@ -1240,7 +1259,6 @@ const {data} = await axios.post(SERVER_URL, readableStream, {
 > **⚠️ Warning**
 > It is recommended to disable redirects by setting maxRedirects: 0 to upload the stream in the **node.js** environment,
 > as follow-redirects package will buffer the entire stream in RAM without following the "backpressure" algorithm.
-
 
 ## 🆕 Rate limiting
 
@@ -1295,13 +1313,12 @@ You can use Gitpod, an online IDE(which is free for Open Source) for contributin
 
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/axios/axios/blob/main/examples/server.js)
 
-
 ## Resources
 
-* [Changelog](https://github.com/axios/axios/blob/v1.x/CHANGELOG.md)
-* [Ecosystem](https://github.com/axios/axios/blob/v1.x/ECOSYSTEM.md)
-* [Contributing Guide](https://github.com/axios/axios/blob/v1.x/CONTRIBUTING.md)
-* [Code of Conduct](https://github.com/axios/axios/blob/v1.x/CODE_OF_CONDUCT.md)
+- [Changelog](https://github.com/axios/axios/blob/v1.x/CHANGELOG.md)
+- [Ecosystem](https://github.com/axios/axios/blob/v1.x/ECOSYSTEM.md)
+- [Contributing Guide](https://github.com/axios/axios/blob/v1.x/CONTRIBUTING.md)
+- [Code of Conduct](https://github.com/axios/axios/blob/v1.x/CODE_OF_CONDUCT.md)
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 <h1 align="center">
-   <b>
-        <a href="https://axios-http.com"><img src="https://axios-http.com/assets/logo.svg" /></a><br>
-    </b>
+  <b>
+    <a href="https://axios-http.com"><img src="https://axios-http.com/assets/logo.svg" /></a><br>
+  </b>
 </h1>
 
 <p align="center">Promise based HTTP client for the browser and node.js</p>
 
 <p align="center">
-    <a href="https://axios-http.com/"><b>Website</b></a> •
-    <a href="https://axios-http.com/docs/intro"><b>Documentation</b></a>
+  <a href="https://axios-http.com/"><b>Website</b></a> •
+  <a href="https://axios-http.com/docs/intro"><b>Documentation</b></a>
 </p>
 
 <div align="center">
@@ -24,9 +24,6 @@
 [![gitter chat](https://img.shields.io/gitter/room/mzabriskie/axios.svg?style=flat-square)](https://gitter.im/mzabriskie/axios)
 [![code helpers](https://www.codetriage.com/axios/axios/badges/users.svg)](https://www.codetriage.com/axios/axios)
 [![Known Vulnerabilities](https://snyk.io/test/npm/axios/badge.svg)](https://snyk.io/test/npm/axios)
-
-
-
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">
   <b>
-    <a href="https://axios-http.com"><img src="https://axios-http.com/assets/logo.svg" /></a><br>
+    <a href="https://axios-http.com"><img src="https://axios-http.com/assets/logo.svg" alt="axios" /></a>
   </b>
 </h1>
 

--- a/README.md
+++ b/README.md
@@ -29,46 +29,48 @@
 
 ## Table of Contents
 
-  - [Features](#features)
-  - [Browser Support](#browser-support)
-  - [Installing](#installing)
-    - [Package manager](#package-manager)
-    - [CDN](#cdn)
-  - [Example](#example)
-  - [Axios API](#axios-api)
+- [Features](#features)
+- [Browser Support](#browser-support)
+- [Installing](#installing)
+  - [Package manager](#package-manager)
+  - [CDN](#cdn)
+- [Example](#example)
+- [axios API](#axios-api)
   - [Request method aliases](#request-method-aliases)
-  - [Concurrency 👎](#concurrency-deprecated)
+  - [Concurrency (👎 deprecated)](#concurrency--deprecated)
   - [Creating an instance](#creating-an-instance)
   - [Instance methods](#instance-methods)
-  - [Request Config](#request-config)
-  - [Response Schema](#response-schema)
-  - [Config Defaults](#config-defaults)
-    - [Global axios defaults](#global-axios-defaults)
-    - [Custom instance defaults](#custom-instance-defaults)
-    - [Config order of precedence](#config-order-of-precedence)
-  - [Interceptors](#interceptors)
-    - [Multiple Interceptors](#multiple-interceptors)
-  - [Handling Errors](#handling-errors)
-  - [Cancellation](#cancellation)
-    - [AbortController](#abortcontroller)
-    - [CancelToken 👎](#canceltoken-deprecated)
-  - [Using application/x-www-form-urlencoded format](#using-applicationx-www-form-urlencoded-format)
-    - [URLSearchParams](#urlsearchparams)
-    - [Query string](#query-string-older-browsers)
-    - [🆕 Automatic serialization](#-automatic-serialization-to-urlsearchparams)
-  - [Using multipart/form-data format](#using-multipartform-data-format)
-    - [FormData](#formdata)
-    - [🆕 Automatic serialization](#-automatic-serialization-to-formdata)
-  - [Files Posting](#files-posting)
-  - [HTML Form Posting](#-html-form-posting-browser)
-  - [🆕 Progress capturing](#-progress-capturing)
-  - [🆕 Rate limiting](#-progress-capturing)
-  - [Semver](#semver)
-  - [Promises](#promises)
-  - [TypeScript](#typescript)
-  - [Resources](#resources)
-  - [Credits](#credits)
-  - [License](#license)
+- [Request Config](#request-config)
+- [Response Schema](#response-schema)
+- [Config Defaults](#config-defaults)
+  - [Global axios defaults](#global-axios-defaults)
+  - [Custom instance defaults](#custom-instance-defaults)
+  - [Config order of precedence](#config-order-of-precedence)
+- [Interceptors](#interceptors)
+  - [Multiple Interceptors](#multiple-interceptors)
+- [Handling Errors](#handling-errors)
+- [Cancellation](#cancellation)
+  - [AbortController](#abortcontroller)
+  - [CancelToken (👎 deprecated)](#canceltoken--deprecated)
+- [Using `application/x-www-form-urlencoded` format](#using-applicationx-www-form-urlencoded-format)
+  - [URLSearchParams](#urlsearchparams)
+  - [Query string (older browsers)](#query-string-older-browsers)
+  - [Older Node.js versions](#older-nodejs-versions)
+  - [🆕 Automatic serialization to URLSearchParams](#-automatic-serialization-to-urlsearchparams)
+- [Using `multipart/form-data` format](#using-multipartform-data-format)
+  - [FormData](#formdata)
+  - [🆕 Automatic serialization to FormData](#-automatic-serialization-to-formdata)
+- [Files Posting](#files-posting)
+- [🆕 HTML Form Posting (browser)](#-html-form-posting-browser)
+- [🆕 Progress capturing](#-progress-capturing)
+- [🆕 Rate limiting](#-rate-limiting)
+- [SemVer](#semver)
+- [Promises](#promises)
+- [TypeScript](#typescript)
+- [Online one-click setup](#online-one-click-setup)
+- [Resources](#resources)
+- [Credits](#credits)
+- [License](#license)
 
 ## Features
 
@@ -301,7 +303,7 @@ For convenience, aliases have been provided for all common request methods.
 ###### NOTE
 When using the alias methods `url`, `method`, and `data` properties don't need to be specified in config.
 
-### Concurrency (Deprecated)
+### Concurrency (👎 deprecated)
 Please use `Promise.all` to replace the below functions.
 
 Helper functions for dealing with concurrent requests.
@@ -824,7 +826,7 @@ axios.get('/foo/bar', {
 controller.abort()
 ```
 
-### CancelToken `👎deprecated`
+### CancelToken (👎 deprecated)
 
 You can also cancel a request using a *CancelToken*.
 
@@ -892,7 +894,7 @@ params.append('extraparam', 'value');
 axios.post('/foo', params);
 ```
 
-### Query string (Older browsers)
+### Query string (older browsers)
 
 For compatibility with very old browsers, there is a [polyfill](https://github.com/WebReflection/url-search-params) available (make sure to polyfill the global environment).
 
@@ -1254,7 +1256,7 @@ const {data} = await axios.post(LOCAL_SERVER_URL, myBuffer, {
 });
 ```
 
-## Semver
+## SemVer
 
 Until axios reaches a `1.0` release, breaking changes will be released with a new minor version. For example `0.5.1`, and `0.5.4` will have the same API, but `0.6.0` will have breaking changes.
 


### PR DESCRIPTION
The table of content was outdated and at least the link to "Rate limiting" wrong.

This PR updates the TOC, edit some paragraphs, fixes some HTML and Markdown issues, corrects typos and more.

Optionally, I committed a config specific to vscode + extension, to configure an automatic TOC generator in 02db412577c94f21bc8a037514bdb6e19d4e9222.

Of course, feel free to choose commits to your liking.