### PR TITLE
feat: make AxiosResponse implement the fetch Response API

### DIFF
--- a/index.d.cts
+++ b/index.d.cts
@@ -446,11 +446,8 @@ declare namespace axios {
     headers?: RawAxiosRequestHeaders | AxiosHeaders | Partial<HeadersDefaults>;
   }
 
-  interface AxiosResponse<T = any, D = any>  {
+  interface AxiosResponse<T = any, D = any> extends Response  {
     data: T;
-    status: number;
-    statusText: string;
-    headers: RawAxiosResponseHeaders | AxiosResponseHeaders;
     config: InternalAxiosRequestConfig<D>;
     request?: any;
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -387,11 +387,8 @@ export interface CreateAxiosDefaults<D = any> extends Omit<AxiosRequestConfig<D>
   headers?: RawAxiosRequestHeaders | AxiosHeaders | Partial<HeadersDefaults>;
 }
 
-export interface AxiosResponse<T = any, D = any> {
+export interface AxiosResponse<T = any, D = any> extends Response {
   data: T;
-  status: number;
-  statusText: string;
-  headers: RawAxiosResponseHeaders | AxiosResponseHeaders;
   config: InternalAxiosRequestConfig<D>;
   request?: any;
 }

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -13,6 +13,7 @@ import zlib from 'zlib';
 import {VERSION} from '../env/data.js';
 import transitionalDefaults from '../defaults/transitional.js';
 import AxiosError from '../core/AxiosError.js';
+import AxiosResponse from '../core/AxiosResponse.js';
 import CanceledError from '../cancel/CanceledError.js';
 import platform from '../platform/index.js';
 import fromDataURI from '../helpers/fromDataURI.js';
@@ -524,13 +525,13 @@ export default isHttpAdapterSupported && function httpAdapter(config) {
         onFinished();
       });
 
-      const response = {
+      const response = new AxiosResponse({
         status: res.statusCode,
         statusText: res.statusMessage,
         headers: new AxiosHeaders(res.headers),
         config,
         request: lastRequest
-      };
+      });
 
       if (responseType === 'stream') {
         response.data = responseStream;

--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -8,6 +8,7 @@ import buildFullPath from '../core/buildFullPath.js';
 import isURLSameOrigin from './../helpers/isURLSameOrigin.js';
 import transitionalDefaults from '../defaults/transitional.js';
 import AxiosError from '../core/AxiosError.js';
+import AxiosResponse from '../core/AxiosResponse.js';
 import CanceledError from '../cancel/CanceledError.js';
 import parseProtocol from '../helpers/parseProtocol.js';
 import platform from '../platform/index.js';
@@ -99,14 +100,14 @@ export default isXHRAdapterSupported && function (config) {
       );
       const responseData = !responseType || responseType === 'text' || responseType === 'json' ?
         request.responseText : request.response;
-      const response = {
+      const response = new AxiosResponse({
         data: responseData,
         status: request.status,
         statusText: request.statusText,
         headers: responseHeaders,
         config,
         request
-      };
+      });
 
       settle(function _resolve(value) {
         resolve(value);

--- a/lib/core/AxiosResponse.js
+++ b/lib/core/AxiosResponse.js
@@ -1,0 +1,85 @@
+class AxiosResponse {
+  #resp;
+
+  constructor(resp) {
+    this.#resp = resp;
+  }
+
+  get data() {
+    return this.#resp.data;
+  }
+
+  get config() {
+    return this.#resp.config;
+  }
+
+  get request() {
+    return this.#resp.request;
+  }
+
+  get headers() {
+    return new Headers(Object.entries(this.#resp.headers));
+  }
+
+  get ok() {
+    return this.#resp.status >= 200 && this.#resp.status < 300;
+  }
+
+  get redirected() {
+    return this.#resp.status >= 300 && this.#resp.status < 400;
+  }
+
+  get status() {
+    return this.#resp.status;
+  }
+
+  get statusText() {
+    return this.#resp.statusText;
+  }
+
+  get type() {
+    return 'basic';
+  }
+
+  get url() {
+    return this.#resp.config.url ?? this.#resp.request.responseURL;
+  }
+
+  get body() {
+    return this.#resp.data;
+  }
+
+  get bodyUsed() {
+    return false;
+  }
+
+  clone() {
+    return new AxiosResponse({ ...this.#resp });
+  }
+
+  async arrayBuffer() {
+    return new TextEncoder().encode(this.#resp.data).buffer;
+  }
+
+  async blob() {
+    return new Blob([this.#resp.data], { type: 'text/plain' });
+  }
+
+  async formData() {
+    throw new Error('formData is not supported by AxiosResponse');
+  }
+
+  async json() {
+    try {
+      return JSON.parse(this.#resp.data);
+    } catch (error) {
+      throw new Error('The data cannot be parsed as JSON');
+    }
+  }
+
+  async text() {
+    return this.#resp.data;
+  }
+}
+
+export default AxiosResponse;


### PR DESCRIPTION
Improve interoperability with tooling that wants native Fetch API Response objects, by implementing the Response interface.

In theory it's unlikely this will break runtime code. It _might_ break types in some projects because `headers` is now a native Headers object.

I also haven't tested this thoroughly. I mainly just want to push for this and prove that it's possible. It will help legacy codebases a lot.