### PR TITLE
fix: properly setup .eslintrc.cjs

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -2,12 +2,20 @@ module.exports = {
   "env": {
     "browser": true,
     "es2018": true,
-    "node": true
+    "node": true,
+    "mocha": true,
+    "jasmine": true
   },
-  "extends": "eslint:recommended",
+  "extends": [
+    "eslint:recommended"
+  ],
   "parserOptions": {
     "ecmaVersion": 2018,
     "sourceType": "module"
+  },
+  "globals": {
+    "axios": "readonly",
+    "getAjaxRequest": "readonly"
   },
   "rules": {
     "no-cond-assign": 0


### PR DESCRIPTION
Eslint is not setup properly. So I have added support for mocha, jasmine, and our global variables such as axios and getAjaxRequest. Now people can actually use eslint.