### PR TITLE
fix(fetch): unsupported BodyInit type

### DIFF
--- a/lib/adapters/fetch.js
+++ b/lib/adapters/fetch.js
@@ -28,17 +28,21 @@ const encodeText = isFetchSupported && (typeof TextEncoder === 'function' ?
 
 const supportsRequestStream = isReadableStreamSupported && (() => {
   let duplexAccessed = false;
-
-  const hasContentType = new Request(platform.origin, {
-    body: new ReadableStream(),
-    method: 'POST',
-    get duplex() {
-      duplexAccessed = true;
-      return 'half';
-    },
-  }).headers.has('Content-Type');
-
-  return duplexAccessed && !hasContentType;
+  // resolve: unsupported BodyInit type
+  // If Request.body does not support streams, an error will be generated and the process will be terminated
+  try {
+    const hasContentType = new Request(platform.origin, {
+      body: new ReadableStream(),
+      method: 'POST',
+      get duplex() {
+        duplexAccessed = true;
+        return 'half';
+      },
+    }).headers.has('Content-Type');
+    return duplexAccessed && !hasContentType;
+  } catch (error) {
+    return false;
+  }
 })();
 
 const DEFAULT_CHUNK_SIZE = 64 * 1024;


### PR DESCRIPTION
#### Instructions

If Request.body does not support streams, an error will be generated and the process will be terminated.
