### PR TITLE
style: get rid of redundency in imports

### DIFF
--- a/lib/adapters/README.md
+++ b/lib/adapters/README.md
@@ -5,7 +5,7 @@ The modules under `adapters/` are modules that handle dispatching a request and 
 ## Example
 
 ```js
-var settle = require('./../core/settle');
+var settle = require('../core/settle');
 
 module.exports = function myAdapter(config) {
   // At this point:

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -1,9 +1,9 @@
 'use strict';
 
-import utils from './../utils.js';
-import settle from './../core/settle.js';
+import utils from '../utils.js';
+import settle from '../core/settle.js';
 import buildFullPath from '../core/buildFullPath.js';
-import buildURL from './../helpers/buildURL.js';
+import buildURL from '../helpers/buildURL.js';
 import {getProxyForUrl} from 'proxy-from-env';
 import http from 'http';
 import https from 'https';

--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -1,11 +1,11 @@
 'use strict';
 
-import utils from './../utils.js';
-import settle from './../core/settle.js';
-import cookies from './../helpers/cookies.js';
-import buildURL from './../helpers/buildURL.js';
+import utils from '../utils.js';
+import settle from '../core/settle.js';
+import cookies from '../helpers/cookies.js';
+import buildURL from '../helpers/buildURL.js';
 import buildFullPath from '../core/buildFullPath.js';
-import isURLSameOrigin from './../helpers/isURLSameOrigin.js';
+import isURLSameOrigin from '../helpers/isURLSameOrigin.js';
 import transitionalDefaults from '../defaults/transitional.js';
 import AxiosError from '../core/AxiosError.js';
 import CanceledError from '../cancel/CanceledError.js';

--- a/lib/core/Axios.js
+++ b/lib/core/Axios.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import utils from './../utils.js';
+import utils from '../utils.js';
 import buildURL from '../helpers/buildURL.js';
 import InterceptorManager from './InterceptorManager.js';
 import dispatchRequest from './dispatchRequest.js';

--- a/lib/core/InterceptorManager.js
+++ b/lib/core/InterceptorManager.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import utils from './../utils.js';
+import utils from '../utils.js';
 
 class InterceptorManager {
   constructor() {

--- a/lib/core/transformData.js
+++ b/lib/core/transformData.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import utils from './../utils.js';
+import utils from '../utils.js';
 import defaults from '../defaults/index.js';
 import AxiosHeaders from '../core/AxiosHeaders.js';
 

--- a/lib/helpers/cookies.js
+++ b/lib/helpers/cookies.js
@@ -1,4 +1,4 @@
-import utils from './../utils.js';
+import utils from '../utils.js';
 import platform from '../platform/index.js';
 
 export default platform.hasStandardBrowserEnv ?

--- a/lib/helpers/isAxiosError.js
+++ b/lib/helpers/isAxiosError.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import utils from './../utils.js';
+import utils from '../utils.js';
 
 /**
  * Determines whether the payload is an error thrown by Axios

--- a/lib/helpers/isURLSameOrigin.js
+++ b/lib/helpers/isURLSameOrigin.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import utils from './../utils.js';
+import utils from '../utils.js';
 import platform from '../platform/index.js';
 
 export default platform.hasStandardBrowserEnv ?

--- a/lib/helpers/parseHeaders.js
+++ b/lib/helpers/parseHeaders.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import utils from './../utils.js';
+import utils from '../utils.js';
 
 // RawAxiosHeaders whose duplicates are ignored by node
 // c.f. https://nodejs.org/api/http.html#http_message_headers


### PR DESCRIPTION
### Discription
Some imports have "./../" before them. The "./" is redundent and does not follow the [node style guide](https://github.com/felixge/node-style-guide). This is most likely left over when someone was moving around files. I have formatted all the imports.

### Example:
Old:
```node
import utils from './../utils.js';
```
New:
```node
import utils from '../utils.js';
```