### PR TITLE
fix(adapter): make sure that the adapters can be imported correctly

### DIFF
--- a/lib/adapters/adapters.js
+++ b/lib/adapters/adapters.js
@@ -3,9 +3,12 @@ import httpAdapter from './http.js';
 import xhrAdapter from './xhr.js';
 import AxiosError from "../core/AxiosError.js";
 
+const isHttpAdapterSupported = typeof process !== 'undefined' && utils.kindOf(process) === 'process';
+const isXHRAdapterSupported = typeof XMLHttpRequest !== 'undefined';
+
 const knownAdapters = {
-  http: httpAdapter,
-  xhr: xhrAdapter
+  http: isHttpAdapterSupported && httpAdapter,
+  xhr: isXHRAdapterSupported && xhrAdapter
 }
 
 utils.forEach(knownAdapters, (fn, value) => {

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -115,8 +115,6 @@ function setProxy(options, configProxy, location) {
   };
 }
 
-const isHttpAdapterSupported = typeof process !== 'undefined' && utils.kindOf(process) === 'process';
-
 // temporary hotfix
 
 const wrapAsync = (asyncExecutor) => {
@@ -144,8 +142,7 @@ const wrapAsync = (asyncExecutor) => {
   })
 };
 
-/*eslint consistent-return:0*/
-export default isHttpAdapterSupported && function httpAdapter(config) {
+export default function httpAdapter(config) {
   return wrapAsync(async function dispatchHttpRequest(resolve, reject, onDone) {
     let {data, lookup, family} = config;
     const {responseType, responseEncoding} = config;

--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -43,9 +43,7 @@ function progressEventReducer(listener, isDownloadStream) {
   };
 }
 
-const isXHRAdapterSupported = typeof XMLHttpRequest !== 'undefined';
-
-export default isXHRAdapterSupported && function (config) {
+export default function xhrAdapter(config) {
   return new Promise(function dispatchXhrRequest(resolve, reject) {
     let requestData = config.data;
     const requestHeaders = AxiosHeaders.from(config.headers).normalize();


### PR DESCRIPTION
Make sure that the adapters can be imported correctly.

This also keeps it consistent with the [0.x](https://github.com/axios/axios/blob/v0.x/lib/adapters/http.js#L84) version behavior.

It allows the method in this [comment](https://github.com/axios/axios/issues/4559#issuecomment-1365717816) to continue to work properly.