### PR TITLE
feat: allow passing custom json parser and encoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -635,6 +635,16 @@ These are the available config options for making requests. Only the `url` is re
     clarifyTimeoutError: false,
   },
 
+  // `jsonEncoder` lets you customize how JSON is stringified. Mostly useful to fix
+  // issues arising with parsing large numbers with `JSON.parse`
+  // see https://github.com/axios/axios/issues/5282
+  jsonEncoder: undefined, // `null` or `undefined` default to `JSON.stringify`
+
+  // `jsonEncoder` lets you customize how JSON is stringified. Mostly useful to fix
+  // issues arising with parsing large numbers with `JSON.parse`
+  // see https://github.com/axios/axios/issues/5282
+  jsonParser: undefined, // `null` or `undefined` default to `JSON.parse`
+
   env: {
     // The FormData class to be used to automatically serialize the payload into a FormData object
     FormData: window?.FormData || global?.FormData

--- a/index.d.cts
+++ b/index.d.cts
@@ -407,6 +407,8 @@ declare namespace axios {
     cancelToken?: CancelToken;
     decompress?: boolean;
     transitional?: TransitionalOptions;
+    jsonParser?: (text: string) => any;
+    jsonEncoder?: (value: any) => string;
     signal?: GenericAbortSignal;
     insecureHTTPParser?: boolean;
     env?: {

--- a/index.d.ts
+++ b/index.d.ts
@@ -348,6 +348,8 @@ export interface AxiosRequestConfig<D = any> {
   cancelToken?: CancelToken;
   decompress?: boolean;
   transitional?: TransitionalOptions;
+  jsonParser?: (text: string) => any;
+  jsonEncoder?: (value: any) => string;
   signal?: GenericAbortSignal;
   insecureHTTPParser?: boolean;
   env?: {

--- a/lib/defaults/index.js
+++ b/lib/defaults/index.js
@@ -37,6 +37,10 @@ const defaults = {
 
   transitional: transitionalDefaults,
 
+  jsonParser: null,
+
+  jsonEncoder: null,
+
   adapter: ['xhr', 'http', 'fetch'],
 
   transformRequest: [function transformRequest(data, headers) {
@@ -91,7 +95,7 @@ const defaults = {
 
     if (isObjectPayload || hasJSONContentType ) {
       headers.setContentType('application/json', false);
-      return stringifySafely(data);
+      return stringifySafely(data, this.jsonParser, this.jsonEncoder);
     }
 
     return data;
@@ -111,7 +115,7 @@ const defaults = {
       const strictJSONParsing = !silentJSONParsing && JSONRequested;
 
       try {
-        return JSON.parse(data);
+        return (this.jsonParser || JSON.parse)(data);
       } catch (e) {
         if (strictJSONParsing) {
           if (e.name === 'SyntaxError') {


### PR DESCRIPTION
This PR adds two new config parameters, `jsonParser` and `jsonEncoder` to allow users to choose which JSON parser to use. It is backward compatible: if `null` or `undefined`, the default `JSON.{parse,stringify}` is used.

Type annotations were taken from tye [TypeScript repository](https://github.com/microsoft/TypeScript/blob/ef514af2675389d38c793d6cc1945486c367e6fa/src/lib/es5.d.ts#L1144-L1151)

This is mostly to fix issues with parsing large numbers in JS.

Related issue: #6279 