### PR TITLE
fix(package.json): add 'bun' package.json 'exports' condition

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,10 @@
         "require": "./index.d.cts",
         "default": "./index.d.ts"
       },
+      "bun": {
+        "require": "./dist/node/axios.cjs",
+        "default": "./index.js"
+      },
       "browser": {
         "require": "./dist/browser/axios.cjs",
         "default": "./index.js"


### PR DESCRIPTION
This adds a `"bun"` package.json exports condition which loads the same build of axios as in Node. [Bun](https://bun.sh) currently loads both the `"browser"` condition and the `"default"` condition, which means that in this case, the `"browser"` condition is chosen first. That causes issues in packages which expect the `"http"` adapter, such as resend.

We've had a few issues where axios would load the browser version in Bun and we will fix that in the module resolver on Bun's end to only choose `"browser"` when no other matches are found, but it's separately a little bit more direct to explicitly add a "bun" export condition here.

Fixes https://github.com/oven-sh/bun/issues/3371

If you'd like, I can go ahead and add Bun to the CI to make sure it works, but that's a larger change than what this PR does so I'll avoid doing that unless asked.


