### PR TITLE
fix(lib/adapters/xhr.js): CVE-2023-45857

### DIFF
--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -188,7 +188,7 @@ export default isXHRAdapterSupported && function (config) {
     // Specifically not if we're in a web worker, or react-native.
     if (platform.isStandardBrowserEnv) {
       // Add xsrf header
-      const xsrfValue = (config.withCredentials || isURLSameOrigin(fullPath))
+      const xsrfValue = (config.withCredentials && isURLSameOrigin(fullPath))
         && config.xsrfCookieName && cookies.read(config.xsrfCookieName);
 
       if (xsrfValue) {


### PR DESCRIPTION
CVE-2023-45857
#6006 

Hi team, @jasonsaayman and @DigitalBrainJS 

It's crucial to ensure the protection of CSRF tokens. These tokens should be treated as confidential information and managed securely at all times.
You may check it here:
https://portswigger.net/web-security/csrf/preventing
https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html

I believe that lib/adapters/xhr.js:191 must check withCredentials **&&** isURLSameOrigin to populate X-XSRF-TOKEN header.

Kind regards, Valentin Panov 
