### PR TITLE
fix(adapter): fix undefined reference to hasBrowserEnv

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -229,7 +229,7 @@ export default isHttpAdapterSupported && function httpAdapter(config) {
 
     // Parse url
     const fullPath = buildFullPath(config.baseURL, config.url);
-    const parsed = new URL(fullPath, utils.hasBrowserEnv ? platform.origin : undefined);
+    const parsed = new URL(fullPath, platform.hasBrowserEnv ? platform.origin : undefined);
     const protocol = parsed.protocol || supportedProtocols[0];
 
     if (protocol === 'data:') {

--- a/test/unit/regression/SNYK-JS-AXIOS-7361793.js
+++ b/test/unit/regression/SNYK-JS-AXIOS-7361793.js
@@ -4,7 +4,6 @@
 import axios from '../../../index.js';
 import http from 'http';
 import assert from 'assert';
-import utils from '../../../lib/utils.js';
 import platform from '../../../lib/platform/index.js';
 
 
@@ -52,17 +51,18 @@ describe('Server-Side Request Forgery (SSRF)', () => {
         let hasBrowserEnv, origin;
 
         before(() => {
-            hasBrowserEnv = utils.hasBrowserEnv;
+            assert.ok(platform.hasBrowserEnv !== undefined);
+            hasBrowserEnv = platform.hasBrowserEnv;
             origin = platform.origin;
-            utils.hasBrowserEnv = true;
+            platform.hasBrowserEnv = true;
             platform.origin = 'http://localhost:' + String(GOOD_PORT);
         });
         after(() => {
-            utils.hasBrowserEnv = hasBrowserEnv;
+            platform.hasBrowserEnv = hasBrowserEnv;
             platform.origin = origin;
         });
         it('should fetch in client-side mode', async () => {
-            utils.hasBrowserEnv = true;
+            platform.hasBrowserEnv = true;
             const ssrfAxios = axios.create({
                 baseURL: 'http://localhost:' + String(GOOD_PORT),
             });


### PR DESCRIPTION
hasBrowserEnv is defined in lib/platform, and not lib/utils. Because of this, the base URL was not defaulting to the origin (window.location.href) in browser environments.

This bug was introduced in #6543.