### PR TITLE
fix: Add options object to docstring so IDE's indicate it's available

### DIFF
--- a/lib/core/InterceptorManager.js
+++ b/lib/core/InterceptorManager.js
@@ -12,6 +12,7 @@ class InterceptorManager {
    *
    * @param {Function} fulfilled The function to handle `then` for a `Promise`
    * @param {Function} rejected The function to handle `reject` for a `Promise`
+   * @param {Object} options The options for the interceptor, synchronous and runWhen
    *
    * @return {Number} An ID used to remove interceptor later
    */


### PR DESCRIPTION
I spent hours looking around issues with my async function in an interceptor. If my IDE had indicated that there was an available `options` object, it would have helped me fix this issue quickly. I will also be opening a similar PR for axios-docs