### PR TITLE
Added some fixes in contributing.md file with using npm

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,9 +20,9 @@ Please update the [docs](README.md) accordingly so that there are no discrepanci
 
 ## Developing
 
-- `grunt test` run the jasmine and mocha tests
-- `grunt build` run webpack and bundle the source
-- `grunt version` prepare the code for release
+- `npm run test` or `grunt test` run the jasmine and mocha tests
+- `npm run build` or `grunt build` run webpack and bundle the source
+- `npm run version` or `grunt version` prepare the code for release
 
 Please don't include changes to `dist/` in your pull request. This should only be updated when releasing a new version.
 


### PR DESCRIPTION
## What does this PR do?
This PR modifies the section [developing](https://github.com/axios/axios/blob/v1.x/CONTRIBUTING.md#developing) mentioning about the below 3 commands

- `grunt test run` the jasmine and mocha tests
- `grunt build run` webpack and bundle the source
- `grunt version` prepare the code for release

Because the package json defines scripts for the same which is using npm, the command for npm us added here.

![Screenshot 2023-10-04 192340](https://github.com/axios/axios/assets/84664410/cf3d654d-cde3-417d-9718-5c6118823516)

Fixes #5969 