### PR TITLE
fix: Unclear error message is thrown when specifying an empty proxy authorization

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -89,11 +89,13 @@ function setProxy(options, configProxy, location) {
       // Support proxy auth object form
       if (proxy.auth.username || proxy.auth.password) {
         proxy.auth = (proxy.auth.username || '') + ':' + (proxy.auth.password || '');
+
+        const base64 = Buffer.from(proxy.auth, 'utf8').toString('base64');
+  
+        options.headers['Proxy-Authorization'] = 'Basic ' + base64;
+      } else {
+        throw new AxiosError('Invalid proxy authorization', AxiosError.ERR_BAD_OPTION, { proxy });
       }
-      const base64 = Buffer
-        .from(proxy.auth, 'utf8')
-        .toString('base64');
-      options.headers['Proxy-Authorization'] = 'Basic ' + base64;
     }
 
     options.headers.host = options.hostname + (options.port ? ':' + options.port : '');

--- a/test/unit/adapters/http.js
+++ b/test/unit/adapters/http.js
@@ -1401,6 +1401,29 @@ describe('supports http with nodejs', function () {
     });
   });
 
+  describe('when invalid proxy options are provided', function () {
+    it('should throw error', function () {
+      const proxy = {
+        protocol: "http:",
+        host: "hostname.abc.xyz",
+        port: 3300,
+        auth: {
+          username: "",
+          password: "",
+        }
+      };
+
+      return axios.get("https://test-domain.abc", {proxy})
+        .then(function(){
+          fail('Does not throw');
+        }, function (error) {          
+          assert.strictEqual(error.message, 'Invalid proxy authorization')
+          assert.strictEqual(error.code, 'ERR_BAD_OPTION')
+          assert.deepStrictEqual(error.config.proxy, proxy)
+        })
+    });
+  });
+
   context('different options for direct proxy configuration (without env variables)', () => {
     const destination = 'www.example.com';
 


### PR DESCRIPTION
<!-- Click "Preview" for a more readable version -->

Solves issue: #5614

Add `AxiosError` to solve unclear error message thrown when specified an empty proxy authorization

PS.: Do you think that would be good to use the `validator` instead? And add a flag that indicates that `axios` could suppress the error 
