### PR TITLE
docs: update README responseEncoding types

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,9 @@ These are the available config options for making requests. Only the `url` is re
 
   // `responseEncoding` indicates encoding to use for decoding responses (Node.js only)
   // Note: Ignored for `responseType` of 'stream' or client-side requests
+  // options are: 'ascii', 'ASCII', 'ansi', 'ANSI', 'binary', 'BINARY', 'base64', 'BASE64', 'base64url',
+  // 'BASE64URL', 'hex', 'HEX', 'latin1', 'LATIN1', 'ucs-2', 'UCS-2', 'ucs2', 'UCS2', 'utf-8', 'UTF-8',
+  // 'utf8', 'UTF8', 'utf16le', 'UTF16LE'
   responseEncoding: 'utf8', // default
 
   // `xsrfCookieName` is the name of the cookie to use as a value for xsrf token


### PR DESCRIPTION
📄 README.md didn't elaborate upon responseEncoding options- now it does.

#### Context
I found it frustrating the documentation didn't elaborate upon possible response encoding types.

I'm using axios to download jpg data; utf-8 isnt suitable, so I needed to know what else was available. 