### PR TITLE
check credentials support for Cloudflare worker in fetch adapter

### DIFF
--- a/lib/adapters/fetch.js
+++ b/lib/adapters/fetch.js
@@ -151,7 +151,10 @@ export default isFetchSupported && (async (config) => {
       }
     }
 
-    if (!utils.isString(withCredentials)) {
+    // credential field is set by default (https://github.com/axios/axios/pull/6505)
+    // which is causing issue when running cloudflare worker (https://github.com/cloudflare/workers-sdk/issues/2514)
+    const isCredentialsSupported = "credentials" in Request.prototype;
+    if (isCredentialsSupported && !utils.isString(withCredentials)) {
       withCredentials = withCredentials ? 'include' : 'omit';
     }
 

--- a/lib/adapters/fetch.js
+++ b/lib/adapters/fetch.js
@@ -154,7 +154,9 @@ export default isFetchSupported && (async (config) => {
     // credential field is set by default (https://github.com/axios/axios/pull/6505)
     // which is causing issue when running cloudflare worker (https://github.com/cloudflare/workers-sdk/issues/2514)
     const isCredentialsSupported = "credentials" in Request.prototype;
-    if (isCredentialsSupported && !utils.isString(withCredentials)) {
+    if (!isCredentialsSupported) {
+      withCredentials = undefined;
+    } else if (!utils.isString(withCredentials)) {
       withCredentials = withCredentials ? 'include' : 'omit';
     }
 


### PR DESCRIPTION
The `credential` field is [set by default](https://github.com/axios/axios/pull/6505), which is causing issue when [running with cloudflare worker](https://github.com/cloudflare/workers-sdk/issues/2514)