### PR TITLE
Fix variable naming conflict in server script

### DIFF
--- a/examples/server.js
+++ b/examples/server.js
@@ -79,7 +79,7 @@ function pipeFileToResponse(res, file, type) {
 dirs = listDirs(__dirname);
 
 server = http.createServer(function (req, res) {
-  let url = req.url;
+  let reqUrl = req.url;
 
   // Process axios itself
   if (/axios\.min\.js$/.test(url)) {
@@ -127,8 +127,8 @@ server = http.createServer(function (req, res) {
 
   // Process server request
   else if (new RegExp('(' + dirs.join('|') + ')\/server').test(url)) {
-    if (fs.existsSync(path.join(__dirname, url + '.js'))) {
-      require(path.join(__dirname, url + '.js'))(req, res);
+    if (fs.existsSync(path.join(__dirname, reqUrl + '.js'))) {
+      require(path.join(__dirname, reqUrl + '.js'))(req, res);
     } else {
       send404(res);
     }


### PR DESCRIPTION
Renamed the variable 'url' used for constructing URLs to 'reqUrl' to avoid conflict with the variable representing the incoming request URL. This change ensures clarity and prevents potential bugs.

<!-- Click "Preview" for a more readable version -->

#### Instructions

Please read and follow the instructions before creating and submitting a pull request:

- Create an issue explaining the feature. It could save you some effort in case we don't consider it should be included in axios.
- If you're fixing a bug, try to commit the failing test/s and the code fixing it in different commits.
- Ensure you're following our [contributing guide](https://github.com/axios/axios/blob/master/CONTRIBUTING.md).

**⚠️👆 Delete the instructions before submitting the pull request 👆⚠️**

Describe your pull request here.
