### PR TITLE
fix(index): add create to index exports

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -724,6 +724,8 @@ export function mergeConfig<D = any>(
   config2: AxiosRequestConfig<D>
 ): AxiosRequestConfig<D>;
 
+export function create(config?: CreateAxiosDefaults): AxiosInstance;
+
 export interface AxiosStatic extends AxiosInstance {
   Cancel: CancelStatic;
   CancelToken: CancelTokenStatic;

--- a/index.js
+++ b/index.js
@@ -20,10 +20,12 @@ const {
   formToJSON,
   getAdapter,
   mergeConfig,
+  create,
 } = axios;
 
 export {
   axios as default,
+  create,
   Axios,
   AxiosError,
   CanceledError,

--- a/tests/unit/api.test.js
+++ b/tests/unit/api.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from 'vitest';
 import assert from 'assert';
-import axios from '../../index.js';
+import axios, { create } from '../../index.js';
 
 describe('static api', () => {
   it('should have request method helpers', () => {
@@ -51,6 +51,11 @@ describe('static api', () => {
 
   it('should have factory method', () => {
     assert.strictEqual(typeof axios.create, 'function');
+  });
+
+  it('should expose create as a named export', () => {
+    assert.strictEqual(typeof create, 'function');
+    assert.strictEqual(create, axios.create);
   });
 
   it('should have CanceledError, CancelToken, and isCancel properties', () => {


### PR DESCRIPTION
Add `create` to exports in `index.js`.

As `create` is being added to the default export in a different way from the other properties, seems like it has been fogotten.
https://github.com/axios/axios/blob/v1.x/lib/axios.js#L39

We are having an issue in our project, that for some reason undiscovered yet, `create` is not available through default export after bundle.

Obs.: The test added do not fail in case of not being exported, as I am not sure why the problem is caused, I am not sure how to test it the best way.