### PR TITLE
fix(fetch): handle ReadableStream body in Alipay webview

### DIFF
--- a/lib/adapters/fetch.js
+++ b/lib/adapters/fetch.js
@@ -28,17 +28,20 @@ const encodeText = isFetchSupported && (typeof TextEncoder === 'function' ?
 
 const supportsRequestStream = isReadableStreamSupported && (() => {
   let duplexAccessed = false;
-
-  const hasContentType = new Request(platform.origin, {
-    body: new ReadableStream(),
-    method: 'POST',
-    get duplex() {
-      duplexAccessed = true;
-      return 'half';
-    },
-  }).headers.has('Content-Type');
-
-  return duplexAccessed && !hasContentType;
+  try {
+    const hasContentType = new Request(platform.origin, {
+      body: new ReadableStream(),
+      method: 'POST',
+      get duplex() {
+        duplexAccessed = true;
+        return 'half';
+      },
+    }).headers.has('Content-Type');
+  
+    return duplexAccessed && !hasContentType;
+  } catch () {
+    return false
+  }
 })();
 
 const DEFAULT_CHUNK_SIZE = 64 * 1024;

--- a/lib/adapters/fetch.js
+++ b/lib/adapters/fetch.js
@@ -39,7 +39,7 @@ const supportsRequestStream = isReadableStreamSupported && (() => {
     }).headers.has('Content-Type');
   
     return duplexAccessed && !hasContentType;
-  } catch () {
+  } catch (e) {
     return false
   }
 })();


### PR DESCRIPTION
When creating a new Request with a body of new ReadableStream(), it causes a crash in the Alipay webview.  Adding this error handling ensures better compatibility and stability in environments where this problem occurs.