### PR TITLE
fix: improve findKey function

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -268,17 +268,7 @@ function forEach(obj, fn, {allOwnKeys = false} = {}) {
 }
 
 function findKey(obj, key) {
-  key = key.toLowerCase();
-  const keys = Object.keys(obj);
-  let i = keys.length;
-  let _key;
-  while (i-- > 0) {
-    _key = keys[i];
-    if (key === _key.toLowerCase()) {
-      return _key;
-    }
-  }
-  return null;
+  return key.toLowerCase() in obj ? key : null
 }
 
 const _global = (() => {


### PR DESCRIPTION
<!-- Click "Preview" for a more readable version -->


fix: Improve code and performance of findKey function
Can be considered to use `Object.hasOwn(obk, key.toLowerCase())` in case of problems with 'in' operator
Describe your pull request here.
