### PR TITLE
feat: add handlers on AxiosInterceptorManager interface

### DIFF
--- a/index.d.cts
+++ b/index.d.cts
@@ -494,6 +494,12 @@ declare namespace axios {
     use(onFulfilled?: (value: V) => V | Promise<V>, onRejected?: (error: any) => any, options?: AxiosInterceptorOptions): number;
     eject(id: number): void;
     clear(): void;
+    handlers: Array<{
+      fulfilled: ((value: V) => V | Promise<V>) | null;
+      rejected: ((error: any) => any) | null;
+      synchronous: boolean;
+      runWhen: (config: InternalAxiosRequestConfig) => boolean;
+    }>;
   }
 
   interface AxiosInstance extends Axios {

--- a/index.d.ts
+++ b/index.d.ts
@@ -477,6 +477,12 @@ export interface AxiosInterceptorManager<V> {
   use(onFulfilled?: ((value: V) => V | Promise<V>) | null, onRejected?: ((error: any) => any) | null, options?: AxiosInterceptorOptions): number;
   eject(id: number): void;
   clear(): void;
+  handlers: Array<{
+    fulfilled: ((value: V) => V | Promise<V>) | null;
+    rejected: ((error: any) => any) | null;
+    synchronous: boolean;
+    runWhen: (config: InternalAxiosRequestConfig) => boolean;
+  }>;
 }
 
 export class Axios {


### PR DESCRIPTION
This  ought to fix https://github.com/axios/axios/issues/6137.

Added `handlers` property accessible via JavaScrip.