### PR TITLE
Corrected the import of EventEmittor

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -19,7 +19,7 @@ import fromDataURI from '../helpers/fromDataURI.js';
 import stream from 'stream';
 import AxiosHeaders from '../core/AxiosHeaders.js';
 import AxiosTransformStream from '../helpers/AxiosTransformStream.js';
-import EventEmitter from 'events';
+import {EventEmitter} from 'events';
 import formDataToStream from "../helpers/formDataToStream.js";
 import readBlob from "../helpers/readBlob.js";
 import ZlibHeaderTransformStream from '../helpers/ZlibHeaderTransformStream.js';


### PR DESCRIPTION
This PR resolves the issue https://github.com/axios/axios/issues/6225

In this PR, i corrected the way we import EventEmitter

after migrating from common.js to ES6 there was a typo 
`import  EventEmitter  from 'events';`

Instead the corrected code should be
`import  {EventEmitter}  from 'events';`