### PR TITLE
fix: #6614, #4680 and more

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,22 +5,29 @@ interface RawAxiosHeaders {
   [key: string]: AxiosHeaderValue;
 }
 
-type MethodsHeaders = Partial<{
-  [Key in Method as Lowercase<Key>]: AxiosHeaders;
-} & {common: AxiosHeaders}>;
+type MethodsHeaders = Partial<
+  {
+    [Key in Method as Lowercase<Key>]: AxiosHeaders;
+  } & { common: AxiosHeaders }
+>;
 
-type AxiosHeaderMatcher = string | RegExp | ((this: AxiosHeaders, value: string, name: string) => boolean);
+type AxiosHeaderMatcher =
+  | string
+  | RegExp
+  | ((this: AxiosHeaders, value: string, name: string) => boolean);
 
 type AxiosHeaderParser = (this: AxiosHeaders, value: AxiosHeaderValue, header: string) => any;
 
 export class AxiosHeaders {
-  constructor(
-      headers?: RawAxiosHeaders | AxiosHeaders | string
-  );
+  constructor(headers?: RawAxiosHeaders | AxiosHeaders | string);
 
   [key: string]: any;
 
-  set(headerName?: string, value?: AxiosHeaderValue, rewrite?: boolean | AxiosHeaderMatcher): AxiosHeaders;
+  set(
+    headerName?: string,
+    value?: AxiosHeaderValue,
+    rewrite?: boolean | AxiosHeaderMatcher
+  ): AxiosHeaders;
   set(headers?: RawAxiosHeaders | AxiosHeaders | string, rewrite?: boolean): AxiosHeaders;
 
   get(headerName: string, parser: RegExp): RegExpExecArray | null;
@@ -34,7 +41,9 @@ export class AxiosHeaders {
 
   normalize(format: boolean): AxiosHeaders;
 
-  concat(...targets: Array<AxiosHeaders | RawAxiosHeaders | string | undefined | null>): AxiosHeaders;
+  concat(
+    ...targets: Array<AxiosHeaders | RawAxiosHeaders | string | undefined | null>
+  ): AxiosHeaders;
 
   toJSON(asStrings?: boolean): RawAxiosHeaders;
 
@@ -42,7 +51,9 @@ export class AxiosHeaders {
 
   static accessor(header: string | string[]): AxiosHeaders;
 
-  static concat(...targets: Array<AxiosHeaders | RawAxiosHeaders | string | undefined | null>): AxiosHeaders;
+  static concat(
+    ...targets: Array<AxiosHeaders | RawAxiosHeaders | string | undefined | null>
+  ): AxiosHeaders;
 
   setContentType(value: ContentType, rewrite?: boolean | AxiosHeaderMatcher): AxiosHeaders;
   getContentType(parser?: RegExp): RegExpExecArray | null;
@@ -77,19 +88,38 @@ export class AxiosHeaders {
   [Symbol.iterator](): IterableIterator<[string, AxiosHeaderValue]>;
 }
 
-type CommonRequestHeadersList = 'Accept' | 'Content-Length' | 'User-Agent' | 'Content-Encoding' | 'Authorization';
+type CommonRequestHeadersList =
+  | "Accept"
+  | "Content-Length"
+  | "User-Agent"
+  | "Content-Encoding"
+  | "Authorization";
 
-type ContentType = AxiosHeaderValue | 'text/html' | 'text/plain' | 'multipart/form-data' | 'application/json' | 'application/x-www-form-urlencoded' | 'application/octet-stream';
+type ContentType =
+  | AxiosHeaderValue
+  | "text/html"
+  | "text/plain"
+  | "multipart/form-data"
+  | "application/json"
+  | "application/x-www-form-urlencoded"
+  | "application/octet-stream";
 
-export type RawAxiosRequestHeaders = Partial<RawAxiosHeaders & {
-  [Key in CommonRequestHeadersList]: AxiosHeaderValue;
-} & {
-  'Content-Type': ContentType
-}>;
+export type RawAxiosRequestHeaders = Partial<
+  RawAxiosHeaders & {
+    [Key in CommonRequestHeadersList]: AxiosHeaderValue;
+  } & {
+    "Content-Type": ContentType;
+  }
+>;
 
 export type AxiosRequestHeaders = RawAxiosRequestHeaders & AxiosHeaders;
 
-type CommonResponseHeadersList = 'Server' | 'Content-Type' | 'Content-Length' | 'Cache-Control'| 'Content-Encoding';
+type CommonResponseHeadersList =
+  | "Server"
+  | "Content-Type"
+  | "Content-Length"
+  | "Cache-Control"
+  | "Content-Encoding";
 
 type RawCommonResponseHeaders = {
   [Key in CommonResponseHeadersList]: AxiosHeaderValue;
@@ -106,7 +136,12 @@ export interface AxiosRequestTransformer {
 }
 
 export interface AxiosResponseTransformer {
-  (this: InternalAxiosRequestConfig, data: any, headers: AxiosResponseHeaders, status?: number): any;
+  (
+    this: InternalAxiosRequestConfig,
+    data: any,
+    headers: AxiosResponseHeaders,
+    status?: number
+  ): any;
 }
 
 export interface AxiosAdapter {
@@ -192,39 +227,61 @@ export enum HttpStatusCode {
 }
 
 export type Method =
-    | 'get' | 'GET'
-    | 'delete' | 'DELETE'
-    | 'head' | 'HEAD'
-    | 'options' | 'OPTIONS'
-    | 'post' | 'POST'
-    | 'put' | 'PUT'
-    | 'patch' | 'PATCH'
-    | 'purge' | 'PURGE'
-    | 'link' | 'LINK'
-    | 'unlink' | 'UNLINK';
+  | "get"
+  | "GET"
+  | "delete"
+  | "DELETE"
+  | "head"
+  | "HEAD"
+  | "options"
+  | "OPTIONS"
+  | "post"
+  | "POST"
+  | "put"
+  | "PUT"
+  | "patch"
+  | "PATCH"
+  | "purge"
+  | "PURGE"
+  | "link"
+  | "LINK"
+  | "unlink"
+  | "UNLINK";
 
 export type ResponseType =
-    | 'arraybuffer'
-    | 'blob'
-    | 'document'
-    | 'json'
-    | 'text'
-    | 'stream'
-    | 'formdata';
+  | "arraybuffer"
+  | "blob"
+  | "document"
+  | "json"
+  | "text"
+  | "stream"
+  | "formdata";
 
 export type responseEncoding =
-    | 'ascii' | 'ASCII'
-    | 'ansi' | 'ANSI'
-    | 'binary' | 'BINARY'
-    | 'base64' | 'BASE64'
-    | 'base64url' | 'BASE64URL'
-    | 'hex' | 'HEX'
-    | 'latin1' | 'LATIN1'
-    | 'ucs-2' | 'UCS-2'
-    | 'ucs2' | 'UCS2'
-    | 'utf-8' | 'UTF-8'
-    | 'utf8' | 'UTF8'
-    | 'utf16le' | 'UTF16LE';
+  | "ascii"
+  | "ASCII"
+  | "ansi"
+  | "ANSI"
+  | "binary"
+  | "BINARY"
+  | "base64"
+  | "BASE64"
+  | "base64url"
+  | "BASE64URL"
+  | "hex"
+  | "HEX"
+  | "latin1"
+  | "LATIN1"
+  | "ucs-2"
+  | "UCS-2"
+  | "ucs2"
+  | "UCS2"
+  | "utf-8"
+  | "UTF-8"
+  | "utf8"
+  | "UTF8"
+  | "utf16le"
+  | "UTF16LE";
 
 export interface TransitionalOptions {
   silentJSONParsing?: boolean;
@@ -247,11 +304,11 @@ export interface FormDataVisitorHelpers {
 
 export interface SerializerVisitor {
   (
-      this: GenericFormData,
-      value: any,
-      key: string | number,
-      path: null | Array<string | number>,
-      helpers: FormDataVisitorHelpers
+    this: GenericFormData,
+    value: any,
+    key: string | number,
+    path: null | Array<string | number>,
+    helpers: FormDataVisitorHelpers
   ): boolean;
 }
 
@@ -263,8 +320,7 @@ export interface SerializerOptions {
 }
 
 // tslint:disable-next-line
-export interface FormSerializerOptions extends SerializerOptions {
-}
+export interface FormSerializerOptions extends SerializerOptions {}
 
 export interface ParamEncoder {
   (value: any, defaultEncoder: (value: any) => any): any;
@@ -300,7 +356,7 @@ export interface AxiosProgressEvent {
 
 type Milliseconds = number;
 
-type AxiosAdapterName = 'fetch' | 'xhr' | 'http' | string;
+type AxiosAdapterName = "fetch" | "xhr" | "http" | string;
 
 type AxiosAdapterConfig = AxiosAdapter | AxiosAdapterName;
 
@@ -339,7 +395,10 @@ export interface AxiosRequestConfig<D = any> {
   maxBodyLength?: number;
   maxRedirects?: number;
   maxRate?: number | [MaxUploadRate, MaxDownloadRate];
-  beforeRedirect?: (options: Record<string, any>, responseDetails: {headers: Record<string, string>, statusCode: HttpStatusCode}) => void;
+  beforeRedirect?: (
+    options: Record<string, any>,
+    responseDetails: { headers: Record<string, string>; statusCode: HttpStatusCode }
+  ) => void;
   socketPath?: string | null;
   transport?: any;
   httpAgent?: any;
@@ -355,8 +414,22 @@ export interface AxiosRequestConfig<D = any> {
   };
   formSerializer?: FormSerializerOptions;
   family?: AddressFamily;
-  lookup?: ((hostname: string, options: object, cb: (err: Error | null, address: LookupAddress | LookupAddress[], family?: AddressFamily) => void) => void) |
-      ((hostname: string, options: object) => Promise<[address: LookupAddressEntry | LookupAddressEntry[], family?: AddressFamily] | LookupAddress>);
+  lookup?:
+    | ((
+        hostname: string,
+        options: object,
+        cb: (
+          err: Error | null,
+          address: LookupAddress | LookupAddress[],
+          family?: AddressFamily
+        ) => void
+      ) => void)
+    | ((
+        hostname: string,
+        options: object
+      ) => Promise<
+        [address: LookupAddressEntry | LookupAddressEntry[], family?: AddressFamily] | LookupAddress
+      >);
   withXSRFToken?: boolean | ((config: InternalAxiosRequestConfig) => boolean | undefined);
   fetchOptions?: Record<string, any>;
 }
@@ -382,11 +455,11 @@ export interface HeadersDefaults {
   unlink?: RawAxiosRequestHeaders;
 }
 
-export interface AxiosDefaults<D = any> extends Omit<AxiosRequestConfig<D>, 'headers'> {
+export interface AxiosDefaults<D = any> extends Omit<AxiosRequestConfig<D>, "headers"> {
   headers: HeadersDefaults;
 }
 
-export interface CreateAxiosDefaults<D = any> extends Omit<AxiosRequestConfig<D>, 'headers'> {
+export interface CreateAxiosDefaults<D = any> extends Omit<AxiosRequestConfig<D>, "headers"> {
   headers?: RawAxiosRequestHeaders | AxiosHeaders | Partial<HeadersDefaults>;
 }
 
@@ -401,11 +474,11 @@ export interface AxiosResponse<T = any, D = any> {
 
 export class AxiosError<T = unknown, D = any> extends Error {
   constructor(
-      message?: string,
-      code?: string,
-      config?: InternalAxiosRequestConfig<D>,
-      request?: any,
-      response?: AxiosResponse<T, D>
+    message?: string,
+    code?: string,
+    config?: InternalAxiosRequestConfig<D>,
+    request?: any,
+    response?: AxiosResponse<T, D>
   );
 
   config?: InternalAxiosRequestConfig<D>;
@@ -422,8 +495,8 @@ export class AxiosError<T = unknown, D = any> extends Error {
     config?: InternalAxiosRequestConfig<D>,
     request?: any,
     response?: AxiosResponse<T, D>,
-    customProps?: object,
-): AxiosError<T, D>;
+    customProps?: object
+  ): AxiosError<T, D>;
   static readonly ERR_FR_TOO_MANY_REDIRECTS = "ERR_FR_TOO_MANY_REDIRECTS";
   static readonly ERR_BAD_OPTION_VALUE = "ERR_BAD_OPTION_VALUE";
   static readonly ERR_BAD_OPTION = "ERR_BAD_OPTION";
@@ -438,8 +511,7 @@ export class AxiosError<T = unknown, D = any> extends Error {
   static readonly ETIMEDOUT = "ETIMEDOUT";
 }
 
-export class CanceledError<T> extends AxiosError<T> {
-}
+export class CanceledError<T> extends AxiosError<T> {}
 
 export type AxiosPromise<T = any> = Promise<AxiosResponse<T>>;
 
@@ -477,7 +549,11 @@ export interface AxiosInterceptorOptions {
 }
 
 export interface AxiosInterceptorManager<V> {
-  use(onFulfilled?: ((value: V) => V | Promise<V>) | null, onRejected?: ((error: any) => any) | null, options?: AxiosInterceptorOptions): number;
+  use(
+    onFulfilled?: ((value: V) => V | Promise<V>) | null,
+    onRejected?: ((error: any) => any) | null,
+    options?: AxiosInterceptorOptions
+  ): number;
   eject(id: number): void;
   clear(): void;
 }
@@ -491,27 +567,64 @@ export class Axios {
   };
   getUri(config?: AxiosRequestConfig): string;
   request<T = any, R = AxiosResponse<T>, D = any>(config: AxiosRequestConfig<D>): Promise<R>;
-  get<T = any, R = AxiosResponse<T>, D = any>(url: string, config?: AxiosRequestConfig<D>): Promise<R>;
-  delete<T = any, R = AxiosResponse<T>, D = any>(url: string, config?: AxiosRequestConfig<D>): Promise<R>;
-  head<T = any, R = AxiosResponse<T>, D = any>(url: string, config?: AxiosRequestConfig<D>): Promise<R>;
-  options<T = any, R = AxiosResponse<T>, D = any>(url: string, config?: AxiosRequestConfig<D>): Promise<R>;
-  post<T = any, R = AxiosResponse<T>, D = any>(url: string, data?: D, config?: AxiosRequestConfig<D>): Promise<R>;
-  put<T = any, R = AxiosResponse<T>, D = any>(url: string, data?: D, config?: AxiosRequestConfig<D>): Promise<R>;
-  patch<T = any, R = AxiosResponse<T>, D = any>(url: string, data?: D, config?: AxiosRequestConfig<D>): Promise<R>;
-  postForm<T = any, R = AxiosResponse<T>, D = any>(url: string, data?: D, config?: AxiosRequestConfig<D>): Promise<R>;
-  putForm<T = any, R = AxiosResponse<T>, D = any>(url: string, data?: D, config?: AxiosRequestConfig<D>): Promise<R>;
-  patchForm<T = any, R = AxiosResponse<T>, D = any>(url: string, data?: D, config?: AxiosRequestConfig<D>): Promise<R>;
+  get<T = any, R = AxiosResponse<T>, D = any>(
+    url: string,
+    config?: AxiosRequestConfig<D>
+  ): Promise<R>;
+  delete<T = any, R = AxiosResponse<T>, D = any>(
+    url: string,
+    config?: AxiosRequestConfig<D>
+  ): Promise<R>;
+  head<T = any, R = AxiosResponse<T>, D = any>(
+    url: string,
+    config?: AxiosRequestConfig<D>
+  ): Promise<R>;
+  options<T = any, R = AxiosResponse<T>, D = any>(
+    url: string,
+    config?: AxiosRequestConfig<D>
+  ): Promise<R>;
+  post<T = any, R = AxiosResponse<T>, D = any>(
+    url: string,
+    data?: D,
+    config?: AxiosRequestConfig<D>
+  ): Promise<R>;
+  put<T = any, R = AxiosResponse<T>, D = any>(
+    url: string,
+    data?: D,
+    config?: AxiosRequestConfig<D>
+  ): Promise<R>;
+  patch<T = any, R = AxiosResponse<T>, D = any>(
+    url: string,
+    data?: D,
+    config?: AxiosRequestConfig<D>
+  ): Promise<R>;
+  postForm<T = any, R = AxiosResponse<T>, D = any>(
+    url: string,
+    data?: D,
+    config?: AxiosRequestConfig<D>
+  ): Promise<R>;
+  putForm<T = any, R = AxiosResponse<T>, D = any>(
+    url: string,
+    data?: D,
+    config?: AxiosRequestConfig<D>
+  ): Promise<R>;
+  patchForm<T = any, R = AxiosResponse<T>, D = any>(
+    url: string,
+    data?: D,
+    config?: AxiosRequestConfig<D>
+  ): Promise<R>;
 }
 
 export interface AxiosInstance extends Axios {
   <T = any, R = AxiosResponse<T>, D = any>(config: AxiosRequestConfig<D>): Promise<R>;
   <T = any, R = AxiosResponse<T>, D = any>(url: string, config?: AxiosRequestConfig<D>): Promise<R>;
 
-  defaults: Omit<AxiosDefaults, 'headers'> & {
+  defaults: Omit<AxiosDefaults, "headers"> & {
     headers: HeadersDefaults & {
-      [key: string]: AxiosHeaderValue
-    }
+      [key: string]: AxiosHeaderValue;
+    };
   };
+  create(config?: CreateAxiosDefaults): AxiosInstance;
 }
 
 export interface GenericFormData {
@@ -524,11 +637,17 @@ export interface GenericHTMLFormElement {
   submit(): void;
 }
 
-export function getAdapter(adapters: AxiosAdapterConfig | AxiosAdapterConfig[] | undefined): AxiosAdapter;
+export function getAdapter(
+  adapters: AxiosAdapterConfig | AxiosAdapterConfig[] | undefined
+): AxiosAdapter;
 
-export function toFormData(sourceObj: object, targetFormData?: GenericFormData, options?: FormSerializerOptions): GenericFormData;
+export function toFormData(
+  sourceObj: object,
+  targetFormData?: GenericFormData,
+  options?: FormSerializerOptions
+): GenericFormData;
 
-export function formToJSON(form: GenericFormData|GenericHTMLFormElement): object;
+export function formToJSON(form: GenericFormData | GenericHTMLFormElement): object;
 
 export function isAxiosError<T = any, D = any>(payload: any): payload is AxiosError<T, D>;
 
@@ -538,7 +657,10 @@ export function isCancel(value: any): value is Cancel;
 
 export function all<T>(values: Array<T | Promise<T>>): Promise<T[]>;
 
-export function mergeConfig<D = any>(config1: AxiosRequestConfig<D>, config2: AxiosRequestConfig<D>): AxiosRequestConfig<D>;
+export function mergeConfig<D = any>(
+  config1: AxiosRequestConfig<D>,
+  config2: AxiosRequestConfig<D>
+): AxiosRequestConfig<D>;
 
 export interface AxiosStatic extends AxiosInstance {
   create(config?: CreateAxiosDefaults): AxiosInstance;


### PR DESCRIPTION
When creating an instance of `AxiosInstance` through `createInstance`, the following function adds a create method to it, that acts as a factory for creating new instances.

Bug: As there was no type definitions for the create method, the typescript used to complain about it. A simple fix was to add the type definition for the `AxiosInstance` class.