### PR TITLE
fix(requestConfig): support URL object in request handling

### DIFF
--- a/dist/axios.js
+++ b/dist/axios.js
@@ -1753,6 +1753,9 @@
       serializedParams = utils$1.isURLSearchParams(params) ? params.toString() : new AxiosURLSearchParams(params, options).toString(_encode);
     }
     if (serializedParams) {
+      if(typeof url === 'object' && url instanceof URL){
+        url = url.toString()
+      }
       var hashmarkIndex = url.indexOf("#");
       if (hashmarkIndex !== -1) {
         url = url.slice(0, hashmarkIndex);


### PR DESCRIPTION
**Description:**
This pull request adds support for the use of URL objects in requests. Previously, passing a URL object caused an error (url.indexOf is not a function). 

Added a type check for URL objects and automatically converted them to strings using .toString().
This ensures Axios can handle both string URLs and URL objects gracefully, preventing errors.

**Related Issue:**
https://github.com/axios/axios/issues/6546

**Changes Made:**
Updated Axios URL handling to support URL objects.
