### PR TITLE
fix(core): resolve assignment to read-only 'set' property

### DIFF
--- a/lib/core/AxiosHeaders.js
+++ b/lib/core/AxiosHeaders.js
@@ -63,7 +63,7 @@ function buildAccessors(obj, header) {
 
   ['get', 'set', 'has'].forEach(methodName => {
     Object.defineProperty(obj, methodName + accessorName, {
-      value: function(arg1, arg2, arg3) {
+      value: function (arg1, arg2, arg3) {
         return this[methodName].call(this, header, arg1, arg2, arg3);
       },
       configurable: true
@@ -88,8 +88,13 @@ class AxiosHeaders {
 
       const key = utils.findKey(self, lHeader);
 
-      if(!key || self[key] === undefined || _rewrite === true || (_rewrite === undefined && self[key] !== false)) {
-        self[key || _header] = normalizeValue(_value);
+      if (!key || self[key] === undefined || _rewrite === true || (_rewrite === undefined && self[key] !== false)) {
+        Object.defineProperty(self, [key || _header], {
+          value: normalizeValue(_value),
+          writable: true,
+          configurable: true,
+          enumerable: true,
+        });
       }
     }
 
@@ -98,7 +103,7 @@ class AxiosHeaders {
 
     if (utils.isPlainObject(header) || header instanceof this.constructor) {
       setHeaders(header, valueOrRewrite)
-    } else if(utils.isString(header) && (header = header.trim()) && !isValidHeaderName(header)) {
+    } else if (utils.isString(header) && (header = header.trim()) && !isValidHeaderName(header)) {
       setHeaders(parseHeaders(header), valueOrRewrite);
     } else {
       header != null && setHeader(valueOrRewrite, header, rewrite);
@@ -183,7 +188,7 @@ class AxiosHeaders {
 
     while (i--) {
       const key = keys[i];
-      if(!matcher || matchHeaderValue(this, this[key], key, matcher, true)) {
+      if (!matcher || matchHeaderValue(this, this[key], key, matcher, true)) {
         delete this[key];
         deleted = true;
       }


### PR DESCRIPTION
Fixes an issue where attempting to assign to the read-only 'set' property of an object was causing an error. This issue was occurring within the setHeader function.

Closes #5768

Sending a request to a specific link that in response, one of his header names is "Set" will cause an "uncaughtException" that cannot be avoided, even by using interceptors, since the setHeader called before the interceptors for the response handling.

TypeError: Cannot assign to read only property 'set' of object '[object Object]'\n    at setHeader 
(/app/node_modules/axios/dist/node/axios.cjs:1651:30)\n    at /app/node_modules/axios/dist/node/axios.cjs:1656:51\n    at 
Object.forEach (/app/node_modules/axios/dist/node/axios.cjs:293:10)\n    at setHeaders 
(/app/node_modules/axios/dist/node/axios.cjs:1656:13)\n    at AxiosHeaders.set 
(/app/node_modules/axios/dist/node/axios.cjs:1659:7)\n    at new AxiosHeaders 
To Reproduce
Send a GET request to the following link: 

https://my424369.businessbydesign.cloud.sap/sap/public/ap/ui/repository/SAP_UI/HTMLOBERON5/client.html?app.component=/SAP_UI_CT/Main/root.uiccwoc&rootWindow=X&redirectUrl=/sap/public/byd/runtime&slalala=25

You will receive the error mentioned above.

Code snippet
`axios.get('https://my424369.businessbydesign.cloud.sap/sap/public/ap/ui/repository/SAP_UI/HTMLOBERON5/client.html?app.component=/SAP_UI_CT/Main/root.uiccwoc&rootWindow=X&redirectUrl=/sap/public/byd/runtime&slalala=25')`
