### PR TITLE
evade override mistake

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -342,9 +342,9 @@ function merge(/* obj1, obj2, obj3, ... */) {
 const extend = (a, b, thisArg, {allOwnKeys}= {}) => {
   forEach(b, (val, key) => {
     if (thisArg && isFunction(val)) {
-      a[key] = bind(val, thisArg);
+      Object.defineProperty(a, key, {value: bind(val, thisArg)});
     } else {
-      a[key] = val;
+      Object.defineProperty(a, key, {value: val});
     }
   }, {allOwnKeys});
   return a;
@@ -375,7 +375,9 @@ const stripBOM = (content) => {
  */
 const inherits = (constructor, superConstructor, props, descriptors) => {
   constructor.prototype = Object.create(superConstructor.prototype, descriptors);
-  constructor.prototype.constructor = constructor;
+  Object.defineProperty(constructor.prototype, 'constructor', {
+    value: constructor
+  });
   Object.defineProperty(constructor, 'super', {
     value: superConstructor.prototype
   });
@@ -537,12 +539,14 @@ const isRegExp = kindOfTest('RegExp');
 
 const reduceDescriptors = (obj, reducer) => {
   const descriptors = Object.getOwnPropertyDescriptors(obj);
-  const reducedDescriptors = {};
+  let reducedDescriptors = {};
 
   forEach(descriptors, (descriptor, name) => {
     let ret;
     if ((ret = reducer(descriptor, name, obj)) !== false) {
-      reducedDescriptors[name] = ret || descriptor;
+      reducedDescriptors = {...reducedDescriptors, 
+        [name]: ret || descriptor
+      };
     }
   });
 


### PR DESCRIPTION
fixes: #6264 

The original code used assignment to override the constructor property. However, if the prototype is frozen, as it is under Hardened JS (aka SES) or under the Node frozen intrinsics flag, then this assignment fails due to the JavaScript [override mistake](https://github.com/tc39/how-we-work/blob/main/terminology.md#override-mistake).