### PR TITLE
fix: skip building address entry when custom DNS lookup function throws an err

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -171,6 +171,9 @@ export default isHttpAdapterSupported && function httpAdapter(config) {
       // hotfix to support opt.all option which is required for node 20.x
       lookup = (hostname, opt, cb) => {
         _lookup(hostname, opt, (err, arg0, arg1) => {
+          if (err) {
+            return cb(err);
+          }
           const addresses = utils.isArray(arg0) ? arg0.map(addr => buildAddressEntry(addr)) : [buildAddressEntry(arg0, arg1)];
 
           opt.all ? cb(err, addresses) : cb(err, addresses[0].address, addresses[0].family);

--- a/test/unit/adapters/http.js
+++ b/test/unit/adapters/http.js
@@ -2216,5 +2216,19 @@ describe('supports http with nodejs', function () {
 
       assert.strictEqual(data, payload);
     });
+
+    it('should handle errors in a custom DNS lookup function', async function () {
+      server = await startHTTPServer(SERVER_HANDLER_STREAM_ECHO);
+
+      const payload = 'test';
+
+      const error = new Error('test');
+
+      await assert.rejects(() => axios.post(`http://fake-name.axios:4444`, payload,{
+          lookup: async (hostname, opt) =>  {
+              throw error;
+          }
+      }), error);
+    });
   });
 });


### PR DESCRIPTION
Currently when lookup throws an err, we try to buildAddressEntry which fails since arg0 and arg1 are both undefined. This results in another error being thrown, callback not being called and ultimately end in UnhandledRejection.