### PR TITLE
feat: Add partial sync execution to request interceptors

### DIFF
--- a/lib/core/Axios.js
+++ b/lib/core/Axios.js
@@ -92,13 +92,21 @@ class Axios {
 
     // filter out skipped interceptors
     const requestInterceptorChain = [];
-    let synchronousRequestInterceptors = true;
+
+    // We'll keep this to track the position of the last asynchronous request
+    // interceptor
+    let requestInterceptorsCount = 0;
+    let asyncInterceptorsThreshold = 0;
     this.interceptors.request.forEach(function unshiftRequestInterceptors(interceptor) {
       if (typeof interceptor.runWhen === 'function' && interceptor.runWhen(config) === false) {
         return;
       }
 
-      synchronousRequestInterceptors = synchronousRequestInterceptors && interceptor.synchronous;
+      requestInterceptorsCount++;
+
+      if (!interceptor.synchronous) {
+        asyncInterceptorsThreshold = requestInterceptorsCount;
+      }
 
       requestInterceptorChain.unshift(interceptor.fulfilled, interceptor.rejected);
     });
@@ -108,53 +116,52 @@ class Axios {
       responseInterceptorChain.push(interceptor.fulfilled, interceptor.rejected);
     });
 
-    let promise;
+    // Since we are always unshifting two elements into the request interceptor
+    // chain, we must decrease 2 times the threshold amount of async interceptors
+    // to get the synchronous request interceptor chain length.
+    const syncLen = requestInterceptorChain.length - 2 * asyncInterceptorsThreshold;
+
+    const chain = [dispatchRequest.bind(this), undefined];
+
+    chain.unshift.apply(chain, requestInterceptorChain);
+    chain.push.apply(chain, responseInterceptorChain);
+
+    const totalLen = chain.length;
+
     let i = 0;
-    let len;
 
-    if (!synchronousRequestInterceptors) {
-      const chain = [dispatchRequest.bind(this), undefined];
-      chain.unshift.apply(chain, requestInterceptorChain);
-      chain.push.apply(chain, responseInterceptorChain);
-      len = chain.length;
-
-      promise = Promise.resolve(config);
-
-      while (i < len) {
-        promise = promise.then(chain[i++], chain[i++]);
-      }
-
-      return promise;
-    }
-
-    len = requestInterceptorChain.length;
-
-    let newConfig = config;
-
-    i = 0;
-
-    while (i < len) {
-      const onFulfilled = requestInterceptorChain[i++];
-      const onRejected = requestInterceptorChain[i++];
+    while (i < syncLen) {
+      const onFulfilled = chain[i++];
+      const onRejected = chain[i++];
       try {
-        newConfig = onFulfilled(newConfig);
+        config = onFulfilled(config);
       } catch (error) {
         onRejected.call(this, error);
         break;
       }
     }
 
-    try {
-      promise = dispatchRequest.call(this, newConfig);
-    } catch (error) {
-      return Promise.reject(error);
+    let promise;
+
+    if (i < requestInterceptorChain.length) {
+      // There are asynchronous request interceptors before the request dispatcher
+      // itself is called.
+      promise = Promise.resolve(config);
+    }
+    else {
+      // All the request interceptors were executed synchronously. Then, the
+      // next element on the interceptor chain will be the request dispatcher
+      // itself and, in this case, we must call it synchronously.
+      try {
+        i += 2;
+        promise = dispatchRequest.call(this, config);
+      } catch (error) {
+        return Promise.reject(error);
+      }
     }
 
-    i = 0;
-    len = responseInterceptorChain.length;
-
-    while (i < len) {
-      promise = promise.then(responseInterceptorChain[i++], responseInterceptorChain[i++]);
+    while (i < totalLen) {
+      promise = promise.then(chain[i++], chain[i++]);
     }
 
     return promise;


### PR DESCRIPTION
## What is this about?

This PR makes the execution of request interceptors flagged as synchronous to always be synchronous as long as there isn't any async interceptors added after them.

## Why is this relevant?

In Vue, the `watchEffect` function captures reactive dependencies synchronously within a function execution.

So, in order to trigger an update on a component within an axios call, all reactive bindings must be used synchronously.

Currently, if we use an axios instance with only sync interceptors, we can trigger updates by using reactive variables inside them, but if we add a single async interceptor (even if it will be executed *after* the sync ones), we lose this capability. A real world example is a header tracked by a Pinia store added synchronously before an access token is issued asynchronously to be set on the `Authorization` header.

Other frameworks might do something similar and sometimes we might need to perform an action synchronously before any request but also have some async tasks to do.

## Considered cases

* ### Instance without any request interceptors
Execution will be as usual. The adapter will be called synchronously and then the response interceptors will be called asynchronously one by one.

* ### Instance with only sync request interceptors
Same as above. All interceptors being executed synchronously (and the adapter).

* ### Instance with only async request interceptors
Same as above. All interceptors will be executed asynchronously, but the adapter will still be called synchronously.

* ### Instance with sync interceptors added AFTER async ones
Since interceptors are executed in a LIFO way, we can execute the sync interceptors synchronously, then continue the execution as if all the next interceptors were async.

* ### Instance with sync interceptors added BEFORE async ones
Since interceptors order of execution must be respected, those sync interceptors must be called after the async ones are resolved, which means we cannot call them synchronously, so we proceed to call the interceptor chain as if all interceptors were async.