### PR TITLE
Add Node.js 22 to CI version matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x, 18.x, 20.x, 21.x]
+        node-version: [12.x, 14.x, 16.x, 18.x, 20.x, 22.x]
       fail-fast: false
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           persist-credentials: true
       - name: Get changed files
@@ -50,7 +50,7 @@ jobs:
             templates/**
             bin/**
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm


### PR DESCRIPTION
Adds Node.js 22 to CI version matrix. Also removes non-LTS version 21 in favor of the 22.

When running those actions on my fork, some deprecation warnings were shown about using old versions of actions/checkout and actions/node. Updated them both to V4 to remedy the situation.
