### PR TITLE
fix(require): use require in the ES6 module

### DIFF
--- a/examples/server.js
+++ b/examples/server.js
@@ -127,8 +127,11 @@ server = http.createServer(function (req, res) {
 
   // Process server request
   else if (new RegExp('(' + dirs.join('|') + ')\/server').test(url)) {
-    if (fs.existsSync(path.join(__dirname, url + '.js'))) {
-      require(path.join(__dirname, url + '.js'))(req, res);
+    const filePath = path.join(__dirname, url + '.js')
+    if (fs.existsSync(filePath)) {
+      import(filePath).then((module) => {
+        module.default(req, res)
+      })
     } else {
       send404(res);
     }


### PR DESCRIPTION
## Fixing bug with examples

In the ES6 module `examples/server.js` `require` (CommonJS syntax) was called.
Needs to be replaced with `import`.

### Steps to reproduce:
- Run examples script `npm run examples`
- In the web browser navigate to http://localhost:3000/get
- Server will crash with error `require is not defined`

There were no tests for examples, so, no changes in tests