### PR TITLE
fix(types): add missing type and its document

### DIFF
--- a/README.md
+++ b/README.md
@@ -788,6 +788,13 @@ axios.interceptors.request.use(function (config) {
 }, null, { synchronous: true });
 ```
 
+You can iterate over all the registered interceptors.
+
+```js
+axios.interceptors.request.use(function () {/*...*/})
+axios.interceptors.request.forEach(function ({ fulfilled, rejected, synchronous, runWhen }) {/*...*/})
+```
+
 If you want to execute a particular interceptor based on a runtime check,
 you can add a `runWhen` function to the options object. The interceptor will not be executed **if and only if** the return
 of `runWhen` is `false`. The function will be called with the config

--- a/index.d.cts
+++ b/index.d.cts
@@ -490,10 +490,18 @@ declare namespace axios {
     runWhen?: (config: InternalAxiosRequestConfig) => boolean;
   }
 
+  interface AxiosInterceptorHandler<V> {
+    fulfilled?: (value: V) => V | Promise<V>;
+    rejected?: (error: any) => any;
+    synchronous: boolean;
+    runWhen: ((config: InternalAxiosRequestConfig) => boolean) | null;
+  }
+
   interface AxiosInterceptorManager<V> {
     use(onFulfilled?: (value: V) => V | Promise<V>, onRejected?: (error: any) => any, options?: AxiosInterceptorOptions): number;
     eject(id: number): void;
     clear(): void;
+    forEach(callback: (handler: AxiosInterceptorHandler<V>) => void): void;
   }
 
   interface AxiosInstance extends Axios {

--- a/index.d.ts
+++ b/index.d.ts
@@ -473,10 +473,18 @@ export interface AxiosInterceptorOptions {
   runWhen?: (config: InternalAxiosRequestConfig) => boolean;
 }
 
+export interface AxiosInterceptorHandler<V> {
+  fulfilled?: (value: V) => V | Promise<V>;
+  rejected?: (error: any) => any;
+  synchronous: boolean;
+  runWhen: ((config: InternalAxiosRequestConfig) => boolean) | null;
+}
+
 export interface AxiosInterceptorManager<V> {
   use(onFulfilled?: ((value: V) => V | Promise<V>) | null, onRejected?: ((error: any) => any) | null, options?: AxiosInterceptorOptions): number;
   eject(id: number): void;
   clear(): void;
+  forEach(callback: (handler: AxiosInterceptorHandler<V>) => void): void;
 }
 
 export class Axios {


### PR DESCRIPTION
AxiosInterceptorManager has a `forEach` method, but there is neither in the .d.ts file, nor in the document. So that I add its type definition in the .d.ts file, and the introduction in README.md.

The source code is right here: 

https://github.com/axios/axios/blob/d844227411263fab39d447442879112f8b0c8de5/lib/core/InterceptorManager.js#L62-L68