### PR TITLE
fix: allow passing a callback as paramsSerializer to buildURL

### DIFF
--- a/lib/helpers/buildURL.js
+++ b/lib/helpers/buildURL.js
@@ -26,7 +26,7 @@ function encode(val) {
  *
  * @param {string} url The base of the url (e.g., http://www.google.com)
  * @param {object} [params] The params to be appended
- * @param {?object} options
+ * @param {?(object|Function)} options
  *
  * @returns {string} The formatted url
  */
@@ -37,6 +37,12 @@ export default function buildURL(url, params, options) {
   }
   
   const _encode = options && options.encode || encode;
+
+  if (utils.isFunction(options)) {
+    options = {
+      serialize: options
+    }
+  } 
 
   const serializeFn = options && options.serialize;
 

--- a/lib/helpers/buildURL.js
+++ b/lib/helpers/buildURL.js
@@ -41,7 +41,7 @@ export default function buildURL(url, params, options) {
   if (utils.isFunction(options)) {
     options = {
       serialize: options
-    }
+    };
   } 
 
   const serializeFn = options && options.serialize;

--- a/test/specs/helpers/buildURL.spec.js
+++ b/test/specs/helpers/buildURL.spec.js
@@ -98,5 +98,12 @@ describe('helpers::buildURL', function () {
     };
 
     expect(buildURL('/foo', params, options)).toEqual('/foo?rendered');
+
+    const customSerializer = (thisParams) => {
+      expect(thisParams).toEqual(params);
+      return "rendered"
+    };
+
+    expect(buildURL('/foo', params, customSerializer)).toEqual('/foo?rendered');
   });
 });


### PR DESCRIPTION
Fixes #6676 

In 1.7.7 if a callback is supplied as paramsSerializer in `getUri` calls it is ignored. I slightly edited `buildURL` function to handle both paramsSerializers of type ParamsSerializerOptions and those of type CustomParamsSerializer.
