### PR TITLE
fix(types): normalize response headers to lowercase in TypeScript types

### DIFF
--- a/index.d.cts
+++ b/index.d.cts
@@ -217,7 +217,7 @@ declare namespace axios {
   type AxiosHeaderValue = AxiosHeaders | string | string[] | number | boolean | null;
 
   type RawCommonResponseHeaders = {
-    [Key in CommonResponseHeadersList]: AxiosHeaderValue;
+    [Key in Lowercase<CommonResponseHeadersList>]: AxiosHeaderValue;
   } & {
     "set-cookie": string[];
   };

--- a/index.d.ts
+++ b/index.d.ts
@@ -92,7 +92,7 @@ export type AxiosRequestHeaders = RawAxiosRequestHeaders & AxiosHeaders;
 type CommonResponseHeadersList = 'Server' | 'Content-Type' | 'Content-Length' | 'Cache-Control'| 'Content-Encoding';
 
 type RawCommonResponseHeaders = {
-  [Key in CommonResponseHeadersList]: AxiosHeaderValue;
+  [Key in Lowercase<CommonResponseHeadersList>]: AxiosHeaderValue;
 } & {
   "set-cookie": string[];
 };


### PR DESCRIPTION
## Normalize response headers to lowercase in TypeScript types
Code Change is related to the bug raised at https://github.com/axios/axios/issues/6677

Description:
This PR addresses a difference between Axios’s TypeScript types for response headers and its actual runtime behavior. Axios normalizes all response header keys to lowercase, allowing headers to be accessed without worrying about casing. However, the TypeScript types defined these headers with Title Case keys.

Changes:
-Updated RawCommonResponseHeaders  in index.d.ts and index.d.cts to ensure all keys are lowercase.

@race-of-sloths Include this PR
