### PR TITLE
fix(lib): throttle ignored `force` argument

### DIFF
--- a/lib/helpers/AxiosTransformStream.js
+++ b/lib/helpers/AxiosTransformStream.js
@@ -78,7 +78,7 @@ class AxiosTransformStream extends stream.Transform{
     }, internals.ticksRate);
 
     const onFinish = () => {
-      internals.updateProgress.call(true);
+      internals.updateProgress(true);
     };
 
     this.once('end', onFinish);

--- a/lib/helpers/throttle.js
+++ b/lib/helpers/throttle.js
@@ -10,9 +10,7 @@ function throttle(fn, freq) {
   let timestamp = 0;
   const threshold = 1000 / freq;
   let timer = null;
-  return function throttled() {
-    const force = this === true;
-
+  return function throttled(force) {
     const now = Date.now();
     if (force || now - timestamp > threshold) {
       if (timer) {


### PR DESCRIPTION
Fixes #6417

On line 14 of `lib/helpers/throttle.js`, `throttle` expects `this` to be `true` when a call to `fn` is enforced; however, `this` would never equal to `true` / `false` in non-strict mode as `this` cannot be a primitive. It instead is a wrapper object around the value in non-strict mode when it is called by `Function.prototype.call()` with `this` bound to any primitive value.

This PR partially reverts d01386e60ace84e4ac19e121c22ebf00ba66f0eb by making `force` a parameter so it works both in strict and non-strict mode.

```javascript
f = function () {
  console.log(this === true);
  console.log(this instanceof Boolean);
  console.log(this.valueOf() === true);
};

f.call(true) // => false true true
```

```javascript
g = function () {
  'use strict';
  console.log(this === true);
  console.log(this instanceof Boolean);
  console.log(this.valueOf() === true);
};

g.call(true) // => true false true
```