### PR TITLE
docs: Linting documentation notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ async function getUser() {
 }
 ```
 
-> **Note** `async/await` is part of ECMAScript 2017 and is not supported in Internet
+> **Note**: `async/await` is part of ECMAScript 2017 and is not supported in Internet
 > Explorer and older browsers, so use with caution.
 
 Performing a `POST` request
@@ -931,8 +931,7 @@ axios.post('https://something.com/', querystring.stringify({ foo: 'bar' }));
 
 You can also use the [`qs`](https://github.com/ljharb/qs) library.
 
-> **Note**
-> The `qs` library is preferable if you need to stringify nested objects, as the `querystring` method has [known issues](https://github.com/nodejs/node-v0.x-archive/issues/1665) with that use case.
+> **Note**: The `qs` library is preferable if you need to stringify nested objects, as the `querystring` method has [known issues](https://github.com/nodejs/node-v0.x-archive/issues/1665) with that use case.
 
 ### 🆕 Automatic serialization to URLSearchParams
 
@@ -1048,8 +1047,7 @@ Axios FormData serializer supports some special endings to perform the following
 - `{}` - serialize the value with JSON.stringify
 - `[]` - unwrap the array-like object as separate fields with the same key
 
-> **Note**
-> unwrap/expand operation will be used by default on arrays and FileList objects
+> **Note**: unwrap/expand operation will be used by default on arrays and FileList objects
 
 FormData serializer supports additional options via `config.formSerializer: object` property to handle rare cases:
 


### PR DESCRIPTION
This PR aims to lint the various **Notes** in the documentation.
Some of them are written in a unique line, some have titles followed by text, some use colons and some do not.

This PR should bring a little of uniformity.