### PR TITLE
fix: handle timeout to destroy the request

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -597,6 +597,12 @@ export default isHttpAdapterSupported && function httpAdapter(config) {
       socket.setKeepAlive(true, 1000 * 60);
     });
 
+    // Handlle timeout
+    req.on('timeout', function() {
+      // The request must be destroyed manually when timeout according to nodejs doc https://nodejs.org/api/http.html#event-timeout
+      req.destroy();
+    });
+
     // Handle request timeout
     if (config.timeout) {
       // This is forcing a int timeout to avoid problems if the `req` interface doesn't handle other types.

--- a/test/unit/adapters/http.js
+++ b/test/unit/adapters/http.js
@@ -263,6 +263,35 @@ describe('supports http with nodejs', function () {
     });
   });
 
+  it('should destroy the request when timeout', function (done) {
+
+    server = http.createServer(function (req, res) {
+      setTimeout(function () {
+        res.end();
+      }, 1000);
+    }).listen(4444, function () {
+      var success = false, failure = false;
+      var error;
+
+      axios.get('http://localhost:4444/', {
+        timeout: 250,
+        timeoutErrorMessage: 'oops, timeout',
+      }).then(function (res) {
+        success = true;
+      }).catch(function (err) {
+        error = err;
+        failure = true;
+      });
+
+      setTimeout(function () {
+        assert.strictEqual(success, false, 'request should not succeed');
+        assert.strictEqual(failure, true, 'request should fail');
+        assert.strictEqual(error.request.destroyed, true);
+        done();
+      }, 300);
+    });
+  });
+
   it('should allow passing JSON', function (done) {
     var data = {
       firstName: 'Fred',


### PR DESCRIPTION
### Proposed changes
Handle timeout logic to destroy the request to avoid the below problem.

### Description of the problem
I sometimes encountered a repeating ECONNRESET error after ETIMEDOUT error. I reproduced it like the below code.
e.g.
```
for (let i = 0; i <= 10; i++) {
  try {
    res = await axios.request(config);
    break;
  } catch(e) {
    console.log(e.code);
  }
}
```

It probably has a problem with handling timeouts. According to [the node docs about timeout event](https://nodejs.org/api/http.html#event-timeout), The request must be destroyed manually when timeout. 
Maybe related to some ECONNRESET issues https://github.com/axios/axios/issues?q=is%3Aissue+is%3Aopen+ECONNRESET+