### PR TITLE
Update http.js for solving issue #5888

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -31,8 +31,8 @@ const zlibOptions = {
 };
 
 const brotliOptions = {
-  flush: zlib.constants.BROTLI_OPERATION_FLUSH,
-  finishFlush: zlib.constants.BROTLI_OPERATION_FLUSH
+  flush: zlib.constants.BROTLI_OPERATION_FLUSH || 2,
+  finishFlush: zlib.constants.BROTLI_OPERATION_FLUSH || 2
 }
 
 const isBrotliSupported = utils.isFunction(zlib.createBrotliDecompress);


### PR DESCRIPTION
Identifying the Issue:

The issue arises when using Axios versions 1.2.1 or greater and involves a missing constant within the Axios library. Specifically, the error is triggered within the Axios HTTP adapter, particularly in the zlibOptions object. This missing constant is causing errors when trying to access exports12.constants.Z_SYNC_FLUSH.

Understanding the Error:

The error message that you might encounter when using Axios versions 1.2.1 or greater might look like this:

Uncaught TypeError: Cannot read properties of undefined (reading 'Z_SYNC_FLUSH') This error message indicates that the code is attempting to access the property Z_SYNC_FLUSH within the constants object, which is missing or undefined in the Axios version you are using.

Temporary Workaround:

To address this issue until an official fix is provided, you can make a temporary modification to the http.js file. Here's how to do it:

Locate the http.js file within the Axios library. It is typically located in the node_modules/axios/lib/adapters directory.

Inside http.js, find the section that defines the zlibOptions object, which looks like this:

var zlibOptions = {
flush: exports12.constants.Z_SYNC_FLUSH,
finishFlush: exports12.constants.Z_SYNC_FLUSH
};
Modify it to add a fallback value when exports12.constants.Z_SYNC_FLUSH is undefined:

var zlibOptions = {
flush: exports12.constants.Z_SYNC_FLUSH || 2, // Use any suitable value as a fallback finishFlush: exports12.constants.Z_SYNC_FLUSH || 2 // Same fallback value };
