### PR TITLE
fix:updated the permalink and right branch in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -661,7 +661,7 @@ instance.defaults.headers.common['Authorization'] = AUTH_TOKEN;
 
 ### Config order of precedence
 
-Config will be merged with an order of precedence. The order is library defaults found in [lib/defaults.js](https://github.com/axios/axios/blob/master/lib/defaults/index.js#L28), then `defaults` property of the instance, and finally `config` argument for the request. The latter will take precedence over the former. Here's an example.
+Config will be merged with an order of precedence. The order is library defaults found in [lib/defaults/index.js](https://github.com/axios/axios/blob/master/lib/defaults/index.js#L49), then `defaults` property of the instance, and finally `config` argument for the request. The latter will take precedence over the former. Here's an example.
 
 ```js
 // Create an instance using the config defaults provided by the library


### PR DESCRIPTION
###What does  this PR do 
Updates the permalink to include the right branch name and point to the proper line of code:

https://github.com/axios/axios/blob/main/lib/defaults/index.js#L49

master → main
L28 → L49
Update the file path:
lib/defaults.js → lib/defaults/index.js

Fixes #5927


###Relevant File(s)
README.md
lib/defaults/index.js