### PR TITLE
fix(http): decode proxy url auth

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -74,9 +74,16 @@ function dispatchBeforeRedirect(options) {
 function setProxy(options, configProxy, location) {
   let proxy = configProxy;
   if (!proxy && proxy !== false) {
-    const proxyUrl = getProxyForUrl(location);
-    if (proxyUrl) {
-      proxy = new URL(proxyUrl);
+    const proxyUrlStr = getProxyForUrl(location);
+    if (proxyUrlStr) {
+      const proxyUrl = new URL(proxyUrlStr);
+      proxy = {
+        protocol: proxyUrl.protocol,
+        hostname: proxyUrl.hostname,
+        port: proxyUrl.port,
+        username: decodeURIComponent(proxyUrl.username),
+        password: decodeURIComponent(proxyUrl.password)
+      };
     }
   }
   if (proxy) {

--- a/test/unit/adapters/http.js
+++ b/test/unit/adapters/http.js
@@ -1287,10 +1287,10 @@ describe('supports http with nodejs', function () {
         });
 
       }).listen(4000, function () {
-        process.env.http_proxy = 'http://user:pass@localhost:4000/';
+        process.env.http_proxy = 'http://user%3F:pass%3F@localhost:4000/';
 
         axios.get('http://localhost:4444/').then(function (res) {
-          var base64 = Buffer.from('user:pass', 'utf8').toString('base64');
+          var base64 = Buffer.from('user?:pass?', 'utf8').toString('base64');
           assert.equal(res.data, 'Basic ' + base64, 'should authenticate to the proxy set by process.env.http_proxy');
           done();
         }).catch(done);


### PR DESCRIPTION
#4852 introduced a subtle bug that recently broke one of our apps. Here's the issue:
Node's `url.parse` automatically decodes the `auth` property:
```js
import url from 'url'
const myURL = url.parse('http://user%3F:pass%3F@localhost:4000')
console.log(myURL.auth) // "user?:pass?"
```
However, the `URL` interface returns `username` and `password` undecoded:
```js
const myURL = new URL('http://user%3F:pass%3F@localhost:4000')
console.log(myURL.username) // "user%3F"
console.log(myURL.password) // "pass%3F"
```
This PR reintroduces the old behavior by manually decoding the `username` and `password` properties with `decodeURIComponent`.