### PR TITLE
docs: Add axios error type definitions in README.MD 

### DIFF
--- a/README.md
+++ b/README.md
@@ -764,6 +764,36 @@ and when the response was fulfilled
 
 Read [the interceptor tests](./test/specs/interceptors.spec.js) for seeing all this in code.
 
+## Error Types
+
+There are many different axios error messages that can appear that can provide basic information about the specifics of the error and where opportunities may lie in debugging.
+
+The general structure of axios errors is as follows:
+| Property  | Definition  |
+| -------- | ----------  |
+| message  | A quick summary of the error message and the status it failed with. |
+| name     | This defines where the error originated from. For axios, it will always be an 'AxiosError'. |
+| stack    | Provides the stack trace of the error. | 
+| config   | An axios config object with specific instance configurations defined by the user from when the request was made |
+| code     | Represents an axios identified error. The table below lists out specific definitions for internal axios error.  |
+| status   | HTTP response status code. See [here](https://en.wikipedia.org/wiki/List_of_HTTP_status_codes) for common HTTP response status code meanings. 
+
+Below is a list of potential axios identified error
+| Code  |  Definition   |
+| -------- | ----------  |
+| ERR_BAD_OPTION_VALUE | Invalid or unsupported value provided in axios configuration. |
+| ERR_BAD_OPTION | Invalid option provided in axios configuration. |
+| ECONNABORTED | Request timed out due to exceeding timeout specified in axios configuration. |
+| ETIMEDOUT | Request timed out due to exceeding default axios timelimit. |
+| ERR_NETWORK | Network-related issue.
+| ERR_FR_TOO_MANY_REDIRECTS | Request is redirected too many times; exceeds max redirects specified in axios configuration.
+| ERR_DEPRECATED | Deprecated feature or method used in axios. 
+| ERR_BAD_RESPONSE | Response cannot be parsed properly or is in an unexpected format. 
+| ERR_BAD_REQUEST | Requested has unexpected format or missing required parameters. |
+| ERR_CANCELED | Feature or method is canceled explicitly by the user.   
+| ERR_NOT_SUPPORT | Feature or method not supported in the current axios environment. 
+| ERR_INVALID_URL | Invalid URL provided for axios request.
+
 ## Handling Errors
 
 the default behavior is to reject every response that returns with a status code that falls out of the range of 2xx and treat it as an error.


### PR DESCRIPTION
This pull request fixes #5760. There is insufficient documentation regarding the error types, their definitions and what they mean in Axios. This pull request is intended to update the README.MD documentation on error types. 
