### PR TITLE
fix: only apply default Content-Type header when body is defined

### DIFF
--- a/lib/core/dispatchRequest.js
+++ b/lib/core/dispatchRequest.js
@@ -42,7 +42,7 @@ export default function dispatchRequest(config) {
     config.transformRequest
   );
 
-  if (['post', 'put', 'patch'].indexOf(config.method) !== -1) {
+  if (['post', 'put', 'patch'].indexOf(config.method) !== -1 && config.body !== undefined) {
     config.headers.setContentType('application/x-www-form-urlencoded', false);
   }
 


### PR DESCRIPTION
Fixes: https://github.com/axios/axios/issues/5236 (and similar others)

I noticed recently that sending a POST/PUT/PATCH request with an undefined body would add a `Content-Type` header of `application/x-www-form-urlencoded`, even when the request body is undefined. The backend I was calling does not support form data, so rejected the request with 415, despite the fact that I wasn't sending a body at all. I found this to be extremely surprising behaviour, and it seems like it would be more sensible to only include this default when a body is present.