### PR TITLE
fix(backport): fix paramsSerializer function validation

### DIFF
--- a/lib/core/Axios.js
+++ b/lib/core/Axios.js
@@ -61,14 +61,18 @@ Axios.prototype.request = function request(configOrUrl, config) {
 
   var paramsSerializer = config.paramsSerializer;
 
-  if (paramsSerializer !== undefined) {
-    validator.assertOptions(paramsSerializer, {
-      encode: validators.function,
-      serialize: validators.function
-    }, true);
+  if (paramsSerializer != null) {
+    if (utils.isFunction(paramsSerializer)) {
+      config.paramsSerializer = {
+        serialize: paramsSerializer
+      };
+    } else {
+      validator.assertOptions(paramsSerializer, {
+        encode: validators.function,
+        serialize: validators.function
+      }, true);
+    }
   }
-
-  utils.isFunction(paramsSerializer) && (config.paramsSerializer = {serialize: paramsSerializer});
 
   // filter out skipped interceptors
   var requestInterceptorChain = [];

--- a/test/unit/adapters/http.js
+++ b/test/unit/adapters/http.js
@@ -1532,4 +1532,24 @@ describe('supports http with nodejs', function () {
       }).catch(done);
     });
   });
+
+  it('should support function as paramsSerializer value', function (done) {
+    server = http.createServer(function (req, res) {
+      res.end('ok');
+    }).listen(4444, function () {
+      var data;
+
+      axios.post('http://localhost:4444', 'test', {
+        params: {
+          x: 1
+        },
+        paramsSerializer: () => 'foo',
+        maxRedirects: 0,
+      }).then(function (res) {
+        assert.strictEqual(res.request.path, '/?foo');
+        data = res;
+        done()
+      }).catch(done);
+    });
+  });
 });


### PR DESCRIPTION
This fixes issue https://github.com/axios/axios/issues/6341.

It copies the code and test from the 1.x branch [here](https://github.com/axios/axios/blob/v1.x/lib/core/Axios.js#L84), and updates the test to match the older testing style on the 0.x branch.