### PR TITLE
fix(fetch): fix ReadableStream couldn't be contructed bewteen chrome 43 and 52

### DIFF
--- a/lib/adapters/fetch.js
+++ b/lib/adapters/fetch.js
@@ -17,8 +17,18 @@ const fetchProgressDecorator = (total, fn) => {
   }));
 }
 
+// between chrome 43 and 52, ReadableStream is available but could not be constructed
+const isReadableStreamConstructable = () => {
+  try {
+    new ReadableStream();
+    return true
+  } catch (error) {
+    return false
+  }
+}
+
 const isFetchSupported = typeof fetch === 'function' && typeof Request === 'function' && typeof Response === 'function';
-const isReadableStreamSupported = isFetchSupported && typeof ReadableStream === 'function';
+const isReadableStreamSupported = isFetchSupported && typeof ReadableStream === 'function' && isReadableStreamConstructable();
 
 // used only inside the fetch adapter
 const encodeText = isFetchSupported && (typeof TextEncoder === 'function' ?


### PR DESCRIPTION
The `ReadableStream` API is available in Chrome 43, but it can only be constructed starting from Chrome 52.

[see: MDN ReadableStream browser_compatibility](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream#browser_compatibility)

![image](https://github.com/axios/axios/assets/55919198/8cbd2e06-4113-435a-bc01-a746e5037006)

Therefore, if Axios is used in a version of Chrome between 43 and 52 (for example, one of my production environments uses Chrome 48), it will result in an `Uncaught TypeError: Illegal constructor`, causing a white screen problem.