### PR TITLE
fix(backport): handle custom param serializer fn

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -128,6 +128,7 @@ export interface CustomParamsSerializer {
 
 export interface ParamsSerializerOptions extends SerializerOptions {
   encode?: ParamEncoder;
+  serialize?: CustomParamsSerializer
 }
 
 export interface AxiosRequestConfig<D = any> {

--- a/lib/core/Axios.js
+++ b/lib/core/Axios.js
@@ -61,6 +61,23 @@ Axios.prototype.request = function request(configOrUrl, config) {
 
   var paramsSerializer = config.paramsSerializer;
 
+  if (paramsSerializer != null) {
+    if (utils.isFunction(paramsSerializer)) {
+      config.paramsSerializer = {
+        serialize: paramsSerializer
+      };
+    } else {
+      validator.assertOptions(
+        paramsSerializer,
+        {
+          encode: validators.function,
+          serialize: validators.function
+        },
+        true
+      );
+    }
+  }
+
   utils.isFunction(paramsSerializer) && (config.paramsSerializer = {serialize: paramsSerializer});
 
   // filter out skipped interceptors

--- a/lib/helpers/buildURL.js
+++ b/lib/helpers/buildURL.js
@@ -27,20 +27,28 @@ module.exports = function buildURL(url, params, options) {
     return url;
   }
 
-  var hashmarkIndex = url.indexOf('#');
-
-  if (hashmarkIndex !== -1) {
-    url = url.slice(0, hashmarkIndex);
-  }
-
   var _encode = options && options.encode || encode;
 
-  var serializerParams = utils.isURLSearchParams(params) ?
-    params.toString() :
-    new AxiosURLSearchParams(params, options).toString(_encode);
+  var serializeFn = options && options.serialize;
 
-  if (serializerParams) {
-    url += (url.indexOf('?') === -1 ? '?' : '&') + serializerParams;
+  var serializedParams;
+
+  if (serializeFn) {
+    serializedParams = serializeFn(params, options);
+  } else {
+    serializedParams = utils.isURLSearchParams(params) ?
+      params.toString() :
+      new AxiosURLSearchParams(params, options).toString(_encode);
+  }
+
+  if (serializedParams) {
+    var hashmarkIndex = url.indexOf('#');
+
+    if (hashmarkIndex !== -1) {
+      url = url.slice(0, hashmarkIndex);
+    }
+
+    url += (url.indexOf('?') === -1 ? '?' : '&') + serializedParams;
   }
 
   return url;

--- a/test/specs/helpers/buildURL.spec.js
+++ b/test/specs/helpers/buildURL.spec.js
@@ -63,4 +63,20 @@ describe('helpers::buildURL', function () {
   it('should support URLSearchParams', function () {
     expect(buildURL('/foo', new URLSearchParams('bar=baz'))).toEqual('/foo?bar=baz');
   });
+
+  it('should support custom serialize function', function () {
+    var params = {
+      x: 1
+    }
+
+    var options = {
+      serialize: function (thisParams, thisOptions) {
+        expect(thisParams).toEqual(params);
+        expect(thisOptions).toEqual(options);
+        return "rendered"
+      }
+    };
+
+    expect(buildURL('/foo', params, options)).toEqual('/foo?rendered');
+  });
 });

--- a/test/typescript/axios.ts
+++ b/test/typescript/axios.ts
@@ -22,7 +22,8 @@ const config: AxiosRequestConfig = {
   params: { id: 12345 },
   paramsSerializer: {
     indexes: true,
-    encode: (value) => value
+    encode: (value) => value,
+    serialize: (value, options) => String(value)
   },
   data: { foo: 'bar' },
   timeout: 10000,


### PR DESCRIPTION
Resolves issues #6274 and #6262.

Changes:

- Re-added the custom param serializer function and fully handled its functionality.
- Enabled the ability to pass both `encode` and `serialize` options in the `paramsSerialize` configuration parameter.

To ensure ease of maintenance, the implementation mirrors the one in v1.6.7 (latest version). 
