### PR TITLE
Escape string type in union to preserve actual string values

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 // TypeScript Version: 4.7
-export type AxiosHeaderValue = AxiosHeaders | string | string[] | number | boolean | null;
+export type AxiosHeaderValue = AxiosHeaders | string & {} | string[] | number | boolean | null;
 
 interface RawAxiosHeaders {
   [key: string]: AxiosHeaderValue;
@@ -298,7 +298,7 @@ export interface AxiosProgressEvent {
 
 type Milliseconds = number;
 
-type AxiosAdapterName = 'xhr' | 'http' | string;
+type AxiosAdapterName = 'xhr' | 'http' | string  & {};
 
 type AxiosAdapterConfig = AxiosAdapter | AxiosAdapterName;
 
@@ -313,7 +313,7 @@ export type LookupAddress = string | LookupAddressEntry;
 
 export interface AxiosRequestConfig<D = any> {
   url?: string;
-  method?: Method | string;
+  method?: Method | string & {};
   baseURL?: string;
   transformRequest?: AxiosRequestTransformer | AxiosRequestTransformer[];
   transformResponse?: AxiosResponseTransformer | AxiosResponseTransformer[];
@@ -327,7 +327,7 @@ export interface AxiosRequestConfig<D = any> {
   adapter?: AxiosAdapterConfig | AxiosAdapterConfig[];
   auth?: AxiosBasicCredentials;
   responseType?: ResponseType;
-  responseEncoding?: responseEncoding | string;
+  responseEncoding?: responseEncoding | string & {};
   xsrfCookieName?: string;
   xsrfHeaderName?: string;
   onUploadProgress?: (progressEvent: AxiosProgressEvent) => void;


### PR DESCRIPTION
The string type found in the union is not coded properly. For example, the type `AxiosAdapterName` is currently declared as:

```ts
type AxiosAdapterName = 'xhr' | 'http' | string;
```

But the its final type is `string`. 

To retain the specific string values, a workaround is applied by modifying `string` to `string & {}`

```ts
type AxiosAdapterName = 'xhr' | 'http' | string & {};
```

Please check this [example](https://www.typescriptlang.org/play?ts=4.7.4#code/C4TwDgpgBAggHgSwPYGcYBMCGZgQE4BymAttALxQDkcAFnpVAD5U3DBgPMrB4IB2AcwDcAKAD0YqFIB6AfhEjQkWIlQZsuQiQgAmKBWp1OLNhyZRuvQVABkUAN4BfURKlQ5QA).

before:
![image](https://github.com/axios/axios/assets/69508345/17fad5db-4746-4a36-9d4a-4aea39a607a7)

after:
![image](https://github.com/axios/axios/assets/69508345/340f1725-de1c-4fde-b035-dba8dc4e2b10)
