### PR TITLE
docs: fix outdated grunt to npm run

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,9 +20,9 @@ Please update the [docs](README.md) accordingly so that there are no discrepanci
 
 ## Developing
 
-- `grunt test` run the jasmine and mocha tests
-- `grunt build` run webpack and bundle the source
-- `grunt version` prepare the code for release
+- `npm run test` run the jasmine and mocha tests
+- `npm run build` run webpack and bundle the source
+- `npm run version` prepare the code for release
 
 Please don't include changes to `dist/` in your pull request. This should only be updated when releasing a new version.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,6 +5,6 @@ To run the examples:
 1. `git clone https://github.com/axios/axios.git`
 2. `cd axios`
 3. `npm install`
-4. `grunt build`
+4. `npm run build`
 5. `npm run examples`
 6. [http://localhost:3000](http://localhost:3000)


### PR DESCRIPTION
As grunt was already removed in the devDependencies in #4787, change the grunt related CLI run, eg. `grunt build/version/test` to `npm run build/version/test`, in `examples/README.md` and `CONTRIBUTING.md`.

Fixes: #5969
Refs: #4787