### PR TITLE
feat(http): add support for proxy tunneling

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,6 +524,12 @@ These are the available config options for making requests. Only the `url` is re
     }
   },
 
+  // When an HTTP proxy is used, this option will make axios tunnel through the proxy.
+  // The tunnel approach is made with the HTTP proxy CONNECT request and requires that the
+  // proxy allows direct connect to the remote port number axios wants to tunnel through to.
+  // Note: This option is ignored if you use a custom agent.
+  proxytunnel: false, // default
+
   // `cancelToken` specifies a cancel token that can be used to cancel the request
   // (see Cancellation section below for details)
   cancelToken: new CancelToken(function (cancel) {

--- a/index.d.cts
+++ b/index.d.cts
@@ -394,6 +394,7 @@ declare namespace axios {
     httpAgent?: any;
     httpsAgent?: any;
     proxy?: AxiosProxyConfig | false;
+    proxytunnel?: boolean;
     cancelToken?: CancelToken;
     decompress?: boolean;
     transitional?: TransitionalOptions;

--- a/index.d.ts
+++ b/index.d.ts
@@ -335,6 +335,7 @@ export interface AxiosRequestConfig<D = any> {
   httpAgent?: any;
   httpsAgent?: any;
   proxy?: AxiosProxyConfig | false;
+  proxytunnel?: boolean;
   cancelToken?: CancelToken;
   decompress?: boolean;
   transitional?: TransitionalOptions;

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -7,6 +7,7 @@ import buildURL from './../helpers/buildURL.js';
 import {getProxyForUrl} from 'proxy-from-env';
 import http from 'http';
 import https from 'https';
+import tls from 'tls';
 import util from 'util';
 import followRedirects from 'follow-redirects';
 import zlib from 'zlib';
@@ -68,10 +69,11 @@ function dispatchBeforeRedirect(options) {
  * @param {http.ClientRequestArgs} options
  * @param {AxiosProxyConfig} configProxy configuration from Axios options object
  * @param {string} location
+ * @param {boolean} [tunnel]
  *
  * @returns {http.ClientRequestArgs}
  */
-function setProxy(options, configProxy, location) {
+function setProxy(options, configProxy, location, tunnel) {
   let proxy = configProxy;
   if (!proxy && proxy !== false) {
     const proxyUrl = getProxyForUrl(location);
@@ -85,6 +87,7 @@ function setProxy(options, configProxy, location) {
       proxy.auth = (proxy.username || '') + ':' + (proxy.password || '');
     }
 
+    let proxyAuthHeader;
     if (proxy.auth) {
       // Support proxy auth object form
       if (proxy.auth.username || proxy.auth.password) {
@@ -93,25 +96,84 @@ function setProxy(options, configProxy, location) {
       const base64 = Buffer
         .from(proxy.auth, 'utf8')
         .toString('base64');
-      options.headers['Proxy-Authorization'] = 'Basic ' + base64;
+      proxyAuthHeader = 'Basic ' + base64;
     }
 
-    options.headers.host = options.hostname + (options.port ? ':' + options.port : '');
-    const proxyHost = proxy.hostname || proxy.host;
-    options.hostname = proxyHost;
-    // Replace 'host' since options is not a URL object
-    options.host = proxyHost;
-    options.port = proxy.port;
-    options.path = location;
-    if (proxy.protocol) {
-      options.protocol = proxy.protocol.includes(':') ? proxy.protocol : `${proxy.protocol}:`;
+    if (!tunnel) {
+      if (proxyAuthHeader) {
+        options.headers['Proxy-Authorization'] = proxyAuthHeader;
+      }
+      options.headers.host = options.hostname + (options.port ? ':' + options.port : '');
+      const proxyHost = proxy.hostname || proxy.host;
+      options.hostname = proxyHost;
+      // Replace 'host' since options is not a URL object
+      options.host = proxyHost;
+      options.port = proxy.port;
+      options.path = location;
+      if (proxy.protocol) {
+        options.protocol = proxy.protocol.includes(':') ? proxy.protocol : `${proxy.protocol}:`;
+        if (isHttps.test(proxy.protocol)) {
+          options.servername = proxyHost;
+        }
+      } else {
+        options.protocol = 'http:';
+      }
+    } else {
+      options.createConnection = (options, callback) => {
+        // The following is adapted from https://github.com/delvedor/hpagent/blob/96f45f1d40bfbdfd0fcc84cdba056be6e0fb8f4c/index.js
+        const reqOptions = {
+          method: 'CONNECT',
+          host: proxy.hostname || proxy.host,
+          port: proxy.port,
+          path: `${options.host}:${options.port}`,
+          headers: { host: `${options.host}:${options.port}` },
+          agent: false,
+          timeout: options.timeout || 0
+        };
+        if (proxyAuthHeader) {
+          reqOptions.headers['Proxy-Authorization'] = proxyAuthHeader;
+        }
+        if (isHttps.test(proxy.protocol)) {
+          reqOptions.servername = proxy.hostname || proxy.host;
+        }
+        const req = (isHttps.test(proxy.protocol) ? https : http).request(reqOptions);
+        req.once('connect', (res, socket) => {
+          req.removeAllListeners();
+          socket.removeAllListeners();
+          if (res.statusCode === 200) {
+            if (options.protocol === 'https:') {
+              const secureSocket = tls.connect({ ...options, socket });
+              callback(null, secureSocket);
+            } else {
+              callback(null, socket);
+            }
+          } else {
+            socket.destroy();
+            callback(new Error(`Bad response: ${res.statusCode}`), null);
+          }
+        });
+        req.once('timeout', () => {
+          req.destroy(new Error('Proxy timeout'));
+        });
+        req.once('error', err => {
+          req.removeAllListeners();
+          callback(err, null);
+        });
+        req.end();
+      };
+      if (options.protocol === 'https:') {
+        // Since we are using the `createConnection` option, Node.js won't use the default
+        // https agent and the following fields won't be correctly set.
+        options.port = options.port || 443;
+        options.servername = options.hostname;
+      }
     }
   }
 
   options.beforeRedirects.proxy = function beforeRedirect(redirectOptions) {
     // Configure proxy for redirected request, passing the original config proxy to apply
     // the exact same logic as if the redirected request was performed by axios directly.
-    setProxy(redirectOptions, configProxy, redirectOptions.href);
+    setProxy(redirectOptions, configProxy, redirectOptions.href, tunnel);
   };
 }
 
@@ -401,7 +463,7 @@ export default isHttpAdapterSupported && function httpAdapter(config) {
     } else {
       options.hostname = parsed.hostname;
       options.port = parsed.port;
-      setProxy(options, config.proxy, protocol + '//' + parsed.hostname + (parsed.port ? ':' + parsed.port : '') + options.path);
+      setProxy(options, config.proxy, protocol + '//' + parsed.hostname + (parsed.port ? ':' + parsed.port : '') + options.path, config.proxytunnel);
     }
 
     let transport;

--- a/test/unit/adapters/http.js
+++ b/test/unit/adapters/http.js
@@ -997,6 +997,32 @@ describe('supports http with nodejs', function () {
     });
   });
 
+  it('should support SSL tunneling through proxy', function (done) {
+    proxy = http.createServer();
+    proxy.on('connect', function (req, socket) {
+      const host = req.url.split(':')[0];
+      const port = parseInt(req.url.split(':')[1], 10);
+      const targetSocket = net.connect(port, host);
+      targetSocket.on('connect', function () {
+        socket.write('HTTP/1.1 200 Connection Established\n\n');
+        socket.pipe(targetSocket);
+        targetSocket.pipe(socket);
+      })
+    });
+    proxy.listen(4000, function () {
+      axios.get('https://www.google.com', {
+        proxy: {
+          host: 'localhost',
+          port: 4000,
+        },
+        proxytunnel: true
+      }).then(function (res) {
+        assert.ok(res.data, 'should tunnel ssl through proxy');
+        done();
+      }).catch(done);
+    });
+  });
+
   it('should not pass through disabled proxy', function (done) {
     // set the env variable
     process.env.http_proxy = 'http://does-not-exists.example.com:4242/';


### PR DESCRIPTION
This is the renewal of #5781 but rather than tunneling every HTTPS request which would be a breaking change, it introduces a new option to tunnel any request as desired.

Additionally, it fixes two issues with the existing proxy implementation: 1. When using an HTTPS proxy, the server name for the SNI TLS extension is incorrectly set to the target's, not the proxy's. 2. When the protocol is not set, it is incorrectly set to the target's, not http.
Admittedly, these changes should have been submitted in a different PR, but I was too lazy.

Oh and by the way, the documentation for the newly added option was ripped off from curl's manpage.