### PR TITLE
fix: change main entry to CJS dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "axios",
   "version": "1.6.8",
   "description": "Promise based HTTP client for the browser and node.js",
-  "main": "index.js",
+  "main": "dist/node/axios.cjs",
   "exports": {
     ".": {
       "types": {


### PR DESCRIPTION
ESM aware tools will only look in `exports` (and not `main`) when resolving a package. Therefore the `main` entry point should always be a CJS file.

I believe this is just an oversight in the `v1.x` branch since the last commit touching `package.json#main` was [10 years ago](https://github.com/axios/axios/blame/v1.x/package.json#L5).

This change will only affect older runtimes like `node@<=10` as well as tools like [`resolve`](https://www.npmjs.com/package/resolve). I'm not sure if those Node versions are officially supported, but this change should be ignored by all new runtime versions and bundlers.

I found this due to a mocking library our tests were using that would fallback to the `resolve` package. In that case Node's `require.resolve` would end up pointing to a different path than `resolve`:

```sh
❯ node --version
v20.12.1
❯ node -e 'console.log(require.resolve("axios"))'
/Users/lukekarrys/Desktop/hmmmm/node_modules/axios/dist/node/axios.cjs
❯ node -e 'console.log(require("resolve").sync("axios"))'
/Users/lukekarrys/Desktop/hmmmm/node_modules/axios/index.js
```

Similar things happen in Node 10 that cause the `require` to throw:

```sh
❯ node --version
v10.24.1
❯ node -e 'console.log(require("axios/dist/node/axios.cjs").VERSION)'
1.6.8
❯ node -e 'console.log(require("axios").VERSION)'
/Users/lukekarrys/Desktop/wtf/node_modules/axios/index.js:1
import axios from './lib/axios.js';
       ^^^^^

SyntaxError: Unexpected identifier
    at Module._compile (internal/modules/cjs/loader.js:723:23)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:789:10)
    at Module.load (internal/modules/cjs/loader.js:653:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
    at Function.Module._load (internal/modules/cjs/loader.js:585:3)
    at Module.require (internal/modules/cjs/loader.js:692:17)
    at require (internal/modules/cjs/helpers.js:25:18)
    at [eval]:1:13
    at Script.runInThisContext (vm.js:122:20)
    at Object.runInThisContext (vm.js:329:38)
```