### PR TITLE
Fix fetch request config

### DIFF
--- a/lib/adapters/fetch.js
+++ b/lib/adapters/fetch.js
@@ -2,7 +2,7 @@ import platform from "../platform/index.js";
 import utils from "../utils.js";
 import AxiosError from "../core/AxiosError.js";
 import composeSignals from "../helpers/composeSignals.js";
-import {trackStream} from "../helpers/trackStream.js";
+import { trackStream } from "../helpers/trackStream.js";
 import AxiosHeaders from "../core/AxiosHeaders.js";
 import progressEventReducer from "../helpers/progressEventReducer.js";
 import resolveConfig from "../helpers/resolveConfig.js";
@@ -22,8 +22,8 @@ const isReadableStreamSupported = isFetchSupported && typeof ReadableStream === 
 
 // used only inside the fetch adapter
 const encodeText = isFetchSupported && (typeof TextEncoder === 'function' ?
-    ((encoder) => (str) => encoder.encode(str))(new TextEncoder()) :
-    async (str) => new Uint8Array(await new Response(str).arrayBuffer())
+  ((encoder) => (str) => encoder.encode(str))(new TextEncoder()) :
+  async (str) => new Uint8Array(await new Response(str).arrayBuffer())
 );
 
 const supportsRequestStream = isReadableStreamSupported && (() => {
@@ -43,10 +43,10 @@ const supportsRequestStream = isReadableStreamSupported && (() => {
 
 const DEFAULT_CHUNK_SIZE = 64 * 1024;
 
-const supportsResponseStream = isReadableStreamSupported && !!(()=> {
+const supportsResponseStream = isReadableStreamSupported && !!(() => {
   try {
     return utils.isReadableStream(new Response('').body);
-  } catch(err) {
+  } catch (err) {
     // return undefined
   }
 })();
@@ -69,23 +69,23 @@ const getBodyLength = async (body) => {
     return 0;
   }
 
-  if(utils.isBlob(body)) {
+  if (utils.isBlob(body)) {
     return body.size;
   }
 
-  if(utils.isSpecCompliantForm(body)) {
+  if (utils.isSpecCompliantForm(body)) {
     return (await new Request(body).arrayBuffer()).byteLength;
   }
 
-  if(utils.isArrayBufferView(body)) {
+  if (utils.isArrayBufferView(body)) {
     return body.byteLength;
   }
 
-  if(utils.isURLSearchParams(body)) {
+  if (utils.isURLSearchParams(body)) {
     body = body + '';
   }
 
-  if(utils.isString(body)) {
+  if (utils.isString(body)) {
     return (await encodeText(body)).byteLength;
   }
 }
@@ -155,7 +155,7 @@ export default isFetchSupported && (async (config) => {
     }
 
     if (!utils.isString(withCredentials)) {
-      withCredentials = withCredentials ? 'cors' : 'omit';
+      withCredentials = withCredentials ? 'include' : 'omit';
     }
 
     request = new Request(url, {
@@ -165,7 +165,7 @@ export default isFetchSupported && (async (config) => {
       headers: headers.normalize().toJSON(),
       body: data,
       duplex: "half",
-      withCredentials
+      credentials: withCredentials
     });
 
     let response = await fetch(request);

--- a/lib/adapters/fetch.js
+++ b/lib/adapters/fetch.js
@@ -2,7 +2,7 @@ import platform from "../platform/index.js";
 import utils from "../utils.js";
 import AxiosError from "../core/AxiosError.js";
 import composeSignals from "../helpers/composeSignals.js";
-import { trackStream } from "../helpers/trackStream.js";
+import {trackStream} from "../helpers/trackStream.js";
 import AxiosHeaders from "../core/AxiosHeaders.js";
 import progressEventReducer from "../helpers/progressEventReducer.js";
 import resolveConfig from "../helpers/resolveConfig.js";
@@ -22,8 +22,8 @@ const isReadableStreamSupported = isFetchSupported && typeof ReadableStream === 
 
 // used only inside the fetch adapter
 const encodeText = isFetchSupported && (typeof TextEncoder === 'function' ?
-  ((encoder) => (str) => encoder.encode(str))(new TextEncoder()) :
-  async (str) => new Uint8Array(await new Response(str).arrayBuffer())
+    ((encoder) => (str) => encoder.encode(str))(new TextEncoder()) :
+    async (str) => new Uint8Array(await new Response(str).arrayBuffer())
 );
 
 const supportsRequestStream = isReadableStreamSupported && (() => {
@@ -43,10 +43,10 @@ const supportsRequestStream = isReadableStreamSupported && (() => {
 
 const DEFAULT_CHUNK_SIZE = 64 * 1024;
 
-const supportsResponseStream = isReadableStreamSupported && !!(() => {
+const supportsResponseStream = isReadableStreamSupported && !!(()=> {
   try {
     return utils.isReadableStream(new Response('').body);
-  } catch (err) {
+  } catch(err) {
     // return undefined
   }
 })();
@@ -69,23 +69,23 @@ const getBodyLength = async (body) => {
     return 0;
   }
 
-  if (utils.isBlob(body)) {
+  if(utils.isBlob(body)) {
     return body.size;
   }
 
-  if (utils.isSpecCompliantForm(body)) {
+  if(utils.isSpecCompliantForm(body)) {
     return (await new Request(body).arrayBuffer()).byteLength;
   }
 
-  if (utils.isArrayBufferView(body)) {
+  if(utils.isArrayBufferView(body)) {
     return body.byteLength;
   }
 
-  if (utils.isURLSearchParams(body)) {
+  if(utils.isURLSearchParams(body)) {
     body = body + '';
   }
 
-  if (utils.isString(body)) {
+  if(utils.isString(body)) {
     return (await encodeText(body)).byteLength;
   }
 }


### PR DESCRIPTION
### Summary

This pull request addresses an issue with the `fetch` adapter's handling of the `withCredentials` option in Axios. The current implementation incorrectly sets `withCredentials` instead of `credentials` in the `Request` object, leading to unexpected behavior.

### Issue

When using the `fetch` adapter with `withCredentials: true`, the cookies are not included in the requests as expected. This inconsistency between Axios and the native `fetch` API causes issues when making cross-origin requests that require credentials.

### Demos
#### Server Code
```js
const express = require('express');
const cors = require('cors');
const cookieParser = require('cookie-parser');

const app = express();
const port = 3000;

app.use(cors({
  origin: 'http://localhost:5000', // Replace with the allowed frontend address
  credentials: true, // Allow credentials
}));

// Use Cookie Parser Middleware
app.use(cookieParser());

// Example route to read Cookies
app.get('/', (req, res) => {
  const cookies = req.cookies;
  console.log('Cookies:', cookies);

  res.json({
    message: 'Cookies received',
    cookies: cookies,
  });
});

// Start server
app.listen(port, () => {
  console.log(`Server is running on http://localhost:${port}`);
});
```
#### Client Code Using Native fetch API
```js
fetch('http://localhost:3000', {
  method: 'GET',
  credentials: 'include'
})
  .then(response => response.json())
  .then(data => console.log(data))
  .catch(error => console.error('Error:', error));

```
The above code correctly prints out all the cookies. If credentials is set to `omit` or `same-origin`, the cookies will be an empty object.

#### Client Code Using Axios fetch adapter
```js
axios.get('http://localhost:3000', {
  withCredentials: true,
  adapter: ['fetch']
})
  .then(response => console.log(response.data))
  .catch(error => console.error('Error:', error));

```
In the above code, if withCredentials is set to include, the printed cookies are an empty object, which is not the expected behavior. By reviewing the source code, it was found that the fetch adapter incorrectly handles the `withCredentials` option. The `Request` constructor in the fetch API should receive a `credentials` option instead of `withCredentials`, with valid values being `omi`t, `same-origin`, and i`nclude`,but not include `cors`

### Solution

Replace the usage of `withCredentials` with `credentials` in the `Request` object initialization within the `fetch` adapter.

### Changes

- Modify `lib/adapters/fetch.js`:
  ```js
  if (!utils.isString(withCredentials)) {
    withCredentials = withCredentials ? 'include' : 'omit';
  }

  request = new Request(url, {
    ...fetchOptions,
    signal: composedSignal,
    method: method.toUpperCase(),
    headers: headers.normalize().toJSON(),
    body: data,
    duplex: "half",
    credentials: withCredentials
  });

### Verification
The corrected fetch adapter now works as expected, aligning with the behavior of the native fetch API. Here are the verification steps:

- Run the server code provided in the description.
- Execute the client code using both the native fetch API and Axios with the modified fetch adapter.
- Confirm that the cookies are correctly included in the response when `withCredentials: true` is set.
