### PR TITLE
fix: add type for request in AxiosError class

### DIFF
--- a/index.d.cts
+++ b/index.d.cts
@@ -85,7 +85,7 @@ declare class AxiosError<T = unknown, D = any> extends Error {
       message?: string,
       code?: string,
       config?: axios.InternalAxiosRequestConfig<D>,
-      request?: any,
+      request?: axios.AxiosRequestConfig,
       response?: axios.AxiosResponse<T, D>
   );
 


### PR DESCRIPTION
### What does this PR introduce ?
This PR adds type(axios.AxiosRequestConfig) for request in AxiosError class in index.d.cts file.

### Why was this change needed ?
This change ensures better type safety when dealing with AxiosError class.

Fixes #5991