### PR TITLE
fix(adapter): construct Request with a url and options

### DIFF
--- a/lib/adapters/fetch.js
+++ b/lib/adapters/fetch.js
@@ -69,7 +69,11 @@ const getBodyLength = async (body) => {
   }
 
   if(utils.isSpecCompliantForm(body)) {
-    return (await new Request(body).arrayBuffer()).byteLength;
+    const _request = new Request(platform.origin, {
+      method: 'POST',
+      body,
+    });
+    return (await _request.arrayBuffer()).byteLength;
   }
 
   if(utils.isArrayBufferView(body) || utils.isArrayBuffer(body)) {


### PR DESCRIPTION
Whilst testing the upload progress features with the new `fetch` adapter, I've found that when passing a `FormData` object as the body, the `onUploadProgress` callback was never triggered.

Debugging this, I found that the `getBodyLength` function was always returning `0`. The problematic line:

```js
(await new Request(body).arrayBuffer()).byteLength
```

After quite a bit of debugging, I double checked the MDN documentation, which doesn't explicitly state that it is okay to pass a `FormData` object to the constructor:

> [input](https://developer.mozilla.org/en-US/docs/Web/API/Request/Request#input)
> Defines the resource that you wish to fetch. This can either be:
> 
> A string containing the URL of the resource you want to fetch. The URL may be relative to the base URL, which is the document's [baseURI](https://developer.mozilla.org/en-US/docs/Web/API/Node/baseURI) in a window context, or [WorkerGlobalScope.location](https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/location) in a worker context.
> A [Request](https://developer.mozilla.org/en-US/docs/Web/API/Request) object, effectively creating a copy. Note the following behavioral updates to retain security while making the constructor less likely to throw exceptions:
> If this object exists on another origin to the constructor call, the [Request.referrer](https://developer.mozilla.org/en-US/docs/Web/API/Request/referrer) is stripped out.
> If this object has a [Request.mode](https://developer.mozilla.org/en-US/docs/Web/API/Request/mode) of navigate, the mode value is converted to same-origin.

Changing the above to the following fixes it for me (Chrome 126 on macOS)

```js
const _request = new Request(platform.origin, {
  method: 'POST',
  body,
});
await _request.arrayBuffer()).byteLength;
```

See: https://developer.mozilla.org/en-US/docs/Web/API/Request/Request