### PR TITLE
fix(lib): paramsSerializer as function

### DIFF
--- a/lib/core/Axios.js
+++ b/lib/core/Axios.js
@@ -61,14 +61,18 @@ Axios.prototype.request = function request(configOrUrl, config) {
 
   var paramsSerializer = config.paramsSerializer;
 
-  if (paramsSerializer !== undefined) {
-    validator.assertOptions(paramsSerializer, {
-      encode: validators.function,
-      serialize: validators.function
-    }, true);
+  if (paramsSerializer != null) {
+    if (utils.isFunction(paramsSerializer)) {
+      config.paramsSerializer = {
+        serialize: paramsSerializer
+      }
+    } else {
+      validator.assertOptions(paramsSerializer, {
+        encode: validators.function,
+        serialize: validators.function
+      }, true);
+    }
   }
-
-  utils.isFunction(paramsSerializer) && (config.paramsSerializer = {serialize: paramsSerializer});
 
   // filter out skipped interceptors
   var requestInterceptorChain = [];

--- a/test/unit/adapters/http.js
+++ b/test/unit/adapters/http.js
@@ -1532,4 +1532,18 @@ describe('supports http with nodejs', function () {
       }).catch(done);
     });
   });
+
+  it('should support function as paramsSerializer value', async () => {
+    server = await startHTTPServer((req, res) => res.end(req.url));
+
+    const {data} = await axios.post(LOCAL_SERVER_URL, 'test', {
+      params: {
+        x: 1
+      },
+      paramsSerializer: () => 'foo',
+      maxRedirects: 0
+    });
+
+    assert.strictEqual(data, '/?foo');
+  });
 });


### PR DESCRIPTION
Fixes #6341 

Allows to set a function in the paramsSerializer option as in 0.28.0 version.

The correction and unit test have been copied from `v1.x` branch.