### PR TITLE
Match ES2022 Error `cause` property on AxiosError

### DIFF
--- a/index.d.cts
+++ b/index.d.cts
@@ -94,7 +94,7 @@ declare class AxiosError<T = unknown, D = any> extends Error {
   isAxiosError: boolean;
   status?: number;
   toJSON: () => object;
-  cause?: Error;
+  cause?: unknown;
   static readonly ERR_FR_TOO_MANY_REDIRECTS = "ERR_FR_TOO_MANY_REDIRECTS";
   static readonly ERR_BAD_OPTION_VALUE = "ERR_BAD_OPTION_VALUE";
   static readonly ERR_BAD_OPTION = "ERR_BAD_OPTION";


### PR DESCRIPTION
Closes https://github.com/axios/axios/issues/5849

Updated `AxiosError.cause` property to match es2022.error `ErrorOptions['cause']` and use `unknown`. This is also more correct with [Typescript (since version 4.4.x) change over to always resolving `.catch` `error` parameter to be `unknown`](https://devblogs.microsoft.com/typescript/announcing-typescript-4-4/#use-unknown-catch-variables).


With `Error`:

<img width="720" alt="Screenshot 2023-08-31 at 1 37 08 PM" src="https://github.com/axios/axios/assets/525506/3c3a32a9-432c-4274-bd7a-0a8e0e5142d0">

With `unknown`:

<img width="401" alt="Screenshot 2023-08-31 at 1 37 39 PM" src="https://github.com/axios/axios/assets/525506/3e829416-5b89-4c58-91a9-0eb49ed2583d">

