### PR TITLE
fix: update aborted error message for clarity

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -569,7 +569,7 @@ export default isHttpAdapterSupported && function httpAdapter(config) {
           }
 
           const err = new AxiosError(
-            'maxContentLength size of ' + config.maxContentLength + ' exceeded',
+            'stream has been aborted',
             AxiosError.ERR_BAD_RESPONSE,
             config,
             lastRequest

--- a/test/unit/adapters/http.js
+++ b/test/unit/adapters/http.js
@@ -1642,7 +1642,7 @@ describe('supports http with nodejs', function () {
         assert.strictEqual(success, false, 'request should not succeed');
         assert.strictEqual(failure, true, 'request should fail');
         assert.strictEqual(error.code, 'ERR_BAD_RESPONSE');
-        assert.strictEqual(error.message, 'maxContentLength size of -1 exceeded');
+        assert.strictEqual(error.message, 'stream has been aborted');
         done();
       }).catch(done);
     });


### PR DESCRIPTION
# Description
Updates the axios error message when an aborted event from the stream is encountered. The error message is especially egregious when `maxContentLength` is defaulted to `-1`. 

This serves to make the message more clear but doesn't attempt to fix underlying causes of any aborted signal.

# Background
I recently encountered this message from a service who made an axios request sourced from a socket.io connection. When that socket connection was killed, an abort signal was generated that caused axios to abort the request. But the message displayed made the situation quite confusing.

# Related Issues
The following are where discussions have been had around the overall confusing nature of the error.
- https://github.com/axios/axios/issues/6437
- https://github.com/axios/axios/issues/6455
- https://github.com/axios/axios/issues/4806