### PR TITLE
fix: missing beforeRedirect requestDetails argument

### DIFF
--- a/index.d.cts
+++ b/index.d.cts
@@ -495,7 +495,8 @@ declare namespace axios {
     maxRate?: number | [MaxUploadRate, MaxDownloadRate];
     beforeRedirect?: (
       options: Record<string, any>,
-      responseDetails: { headers: Record<string, string>; statusCode: HttpStatusCode }
+      responseDetails: { headers: Record<string, string>; statusCode: HttpStatusCode },
+      requestDetails: { headers: Record<string, string>; url: string; method: string },
     ) => void;
     socketPath?: string | null;
     allowedSocketPaths?: string | string[] | null;

--- a/index.d.ts
+++ b/index.d.ts
@@ -394,7 +394,12 @@ export interface AxiosRequestConfig<D = any> {
     responseDetails: {
       headers: Record<string, string>;
       statusCode: HttpStatusCode;
-    }
+    },
+    requestDetails: {
+      headers: Record<string, string>;
+      url: string;
+      method: string;
+    },
   ) => void;
   socketPath?: string | null;
   allowedSocketPaths?: string | string[] | null;

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -176,12 +176,12 @@ const http2Sessions = new Http2Sessions();
  *
  * @returns {Object<string, any>}
  */
-function dispatchBeforeRedirect(options, responseDetails) {
+function dispatchBeforeRedirect(options, responseDetails, requestDetails) {
   if (options.beforeRedirects.proxy) {
     options.beforeRedirects.proxy(options);
   }
   if (options.beforeRedirects.config) {
-    options.beforeRedirects.config(options, responseDetails);
+    options.beforeRedirects.config(options, responseDetails, requestDetails);
   }
 }
 

--- a/tests/unit/adapters/http.test.js
+++ b/tests/unit/adapters/http.test.js
@@ -385,6 +385,37 @@ describe('supports http with nodejs', () => {
     }
   });
 
+  it('should pass requestDetails to beforeRedirect with the original URL', async () => {
+    const server = await startHTTPServer(
+      (req, res) => {
+        res.setHeader('Location', '/foo');
+        res.statusCode = 302;
+        res.end();
+      },
+      { port: SERVER_PORT }
+    );
+
+    const originalUrl = `http://localhost:${server.address().port}/bar`;
+    let capturedUrl;
+
+    try {
+      await axios.get(originalUrl, {
+        maxRedirects: 3,
+        beforeRedirect: (options, responseDetails, requestDetails) => {
+          if (options.path === '/foo' && responseDetails.headers.location === '/foo') {
+            capturedUrl = requestDetails.url;
+            throw new Error('Provided path is not allowed');
+          }
+        },
+      });
+    } catch (error) {
+      assert.strictEqual(error.message, 'Redirected request failed: Provided path is not allowed');
+      assert.strictEqual(capturedUrl, originalUrl);
+    } finally {
+      await stopHTTPServer(server);
+    }
+  });
+
   it('should support beforeRedirect and proxy with redirect', async () => {
     let requestCount = 0;
     let proxyUseCount = 0;


### PR DESCRIPTION
When attempting to upgrade from `v0.27.2` to `v1.67.0` we found that Axios is no longer passing through the third `requestDetails` argument to the `beforeRedirect(…)` function.

This contains the request’s original method, URL, and headers prior to the redirect.

This PR adds this argument back in.

Fixes #6442