### PR TITLE
feat(http): enable ssl tunneling through proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,6 +513,7 @@ These are the available config options for making requests. Only the `url` is re
   // This will set an `Proxy-Authorization` header, overwriting any existing
   // `Proxy-Authorization` custom headers you have set using `headers`.
   // If the proxy server uses HTTPS, then you must set the protocol to `https`.
+  // If you are using a custom https agent, you must handle SSL tunneling yourself.
   proxy: {
     protocol: 'https',
     host: '127.0.0.1',

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -7,6 +7,7 @@ import buildURL from './../helpers/buildURL.js';
 import {getProxyForUrl} from 'proxy-from-env';
 import http from 'http';
 import https from 'https';
+import tls from 'tls';
 import util from 'util';
 import followRedirects from 'follow-redirects';
 import zlib from 'zlib';
@@ -85,6 +86,7 @@ function setProxy(options, configProxy, location) {
       proxy.auth = (proxy.username || '') + ':' + (proxy.password || '');
     }
 
+    let proxyAuthHeader;
     if (proxy.auth) {
       // Support proxy auth object form
       if (proxy.auth.username || proxy.auth.password) {
@@ -93,18 +95,66 @@ function setProxy(options, configProxy, location) {
       const base64 = Buffer
         .from(proxy.auth, 'utf8')
         .toString('base64');
-      options.headers['Proxy-Authorization'] = 'Basic ' + base64;
+      proxyAuthHeader = 'Basic ' + base64;
     }
 
-    options.headers.host = options.hostname + (options.port ? ':' + options.port : '');
-    const proxyHost = proxy.hostname || proxy.host;
-    options.hostname = proxyHost;
-    // Replace 'host' since options is not a URL object
-    options.host = proxyHost;
-    options.port = proxy.port;
-    options.path = location;
-    if (proxy.protocol) {
-      options.protocol = proxy.protocol.includes(':') ? proxy.protocol : `${proxy.protocol}:`;
+    if (isHttps.test(options.protocol) && options.hostname !== 'localhost') {
+      options.createConnection = (options, callback) => {
+        // The following is adapted from https://github.com/delvedor/hpagent/blob/96f45f1d40bfbdfd0fcc84cdba056be6e0fb8f4c/index.js#L74
+        const reqOptions = {
+          method: 'CONNECT',
+          host: proxy.hostname || proxy.host,
+          port: proxy.port,
+          path: `${options.host}:${options.port}`,
+          headers: { host: `${options.host}:${options.port}` },
+          agent: false,
+          timeout: options.timeout || 0
+        };
+        if (proxyAuthHeader) {
+          reqOptions.headers['Proxy-Authorization'] = proxyAuthHeader;
+        }
+        if (isHttps.test(proxy.protocol)) {
+          reqOptions.servername = proxy.hostname || proxy.host;
+        }
+        const req = (isHttps.test(proxy.protocol) ? https : http).request(reqOptions);
+        req.once('connect', (res, socket) => {
+          req.removeAllListeners();
+          socket.removeAllListeners();
+          if (res.statusCode === 200) {
+            const secureSocket = tls.connect({ ...options, socket });
+            callback(null, secureSocket);
+          } else {
+            socket.destroy();
+            callback(new Error(`Bad response: ${res.statusCode}`), null);
+          }
+        });
+        req.once('timeout', () => {
+          req.destroy(new Error('Proxy timeout'));
+        });
+        req.once('error', err => {
+          req.removeAllListeners();
+          callback(err, null);
+        });
+        req.end();
+      };
+      // Since we are using the `createConnection` option, Node.js won't use the default
+      // https agent and the following fields won't be correctly set.
+      options.port = options.port || 443;
+      options.servername = options.hostname;
+    } else {
+      if (proxyAuthHeader) {
+        options.headers['Proxy-Authorization'] = proxyAuthHeader;
+      }
+      options.headers.host = options.hostname + (options.port ? ':' + options.port : '');
+      const proxyHost = proxy.hostname || proxy.host;
+      options.hostname = proxyHost;
+      // Replace 'host' since options is not a URL object
+      options.host = proxyHost;
+      options.port = proxy.port;
+      options.path = location;
+      if (proxy.protocol) {
+        options.protocol = proxy.protocol.includes(':') ? proxy.protocol : `${proxy.protocol}:`;
+      }
     }
   }
 


### PR DESCRIPTION
This is similar to #5037 but has a simpler implementation adapted from [hpagent](https://github.com/delvedor/hpagent) and additionally supports HTTPS proxies.