### PR TITLE
feat: add automatic minor and patch upgrades for npm packages used in axios

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,23 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  # Upgrade for npm packages, minor and patch versions only
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    groups:
+      production_dependencies:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+      development_dependencies:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 5
     groups:
       production_dependencies:
         dependency-type: "production"


### PR DESCRIPTION
# Summary
- add automatic minor and patch upgrades for npm packages used in axios

A couple of screenshots to show the automatic PRs getting created by github dependabot, hopefully it will make your lives easier when having to release new minor and patch upgrades for dependencies getting used in this project

![image](https://github.com/axios/axios/assets/30316250/ebcb8470-1d88-4fc2-981a-7c47090c18c9)

![image](https://github.com/axios/axios/assets/30316250/6b81e0ab-63fb-423f-a06d-d1be14540a9b)

![image](https://github.com/axios/axios/assets/30316250/4562277b-db07-4dc8-af97-c7f824d1b6a1)

![image](https://github.com/axios/axios/assets/30316250/b6050ad5-8803-4486-bca7-3e041440cb5e)

![image](https://github.com/axios/axios/assets/30316250/e4a0869f-6767-4577-9561-5e17f8e79f8d)

