### PR TITLE
fix(backport): Uncaught ReferenceError req is not defined at AbortSig…

### DIFF
--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -196,7 +196,7 @@ module.exports = function xhrAdapter(config) {
         if (!request) {
           return;
         }
-        reject(!cancel || cancel.type ? new CanceledError(null, config, req) : cancel);
+        reject(!cancel || cancel.type ? new CanceledError(null, config, request) : cancel);
         request.abort();
         request = null;
       };


### PR DESCRIPTION
Resolves issue #6301.

The veriable name used to be ```req```. This is a mistake and caused a Uncaught ReferenceError. So I have fixed it by replacing the name with the correct one, ```request```.

This is already fixed in v1.6.8 (latest version), so I have brought the fix to this branch.