### PR TITLE
backport: custom params serializer support for v0.x

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -128,6 +128,7 @@ export interface CustomParamsSerializer {
 
 export interface ParamsSerializerOptions extends SerializerOptions {
   encode?: ParamEncoder;
+  serialize?: CustomParamsSerializer;
 }
 
 export interface AxiosRequestConfig<D = any> {

--- a/lib/core/Axios.js
+++ b/lib/core/Axios.js
@@ -61,6 +61,13 @@ Axios.prototype.request = function request(configOrUrl, config) {
 
   var paramsSerializer = config.paramsSerializer;
 
+  if (paramsSerializer !== undefined) {
+    validator.assertOptions(paramsSerializer, {
+      encode: validators.function,
+      serialize: validators.function
+    }, true);
+  }
+
   utils.isFunction(paramsSerializer) && (config.paramsSerializer = {serialize: paramsSerializer});
 
   // filter out skipped interceptors

--- a/lib/helpers/buildURL.js
+++ b/lib/helpers/buildURL.js
@@ -35,12 +35,20 @@ module.exports = function buildURL(url, params, options) {
 
   var _encode = options && options.encode || encode;
 
-  var serializerParams = utils.isURLSearchParams(params) ?
-    params.toString() :
-    new AxiosURLSearchParams(params, options).toString(_encode);
+  var serializeFn = options && options.serialize;
 
-  if (serializerParams) {
-    url += (url.indexOf('?') === -1 ? '?' : '&') + serializerParams;
+  var serializedParams;
+
+  if (serializeFn) {
+    serializedParams = serializeFn(params, options);
+  } else {
+    serializedParams = utils.isURLSearchParams(params) ?
+      params.toString() :
+      new AxiosURLSearchParams(params, options).toString(_encode);
+  }
+
+  if (serializedParams) {
+    url += (url.indexOf('?') === -1 ? '?' : '&') + serializedParams;
   }
 
   return url;

--- a/test/specs/helpers/buildURL.spec.js
+++ b/test/specs/helpers/buildURL.spec.js
@@ -63,4 +63,20 @@ describe('helpers::buildURL', function () {
   it('should support URLSearchParams', function () {
     expect(buildURL('/foo', new URLSearchParams('bar=baz'))).toEqual('/foo?bar=baz');
   });
+
+  it('should support custom serialize function', function () {
+    var params = {
+      x: 1
+    }
+
+    var options = {
+      serialize: (thisParams, thisOptions) => {
+        expect(thisParams).toEqual(params);
+        expect(thisOptions).toEqual(options);
+        return 'rendered'
+      }
+    };
+
+    expect(buildURL('/foo', params, options)).toEqual('/foo?rendered');
+  });
 });

--- a/test/specs/helpers/buildURL.spec.js
+++ b/test/specs/helpers/buildURL.spec.js
@@ -67,13 +67,13 @@ describe('helpers::buildURL', function () {
   it('should support custom serialize function', function () {
     var params = {
       x: 1
-    }
+    };
 
     var options = {
-      serialize: (thisParams, thisOptions) => {
+      serialize: function (thisParams, thisOptions) {
         expect(thisParams).toEqual(params);
         expect(thisOptions).toEqual(options);
-        return 'rendered'
+        return 'rendered';
       }
     };
 

--- a/test/typescript/axios.ts
+++ b/test/typescript/axios.ts
@@ -22,7 +22,8 @@ const config: AxiosRequestConfig = {
   params: { id: 12345 },
   paramsSerializer: {
     indexes: true,
-    encode: (value) => value
+    encode: (value) => value,
+    serialize: (value, options) => String(value)
   },
   data: { foo: 'bar' },
   timeout: 10000,


### PR DESCRIPTION
Resolves #6262

This will add similar support to #5113 (`paramsSerializer: { serializer? }` or `paramsSerializer(params) { .. }`) which was missing in v0.x.

Was hoping if this could be released as a patch for v0.28.x