### PR TITLE
fixes: Change Logo Size on Intro Page

### DIFF
--- a/sandbox/client.html
+++ b/sandbox/client.html
@@ -27,7 +27,7 @@
 </head>
 <body class="container">
 <div class="header">
-  <img src="https://axios-http.com/assets/logo.svg" alt="axios" width="130" height="60">
+  <img src="https://axios-http.com/assets/logo.svg" alt="axios" width="110" height="40">
    
   <h1> &nbsp;| Sandbox</h1>
 </div>


### PR DESCRIPTION
Changes Made:

This pull request addresses the following changes:

-  Adjusted the size of the logo on the intro page.
- Changed size from width="130" height="60" to width="110" height="40"

Context:

This change is in response to Issue #5948, where the need to modify the logo size on the intro page was discussed.