### PR TITLE
feat: add advanced timeout

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -311,6 +311,14 @@ export interface LookupAddressEntry {
 
 export type LookupAddress = string | LookupAddressEntry;
 
+type IEventSequence = ['socket', 'lookup', 'connect', 'response', 'end'];
+export type IAdvancedTimeout = {
+  startShot?: Exclude<IEventSequence[number], 'end'>;
+  timeout: number;
+  finishLine: Exclude<IEventSequence[number], IEventSequence[0]> | 'activity';
+  timeoutErrorMessage?: string;
+};
+
 export interface AxiosRequestConfig<D = any> {
   url?: string;
   method?: Method | string;
@@ -323,6 +331,7 @@ export interface AxiosRequestConfig<D = any> {
   data?: D;
   timeout?: Milliseconds;
   timeoutErrorMessage?: string;
+  advancedTimeout?: IAdvancedTimeout[];
   withCredentials?: boolean;
   adapter?: AxiosAdapterConfig | AxiosAdapterConfig[];
   auth?: AxiosBasicCredentials;

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -1,29 +1,29 @@
 'use strict';
 
-import utils from './../utils.js';
-import settle from './../core/settle.js';
-import buildFullPath from '../core/buildFullPath.js';
-import buildURL from './../helpers/buildURL.js';
-import {getProxyForUrl} from 'proxy-from-env';
+import EventEmitter from 'events';
+import followRedirects from 'follow-redirects';
 import http from 'http';
 import https from 'https';
-import util from 'util';
-import followRedirects from 'follow-redirects';
-import zlib from 'zlib';
-import {VERSION} from '../env/data.js';
-import transitionalDefaults from '../defaults/transitional.js';
-import AxiosError from '../core/AxiosError.js';
-import CanceledError from '../cancel/CanceledError.js';
-import platform from '../platform/index.js';
-import fromDataURI from '../helpers/fromDataURI.js';
+import { getProxyForUrl } from 'proxy-from-env';
 import stream from 'stream';
+import util from 'util';
+import zlib from 'zlib';
+import CanceledError from '../cancel/CanceledError.js';
+import AxiosError from '../core/AxiosError.js';
 import AxiosHeaders from '../core/AxiosHeaders.js';
+import buildFullPath from '../core/buildFullPath.js';
+import transitionalDefaults from '../defaults/transitional.js';
+import { VERSION } from '../env/data.js';
 import AxiosTransformStream from '../helpers/AxiosTransformStream.js';
-import EventEmitter from 'events';
-import formDataToStream from "../helpers/formDataToStream.js";
-import readBlob from "../helpers/readBlob.js";
 import ZlibHeaderTransformStream from '../helpers/ZlibHeaderTransformStream.js';
 import callbackify from "../helpers/callbackify.js";
+import formDataToStream from "../helpers/formDataToStream.js";
+import fromDataURI from '../helpers/fromDataURI.js';
+import readBlob from "../helpers/readBlob.js";
+import platform from '../platform/index.js';
+import settle from './../core/settle.js';
+import buildURL from './../helpers/buildURL.js';
+import utils from './../utils.js';
 
 const zlibOptions = {
   flush: zlib.constants.Z_SYNC_FLUSH,
@@ -447,6 +447,55 @@ export default isHttpAdapterSupported && function httpAdapter(config) {
       options.insecureHTTPParser = config.insecureHTTPParser;
     }
 
+    if (config.advancedTimeout) {
+      const rejectConfig = (msg) => {
+        reject(new AxiosError(msg, AxiosError.ERR_BAD_OPTION_VALUE, config));
+      }
+      if (!Array.isArray(config.advancedTimeout)) {
+        return rejectConfig('`advancedTimeout` must be an array');
+      }
+      const eventSequence = [
+        'socket',
+        'lookup',
+        'connect',
+        'response',
+        'activity',
+        'end',
+      ];
+      const errorMsg = config.advancedTimeout
+        .map((conf, idx) => {
+          const thisConf = `advancedTimeout[${idx}]`;
+          if (typeof conf !== 'object' || conf === null) {
+            return `\`${thisConf}\` must be a non-null object`;
+          }
+          const missingProp = ['timeout', 'finishLine'].find(prop => conf[prop] === undefined);
+          if (missingProp) {
+            return `\`${thisConf}.${missingProp}\` is required`;
+          }
+          if (typeof conf.timeout !== 'number' || conf.timeout <= 0 || Number.isNaN(conf.timeout)) {
+            return `\`${thisConf}.timeout\` must be a positive number`;
+          }
+          conf.startShot = conf.startShot || 'socket';
+          const invalidEventProp = ['startShot', 'finishLine'].find(
+            (prop) => eventSequence.indexOf(conf[prop]) === -1
+          );
+          if (invalidEventProp) {
+            return `\`${thisConf}.${invalidEventProp}\` must be a valid event`;
+          }
+          if (conf.startShot === 'activity') {
+            return `\`${thisConf}.startShot\` must not be 'activity'`;
+          }
+          if (
+            eventSequence.indexOf(conf.startShot) >=
+            eventSequence.indexOf(conf.finishLine)
+          ) {
+            return `\`${thisConf}.finishLine\` must occurs after \`${thisConf}.startShot\``;
+          }
+        })
+        .find((msg) => msg);
+      if (errorMsg) return rejectConfig(errorMsg);
+    }
+
     // Create the request
     req = transport.request(options, function handleResponse(res) {
       if (req.destroyed) return;
@@ -594,6 +643,11 @@ export default isHttpAdapterSupported && function httpAdapter(config) {
       });
     });
 
+    const abortRequest = (msg, code) => {
+      reject(new AxiosError(msg, code, config, req));
+      abort();
+    };
+
     emitter.once('abort', err => {
       reject(err);
       req.destroy(err);
@@ -610,6 +664,53 @@ export default isHttpAdapterSupported && function httpAdapter(config) {
     req.on('socket', function handleRequestSocket(socket) {
       // default interval of sending ack packet is 1 minute
       socket.setKeepAlive(true, 1000 * 60);
+      if (!config.advancedTimeout) return;
+      const transitional = config.transitional || transitionalDefaults;
+      const errCode = transitional.clarifyTimeoutError
+        ? AxiosError.ETIMEDOUT
+        : AxiosError.ECONNABORTED;
+      config.advancedTimeout.forEach((conf) => {
+        let toId;
+        let startShot = () => {
+          toId = setTimeout(() => {
+            toId = undefined;
+            const timeoutErrorMessage =
+              conf.timeoutErrorMessage ||
+              `Timeout between ${conf.startShot} and ${conf.finishLine} of ${conf.timeout}ms exceeded`;
+            abortRequest(timeoutErrorMessage, errCode);
+          }, conf.timeout);
+        };
+        const finishLine = () => {
+          toId && clearTimeout(toId);
+        }
+        switch (conf.finishLine) {
+          case 'activity':
+            startShot = () => {
+              socket.setTimeout(conf.timeout, () => {
+                const timeoutErrorMessage =
+                  conf.timeoutErrorMessage ||
+                  `Post-${conf.startShot} activity timeout of ${conf.timeout}ms exceeded`;
+                abortRequest(timeoutErrorMessage, errCode);
+              });
+            };
+            break;
+          case 'response':
+            req.once(conf.finishLine, finishLine);
+            break;
+          default:
+            socket.once(conf.finishLine, finishLine);
+        }
+        switch (conf.startShot) {
+          case 'socket':
+            startShot();
+            break;
+          case 'response':
+            req.once(conf.startShot, startShot);
+            break;
+          default:
+            socket.once(conf.startShot, startShot);
+        }
+      });
     });
 
     // Handle request timeout

--- a/lib/defaults/index.js
+++ b/lib/defaults/index.js
@@ -1,12 +1,12 @@
 'use strict';
 
-import utils from '../utils.js';
 import AxiosError from '../core/AxiosError.js';
-import transitionalDefaults from './transitional.js';
+import formDataToJSON from '../helpers/formDataToJSON.js';
 import toFormData from '../helpers/toFormData.js';
 import toURLEncodedForm from '../helpers/toURLEncodedForm.js';
 import platform from '../platform/index.js';
-import formDataToJSON from '../helpers/formDataToJSON.js';
+import utils from '../utils.js';
+import transitionalDefaults from './transitional.js';
 
 /**
  * It takes a string, tries to parse it, and if it fails, it returns the stringified version
@@ -128,6 +128,36 @@ const defaults = {
    * timeout is not created.
    */
   timeout: 0,
+
+  /** @typedef {'lookup'|'connect'|'response'} ITimeoutInbetweenEvents */
+  /** @typedef {'socket'|ITimeoutInbetweenEvents} ITimeoutStartShot */
+  /** @typedef {ITimeoutInbetweenEvents|'end'|'activity'} ITimeoutFinishLine */
+  /**
+   * @typedef IAdvancedTimeout
+   * @property {ITimeoutStartShot} [startShot='socket']
+   * @property {ITimeoutFinishLine} finishLine
+   * @property {number} timeout
+   * @property {string} [timeoutErrorMessage]
+   */
+  /** 
+   * @type {IAdvancedTimeout[]}
+   * @description Advanced timeouts to abort a request.
+   * 
+   * `startShot` event triggers the `timeout` (in milliseconds) for the occurrence of the `finishLine` event.
+   * `startShot` defaults to `'socket'`.
+   * `finishLine` event must occurs after the `startShot` one.
+   * 
+   * Possible events:
+   * - `'socket'`: Emitted by the `request` when a socket is assigned to the request.
+   * - `'lookup'`: Emitted by the `socket` after resolving the host name but before connecting. Not applicable to Unix sockets.
+   * - `'connect'`: Emitted by the `socket` when a socket connection is successfully established.
+   * - `'response'`: Emitted by the `request` upon receiving the first packet (response status and headers).
+   * - `'end'`: Emitted by the `socket` when the other end of the socket signals the end of transmission, thus ending the readable side of the socket.
+   * - `'activity'`: Corresponds to `socket.setTimeout(timeout)` upon the emission of `startShot`, so the timeout refreshes on each subsequent event until the end of the request.
+   * 
+   * Reach https://nodejs.org/api/net.html#class-netsocket and https://nodejs.org/api/http.html#class-httpclientrequest for more details.
+   */
+  advancedTimeout: [],
 
   xsrfCookieName: 'XSRF-TOKEN',
   xsrfHeaderName: 'X-XSRF-TOKEN',

--- a/test/unit/adapters/http.js
+++ b/test/unit/adapters/http.js
@@ -1,27 +1,28 @@
-import axios from '../../../index.js';
+import { AbortController } from 'abortcontroller-polyfill/dist/cjs-ponyfill.js';
+import assert from 'assert';
+import bodyParser from 'body-parser';
+import devNull from 'dev-null';
+import express from 'express';
+import FormDataLegacy from 'form-data';
+import { Blob as BlobPolyfill, File as FilePolyfill, FormData as FormDataPolyfill } from 'formdata-node';
+import formidable from 'formidable';
+import fs from 'fs';
 import http from 'http';
 import https from 'https';
-import net from 'net';
-import url from 'url';
-import zlib from 'zlib';
-import stream from 'stream';
-import util from 'util';
-import assert from 'assert';
-import fs from 'fs';
-import path from 'path';
-let server, proxy;
-import AxiosError from '../../../lib/core/AxiosError.js';
-import FormDataLegacy from 'form-data';
-import formidable from 'formidable';
-import express from 'express';
 import multer from 'multer';
-import bodyParser from 'body-parser';
+import net from 'net';
+import dns from 'node:dns';
+import path from 'path';
+import stream from 'stream';
+import { Throttle } from 'stream-throttle';
+import url from 'url';
+import util from 'util';
+import zlib from 'zlib';
+import axios from '../../../index.js';
+import { __setProxy } from "../../../lib/adapters/http.js";
+import AxiosError from '../../../lib/core/AxiosError.js';
+let server, proxy;
 const isBlobSupported = typeof Blob !== 'undefined';
-import {Throttle} from 'stream-throttle';
-import devNull from 'dev-null';
-import {AbortController} from 'abortcontroller-polyfill/dist/cjs-ponyfill.js';
-import {__setProxy} from "../../../lib/adapters/http.js";
-import {FormData as FormDataPolyfill, Blob as BlobPolyfill, File as FilePolyfill} from 'formdata-node';
 
 const FormDataSpecCompliant = typeof FormData !== 'undefined' ? FormData : FormDataPolyfill;
 const BlobSpecCompliant = typeof Blob !== 'undefined' ? Blob : BlobPolyfill;
@@ -269,6 +270,281 @@ describe('supports http with nodejs', function () {
         assert.strictEqual(error.message, 'oops, timeout');
         done();
       }, 300);
+    });
+  });
+
+  context('different test cases for advanced timeout configuration', () => {
+    const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+    const enumTestResult = {
+      SUCCEEDED: 'SUCCEEDED',
+      FAILED: 'FAILED',
+      PENDING: 'PENDING',
+    };
+    const isInProgress = function ({ testResult, error }) {
+      assert.equal(testResult, enumTestResult.PENDING, 'request should be in progress');
+      assert.equal(error, undefined);
+    };
+    const hasSucceeded = function ({ testResult, error, done }) {
+      assert.equal(testResult, enumTestResult.SUCCEEDED, 'request should succeed');
+      assert.equal(error, undefined);
+      done();
+    };
+    const hasFailed = function ({ testResult, error, done }, expectedError) {
+      assert.equal(testResult, enumTestResult.FAILED, 'request should fail');
+      for (const [key, expected] of Object.entries(expectedError)) {
+        try {
+          assert.equal(error[key], expected);
+        } catch (error) {
+          return done(error);
+        }
+      }
+      done();
+    };
+
+    const bufferTime = 4;
+    const timeSpan = {
+      roundTripTime: 3 * bufferTime,
+      serverProcessing: 3 * bufferTime,
+    };
+    const totalPackets = 4;
+    class EventSchedule {
+      static eventSequence = [
+        'socket',
+        'lookup',
+        'connect',
+        'response',
+        'end'
+      ];
+      static inbetweenIntervalTillEvent = {
+        'socket': 1,
+        'lookup': timeSpan.roundTripTime, // simulating connect time
+        'connect': 1,
+        'response': timeSpan.roundTripTime + timeSpan.serverProcessing,
+        'end': (totalPackets - 1) * timeSpan.roundTripTime
+      }
+      constructor() {
+        const { inbetweenIntervalTillEvent: intervalTill, eventSequence } = EventSchedule;
+        let lastEvent = 'request';
+        this[lastEvent] = Date.now();
+        eventSequence.forEach((event) => {
+          this[event] = this[lastEvent] + intervalTill[event];
+          lastEvent = event;
+        })
+      }
+    }
+    
+    const succeedValidator = (context) => {
+      const { end: endAt, request: requestAt } = context.schedule;
+      const requestLifeSpan = endAt - requestAt;
+      setTimeout(() => {
+        isInProgress(context);
+        setTimeout(() => hasSucceeded(context), 2 * bufferTime);
+      }, requestLifeSpan - bufferTime);
+    }
+    const failValidatorFactory = (timeoutRefPoint = undefined) =>
+      function failValidator(context) {
+        const { startShot = 'socket', timeout, finishLine, timeoutErrorMessage } = this.advancedTimeout[0];
+        timeoutRefPoint = timeoutRefPoint || startShot;
+        const { request: requestAt, [timeoutRefPoint]: timeoutRefPointAt } = context.schedule;
+        const requestLifeSpan = timeoutRefPointAt + timeout - requestAt;
+        const message =
+          timeoutErrorMessage ||
+          (finishLine === 'activity'
+            ? `Post-${startShot} activity timeout of ${timeout}ms exceeded`
+            : `Timeout between ${startShot} and ${finishLine} of ${timeout}ms exceeded`);
+        const expectedError = { code: 'ECONNABORTED', message };
+        setTimeout(() => {
+          isInProgress(context);
+          setTimeout(() => hasFailed(context, expectedError), 2 * bufferTime);
+        }, requestLifeSpan - bufferTime);
+      }
+
+    const scheduleAux = new EventSchedule();
+    const mountTestCases = (config) => {
+      const { startShot = 'socket', finishLine } = config;
+      const { [finishLine]: finishLineAt, [startShot]: startShotAt } = scheduleAux;
+      const raceInterval = finishLineAt - startShotAt;
+      const timeoutDesc = `timeout between ${startShot} and ${finishLine}`;
+      return [{
+        description: `should resolve a request when a ${timeoutDesc} is set and not exceeded`,
+        advancedTimeout: [{ ...config, timeout: raceInterval + bufferTime }],
+        validator: succeedValidator,
+      }, {
+        description: `should fail a request when a ${timeoutDesc} is set and exceeded`,
+        advancedTimeout: [{ ...config, timeout: raceInterval - bufferTime }],
+        validator: failValidatorFactory(),
+      }];
+    }
+    const mountActivityTestCases = (startShot = 'socket', timeoutCases) => {
+      const timeoutDesc = `post-${startShot} activity timeout`;
+      return timeoutCases.map(({ timeout, lastSignal }) => {
+        const advancedTimeout = [{ startShot, finishLine: 'activity', timeout }];
+        if (lastSignal) {
+          return {
+            description: `should fail a request when a ${timeoutDesc} is set and exceeded`,
+            advancedTimeout,
+            validator: failValidatorFactory(lastSignal),
+          };
+        }
+        return {
+          description: `should resolve a request when a ${timeoutDesc} is set and not exceeded`,
+          advancedTimeout,
+          validator: succeedValidator,
+        }
+      });
+    }
+
+    const { inbetweenIntervalTillEvent: intervalTill } = EventSchedule;
+    const testCaseList = [
+      ...EventSchedule.eventSequence.flatMap(
+        (startShot, idx, arr) => arr.slice(idx + 1).flatMap(
+          (finishLine) => mountTestCases({ startShot, finishLine })
+        )
+      ),
+      ...mountActivityTestCases('socket', [
+        { timeout: intervalTill.response + bufferTime },
+        { timeout: intervalTill.response - bufferTime, lastSignal: 'connect' },
+        { timeout: timeSpan.roundTripTime + bufferTime, lastSignal: 'connect' },
+        { timeout: timeSpan.roundTripTime - bufferTime, lastSignal: 'socket' },
+      ]),
+      ...mountActivityTestCases('connect', [
+        { timeout: intervalTill.response + bufferTime },
+        { timeout: intervalTill.response - bufferTime, lastSignal: 'connect' },
+        { timeout: timeSpan.roundTripTime + bufferTime, lastSignal: 'connect' },
+        { timeout: timeSpan.roundTripTime - bufferTime, lastSignal: 'connect' },
+      ]),
+      ...mountActivityTestCases('response', [
+        { timeout: intervalTill.response + bufferTime },
+        { timeout: intervalTill.response - bufferTime },
+        { timeout: timeSpan.roundTripTime + bufferTime },
+        { timeout: timeSpan.roundTripTime - bufferTime, lastSignal: 'response' },
+      ]),
+      {
+        description: `should fail due to timeout with a custom error message`,
+        advancedTimeout: [{ finishLine: 'response', timeout: 1, timeoutErrorMessage: 'foobar' }],
+        validator: failValidatorFactory(),
+      }
+    ]
+
+    testCaseList.forEach(testCase => {
+      const positiveTimeout = testCase.advancedTimeout[0].timeout > 0;
+      const maybeIt = positiveTimeout ? it : it.skip;
+      maybeIt(testCase.description, function (done) {
+        let schedule;
+        server = http.createServer(async function (req, res) {
+          await sleep(schedule.response - Date.now());
+          res.write('data');
+          for (let packets = 1; packets < totalPackets; ++packets) {
+            const latency = Math.round(
+              (schedule.end - Date.now()) /
+              (totalPackets - packets)
+            );
+            await sleep(latency);
+            res.write('data');
+          }
+          res.end();
+        }).listen(4444, function () {
+          const context = {
+            testResult: enumTestResult.PENDING,
+            error: undefined,
+            done,
+            schedule: (schedule = new EventSchedule()),
+          };
+          testCase.validator(context);
+          axios.get('http://localhost:4444/', {
+            advancedTimeout: testCase.advancedTimeout,
+            lookup: (...args) => {
+              setTimeout(() => dns.lookup(...args), schedule.lookup - Date.now());
+            },
+          }).then(function (res) {
+            context.testResult = enumTestResult.SUCCEEDED;
+          }).catch(function (err) {
+            context.testResult = enumTestResult.FAILED;
+            context.error = err;
+          });
+        });
+      });
+    });
+    
+    const validConfig = { finishLine: 'activity', timeout: 1000 };
+    const invalidConfigTestCaseList = [
+      {
+        description: 'should fail if `advancedTimeout` is not an array',
+        advancedTimeout: validConfig,
+        errorMessage: '`advancedTimeout` must be an array'
+      },
+      ...[null, validConfig.timeout].map(config => ({
+          description: `should fail if \`config\` is \`${config}\``,
+          advancedTimeout: [config],
+          errorMessage: '`advancedTimeout[0]` must be a non-null object'
+        })
+      ),
+      ...['timeout', 'finishLine'].map(requiredField => ({
+        description: `should fail if \`${requiredField}\` is missing`,
+        advancedTimeout: [{ ...validConfig, [requiredField]: undefined }],
+        errorMessage: `\`advancedTimeout[0].${requiredField}\` is required`
+      })),
+      ...[
+        { timeout: 'abc', isX: 'is not a number' },
+        { timeout: '123', isX: 'is not a strict number' },
+        { timeout: -123, isX: 'is not a positive number' },
+        { timeout: 0, isX: 'is zero' },
+        { timeout: NaN, isX: 'is NaN' }
+      ].map(({ timeout, isX }) => ({
+          description: `should fail if \`timeout\` ${isX}`,
+          advancedTimeout: [{ ...validConfig, timeout }],
+          errorMessage: '`advancedTimeout[0].timeout` must be a positive number'
+        })
+      ),
+      ...['startShot', 'finishLine'].map((eventField) => ({
+          description: `should fail if \`${eventField}\` is not a valid event`,
+          advancedTimeout: [{ ...validConfig, [eventField]: 'foobar' }],
+          errorMessage: `\`advancedTimeout[0].${eventField}\` must be a valid event`
+        })
+      ),
+      {
+        description: "should fail if `startShot` is 'activity'",
+        advancedTimeout: [{ ...validConfig, startShot: 'activity' }],
+        errorMessage: `\`advancedTimeout[0].startShot\` must not be 'activity'`
+      },
+      ...EventSchedule.eventSequence.flatMap((startShot, idx, arr) => {
+        const nonExhaustiveFinishEventList = idx === 0
+          ? [startShot]
+          : arr.slice(idx - 1, idx + 1);
+        return nonExhaustiveFinishEventList.map(finishLine => ({
+            description: `should fail for an incorrect event sequence from ${startShot} to ${finishLine}`,
+            advancedTimeout: [{ startShot, finishLine, timeout: 1000 }],
+            errorMessage: `\`advancedTimeout[0].finishLine\` must occurs after \`advancedTimeout[0].startShot\``,
+          })
+        );
+      }),
+    ];
+    invalidConfigTestCaseList.forEach(testCase => {
+      it(testCase.description, function (done) {
+        server = http.createServer(async function (req, res) {
+          res.end('data');
+        }).listen(4444, function () {
+          const context = {
+            testResult: enumTestResult.PENDING,
+            error: undefined,
+            done,
+          };
+          axios.get('http://localhost:4444/', {
+            advancedTimeout: testCase.advancedTimeout,
+          }).then(function (res) {
+            context.testResult = enumTestResult.SUCCEEDED;
+          }).catch(function (err) {
+            context.testResult = enumTestResult.FAILED;
+            context.error = err;
+          });
+          sleep(10).then(() => {
+            hasFailed(context, {
+              code: 'ERR_BAD_OPTION_VALUE',
+              message: testCase.errorMessage
+            })
+          })
+        });
+      });
     });
   });
 


### PR DESCRIPTION
Refs: #6156

It introduces functionality for advanced timeouts, enabling users to configure timeouts intervals between any supported events such as 'socket', 'lookup', 'connect', 'response', and 'end'.

Moreover, it offers the flexibility to set an activity timeout originating from any specified event. For instance, users can initiate activity measurement from the 'response' event, enabling monitoring of activity within the response data flow.