### PR TITLE
fix(interceptor): handle the error in the same interceptor

### DIFF
--- a/lib/core/Axios.js
+++ b/lib/core/Axios.js
@@ -143,7 +143,7 @@ class Axios {
       promise = Promise.resolve(config);
 
       while (i < len) {
-        promise = promise.then(chain[i++], chain[i++]);
+        promise = promise.then(chain[i++]).catch(chain[i++]);
       }
 
       return promise;
@@ -176,7 +176,7 @@ class Axios {
     len = responseInterceptorChain.length;
 
     while (i < len) {
-      promise = promise.then(responseInterceptorChain[i++], responseInterceptorChain[i++]);
+      promise = promise.then(responseInterceptorChain[i++]).catch(responseInterceptorChain[i++]);
     }
 
     return promise;

--- a/test/specs/interceptors.spec.js
+++ b/test/specs/interceptors.spec.js
@@ -599,4 +599,54 @@ describe('interceptors', function () {
 
     expect(instance.interceptors.response.handlers.length).toBe(0);
   });
+
+  it('should handler the error in the same request interceptors', function (done) {
+    const rejectedSpy1 = jasmine.createSpy('rejectedSpy1');
+    const rejectedSpy2 = jasmine.createSpy('rejectedSpy2');
+    const error1 = new Error('deadly error 1');
+    const error2 = new Error('deadly error 2');
+    axios.interceptors.request.use(function () {
+      throw error1;
+    }, rejectedSpy1);
+
+    axios.interceptors.request.use(function () {
+      throw error2;
+    }, rejectedSpy2);
+
+    axios('/foo').finally(function () {
+      expect(rejectedSpy1).toHaveBeenCalledWith(error1);
+      expect(rejectedSpy2).toHaveBeenCalledWith(error2);
+      done();
+    });
+  });
+
+  it('should handler the error in the same response interceptors', function (done) {
+    const rejectedSpy1 = jasmine.createSpy('rejectedSpy1');
+    const rejectedSpy2 = jasmine.createSpy('rejectedSpy2');
+    const error1 = new Error('deadly error 1');
+    const error2 = new Error('deadly error 2');
+    axios.interceptors.response.use(function () {
+      throw error1;
+    }, rejectedSpy1);
+
+    axios.interceptors.response.use(function () {
+      throw error2;
+    }, rejectedSpy2);
+
+    axios('/foo');
+
+
+    getAjaxRequest().then(function (request) {
+      request.respondWith({
+        status: 200,
+        responseText: 'OK'
+      });
+
+      setTimeout(function () {
+        expect(rejectedSpy1).toHaveBeenCalledWith(error1);
+        expect(rejectedSpy2).toHaveBeenCalledWith(error2);
+        done();
+      }, 100);
+    });
+  });
 });


### PR DESCRIPTION
fixes: #4537 

When handling error in asynchronous request interceptors,  `onRejected` always handle the error in the next interceptors. So I make a fix about this case. Detail context is in the issue.

During the fix, I found that it will cause a TypeError when an error occurred in the request interceptors, because the config is lost during the promise chain. 

```
TypeError: Cannot read properties of undefined (reading 'cancelToken')
```

So we can define the `onRejected` handler behavior. If users want to continue the request, they should return a default config in the `onRejected` function.