### PR TITLE
fix: regression which broke auto-destroying http requests

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -453,7 +453,7 @@ export default isHttpAdapterSupported && function httpAdapter(config) {
 
     // Create the request
     req = transport.request(options, function handleResponse(res) {
-      if (req.destroyed) return;
+      if (req.aborted) return;
 
       const streams = [res];
 


### PR DESCRIPTION
Hello!

It appears that the `node:http` implementation in Bun [sets `autoDestroy: true` on requests](https://github.com/oven-sh/bun/blob/73a55cf07555680fff022231341bf7b358be17b0/src/js/node/stream.js#L3511) whereas it looks like in Node [`autoDestroy` is set to `false` by default](https://github.com/nodejs/node/blob/6d2d3f17ba96353ea76147d95b6106bc4ff587d4/lib/internal/http2/core.js#L1981).

This means that in Bun, the `if (req.destroyed)` check in axios was always being hit.

The observed behavior was that the `axios(...)` promise was never resolving _or_ throwing an exception.

This looks like a regression introduced in #4787. Axios used to check `req.aborted` rather than `req.destroyed`, which fixes this bug.

Thanks!