### PR TITLE
style: turn '()=>' into '() =>'

### DIFF
--- a/bin/contributors.js
+++ b/bin/contributors.js
@@ -194,7 +194,7 @@ const renderPRsList = async (tag, template, {comments_threshold= 5, awesome_thre
   for(const merge of release.merges) {
     const pr = await getIssueById(merge.id);
 
-    if (pr && pr.labels.find(({name})=> name === label)) {
+    if (pr && pr.labels.find(({name}) => name === label)) {
       const {reactions, body} = pr;
       prs[pr.number] = pr;
       pr.isHot = pr.comments > comments_threshold;

--- a/bin/helpers/colorize.js
+++ b/bin/helpers/colorize.js
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 
-export const colorize = (...colors)=> {
+export const colorize = (...colors) => {
   if(!colors.length) {
     colors = ['green', 'cyan', 'magenta', 'blue', 'yellow', 'red'];
   }

--- a/bin/pr.js
+++ b/bin/pr.js
@@ -61,7 +61,7 @@ const generateBody = async ({files, template = './templates/pr.hbs'} = {}) => {
     files: await generateFileReport(files)
   };
 
-  Handlebars.registerHelper('filesize', (bytes)=> prettyBytes(bytes));
+  Handlebars.registerHelper('filesize', (bytes) => prettyBytes(bytes));
 
   return Handlebars.compile(String(await fs.readFile(template)))(data);
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -40,7 +40,7 @@ async function getContributors(user, repo, maxCount = 1) {
     { params: { per_page: maxCount } }
   )).data;
 
-  return Promise.all(contributors.map(async (contributor)=> {
+  return Promise.all(contributors.map(async (contributor) => {
     return {...contributor, ...(await axios.get(
       `https://api.github.com/users/${encodeURIComponent(contributor.login)}`
     )).data};

--- a/test/module/test.js
+++ b/test/module/test.js
@@ -44,7 +44,7 @@ const remove = async (file) => {
 
 describe('module', function () {
 
-  before(async ()=> {
+  before(async () => {
     console.log('✓ Creating build backup...');
     await fs.copy('./dist/', BACKUP_PATH);
     console.log('✓ Exec build script...');
@@ -149,10 +149,10 @@ describe('module', function () {
   });
 
   describe('typings', () => {
-    describe('ESM', ()=> {
+    describe('ESM', () => {
       const pkgPath = path.join(__dirname, './typings/esm');
 
-      after(async ()=> {
+      after(async () => {
         await remove(path.join(pkgPath, './node_modules'));
       });
 
@@ -166,10 +166,10 @@ describe('module', function () {
       });
     });
 
-    describe('CommonJS', ()=> {
+    describe('CommonJS', () => {
       const pkgPath = path.join(__dirname, './typings/cjs');
 
-      after(async ()=> {
+      after(async () => {
         await remove(path.join(pkgPath, './node_modules'));
       });
 

--- a/test/specs/core/mergeConfig.spec.js
+++ b/test/specs/core/mergeConfig.spec.js
@@ -101,7 +101,7 @@ describe('core::mergeConfig', function() {
     expect(merged.nestedConfig.propertyOnRequestConfig).toEqual(true);
   });
 
-  describe('headers', ()=> {
+  describe('headers', () => {
     it('should allow merging with AxiosHeaders instances', () => {
       const merged = mergeConfig({
         headers: new AxiosHeaders({

--- a/test/specs/headers.spec.js
+++ b/test/specs/headers.spec.js
@@ -135,7 +135,7 @@ describe('headers', function () {
     });
   });
 
-  it('should allow an AxiosHeaders instance to be used as the value of the headers option', async ()=> {
+  it('should allow an AxiosHeaders instance to be used as the value of the headers option', async () => {
     const instance = axios.create({
       headers: new AxiosHeaders({
         xFoo: 'foo',

--- a/test/specs/utils/merge.spec.js
+++ b/test/specs/utils/merge.spec.js
@@ -84,7 +84,7 @@ describe('utils::merge', function () {
     expect(d.a).not.toBe(a);
   });
 
-  it('should support caseless option', ()=> {
+  it('should support caseless option', () => {
     const a = {x: 1};
     const b = {X: 2};
     const merged = merge.call({caseless: true}, a, b);

--- a/test/unit/adapters/adapters.js
+++ b/test/unit/adapters/adapters.js
@@ -26,12 +26,12 @@ describe('adapters', function () {
 
   it('should detect adapter unavailable status', function () {
     adapters.adapters['testadapter'] = null;
-    assert.throws(()=> adapters.getAdapter('testAdapter'), /is not available in the build/)
+    assert.throws(() => adapters.getAdapter('testAdapter'), /is not available in the build/)
   });
 
   it('should detect adapter unsupported status', function () {
     adapters.adapters['testadapter'] = false;
-    assert.throws(()=> adapters.getAdapter('testAdapter'), /is not supported by the environment/)
+    assert.throws(() => adapters.getAdapter('testAdapter'), /is not supported by the environment/)
   });
 
   it('should pick suitable adapter from the list', function () {

--- a/test/unit/adapters/http.js
+++ b/test/unit/adapters/http.js
@@ -56,7 +56,7 @@ function toleranceRange(positive, negative) {
 const nodeVersion = process.versions.node.split('.').map(v => parseInt(v, 10));
 const nodeMajorVersion = nodeVersion[0];
 
-var noop = ()=> {};
+var noop = () => {};
 
 const LOCAL_SERVER_URL = 'http://localhost:4444';
 
@@ -581,7 +581,7 @@ describe('supports http with nodejs', function () {
       });
     });
 
-    describe('algorithms', ()=> {
+    describe('algorithms', () => {
       const responseBody ='str';
 
       for (const [typeName, zipped] of Object.entries({
@@ -823,7 +823,7 @@ describe('supports http with nodejs', function () {
       // consume the req stream
       req.on('data', noop);
       // and wait for the end before responding, otherwise an ECONNRESET error will be thrown
-      req.on('end', ()=> {
+      req.on('end', () => {
         res.end('OK');
       });
     }).listen(4444, function (err) {
@@ -1861,7 +1861,7 @@ describe('supports http with nodejs', function () {
 
       const dataURI = 'data:application/octet-stream;base64,' + buffer.toString('base64');
 
-      axios.get(dataURI).then(({data})=> {
+      axios.get(dataURI).then(({data}) => {
         assert.deepStrictEqual(data, buffer);
         done();
       }).catch(done);
@@ -1878,7 +1878,7 @@ describe('supports http with nodejs', function () {
 
       const dataURI = 'data:application/octet-stream;base64,' + buffer.toString('base64');
 
-      axios.get(dataURI, {responseType: 'blob'}).then(async ({data})=> {
+      axios.get(dataURI, {responseType: 'blob'}).then(async ({data}) => {
         assert.strictEqual(data.type, 'application/octet-stream');
         assert.deepStrictEqual(await data.text(), '123');
         done();
@@ -1890,7 +1890,7 @@ describe('supports http with nodejs', function () {
 
       const dataURI = 'data:application/octet-stream;base64,' + buffer.toString('base64');
 
-      axios.get(dataURI, {responseType: "text"}).then(({data})=> {
+      axios.get(dataURI, {responseType: "text"}).then(({data}) => {
         assert.deepStrictEqual(data, '123');
         done();
       }).catch(done);
@@ -1901,7 +1901,7 @@ describe('supports http with nodejs', function () {
 
       const dataURI = 'data:application/octet-stream;base64,' + buffer.toString('base64');
 
-      axios.get(dataURI, {responseType: "stream"}).then(({data})=> {
+      axios.get(dataURI, {responseType: "stream"}).then(({data}) => {
         var str = '';
 
         data.on('data', function(response){
@@ -2059,7 +2059,7 @@ describe('supports http with nodejs', function () {
         maxRedirects: 0
       });
 
-      samples.slice(skip).forEach(({rate, progress}, i, _samples)=> {
+      samples.slice(skip).forEach(({rate, progress}, i, _samples) => {
         assert.ok(compareValues(rate, configRate),
           `Rate sample at index ${i} is out of the expected range (${rate} / ${configRate}) [${
             _samples.map(({rate}) => rate).join(', ')
@@ -2107,7 +2107,7 @@ describe('supports http with nodejs', function () {
         maxRedirects: 0
       });
 
-      samples.slice(skip).forEach(({rate, progress}, i, _samples)=> {
+      samples.slice(skip).forEach(({rate, progress}, i, _samples) => {
         assert.ok(compareValues(rate, configRate),
           `Rate sample at index ${i} is out of the expected range (${rate} / ${configRate}) [${
             _samples.map(({rate}) => rate).join(', ')

--- a/test/unit/core/AxiosHeaders.js
+++ b/test/unit/core/AxiosHeaders.js
@@ -138,12 +138,12 @@ describe('AxiosHeaders', function () {
 
         headers.set('foo', 'bar=value1');
 
-        assert.strictEqual(headers.has('foo', (value, header, headers)=> {
+        assert.strictEqual(headers.has('foo', (value, header, headers) => {
           assert.strictEqual(value, 'bar=value1');
           assert.strictEqual(header, 'foo');
           return true;
         }), true);
-        assert.strictEqual(headers.has('foo', ()=> false), false);
+        assert.strictEqual(headers.has('foo', () => false), false);
       });
 
       it('should support string pattern', function () {
@@ -216,7 +216,7 @@ describe('AxiosHeaders', function () {
 
         headers.set('foo', 'bar=value1');
 
-        headers.delete('foo', (value, header)=> {
+        headers.delete('foo', (value, header) => {
           assert.strictEqual(value, 'bar=value1');
           assert.strictEqual(header, 'foo');
           return false;
@@ -224,7 +224,7 @@ describe('AxiosHeaders', function () {
 
         assert.strictEqual(headers.has('foo'), true);
 
-        assert.strictEqual(headers.delete('foo', ()=> true), true);
+        assert.strictEqual(headers.delete('foo', () => true), true);
 
         assert.strictEqual(headers.has('foo'), false);
       });
@@ -247,7 +247,7 @@ describe('AxiosHeaders', function () {
     });
   });
 
-  describe('clear', ()=> {
+  describe('clear', () => {
     it('should clear all headers', () => {
       const headers = new AxiosHeaders({x: 1, y:2});
 


### PR DESCRIPTION
Before:
```node
export const colorize = (...colors)=> {
```

After:
```node
export const colorize = (...colors) => {
```

Most of the examples in this project already look life the after, so I made all of them look the same. This comply better with [node style guide](https://github.com/felixge/node-style-guide).