### PR TITLE
fix(TypeScript): Fix `AxiosHeaders` types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -45,37 +45,37 @@ export class AxiosHeaders {
   static concat(...targets: Array<AxiosHeaders | RawAxiosHeaders | string | undefined | null>): AxiosHeaders;
 
   setContentType(value: ContentType, rewrite?: boolean | AxiosHeaderMatcher): AxiosHeaders;
-  getContentType(parser?: RegExp): RegExpExecArray | null;
+  getContentType(parser: RegExp): RegExpExecArray | null;
   getContentType(matcher?: AxiosHeaderMatcher): AxiosHeaderValue;
   hasContentType(matcher?: AxiosHeaderMatcher): boolean;
 
   setContentLength(value: AxiosHeaderValue, rewrite?: boolean | AxiosHeaderMatcher): AxiosHeaders;
-  getContentLength(parser?: RegExp): RegExpExecArray | null;
+  getContentLength(parser: RegExp): RegExpExecArray | null;
   getContentLength(matcher?: AxiosHeaderMatcher): AxiosHeaderValue;
   hasContentLength(matcher?: AxiosHeaderMatcher): boolean;
 
   setAccept(value: AxiosHeaderValue, rewrite?: boolean | AxiosHeaderMatcher): AxiosHeaders;
-  getAccept(parser?: RegExp): RegExpExecArray | null;
+  getAccept(parser: RegExp): RegExpExecArray | null;
   getAccept(matcher?: AxiosHeaderMatcher): AxiosHeaderValue;
   hasAccept(matcher?: AxiosHeaderMatcher): boolean;
 
   setAcceptEncoding(value: AxiosHeaderValue, rewrite?: boolean | AxiosHeaderMatcher): AxiosHeaders;
-  getAcceptEncoding(parser?: RegExp): RegExpExecArray | null;
+  getAcceptEncoding(parser: RegExp): RegExpExecArray | null;
   getAcceptEncoding(matcher?: AxiosHeaderMatcher): AxiosHeaderValue;
   hasAcceptEncoding(matcher?: AxiosHeaderMatcher): boolean;
 
   setUserAgent(value: AxiosHeaderValue, rewrite?: boolean | AxiosHeaderMatcher): AxiosHeaders;
-  getUserAgent(parser?: RegExp): RegExpExecArray | null;
+  getUserAgent(parser: RegExp): RegExpExecArray | null;
   getUserAgent(matcher?: AxiosHeaderMatcher): AxiosHeaderValue;
   hasUserAgent(matcher?: AxiosHeaderMatcher): boolean;
 
   setContentEncoding(value: AxiosHeaderValue, rewrite?: boolean | AxiosHeaderMatcher): AxiosHeaders;
-  getContentEncoding(parser?: RegExp): RegExpExecArray | null;
+  getContentEncoding(parser: RegExp): RegExpExecArray | null;
   getContentEncoding(matcher?: AxiosHeaderMatcher): AxiosHeaderValue;
   hasContentEncoding(matcher?: AxiosHeaderMatcher): boolean;
 
   setAuthorization(value: AxiosHeaderValue, rewrite?: boolean | AxiosHeaderMatcher): AxiosHeaders;
-  getAuthorization(parser?: RegExp): RegExpExecArray | null;
+  getAuthorization(parser: RegExp): RegExpExecArray | null;
   getAuthorization(matcher?: AxiosHeaderMatcher): AxiosHeaderValue;
   hasAuthorization(matcher?: AxiosHeaderMatcher): boolean;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -59,6 +59,11 @@ export class AxiosHeaders {
   getAccept(matcher?: AxiosHeaderMatcher): AxiosHeaderValue;
   hasAccept(matcher?: AxiosHeaderMatcher): boolean;
 
+  setAcceptEncoding(value: AxiosHeaderValue, rewrite?: boolean | AxiosHeaderMatcher): AxiosHeaders;
+  getAcceptEncoding(parser?: RegExp): RegExpExecArray | null;
+  getAcceptEncoding(matcher?: AxiosHeaderMatcher): AxiosHeaderValue;
+  hasAcceptEncoding(matcher?: AxiosHeaderMatcher): boolean;
+
   setUserAgent(value: AxiosHeaderValue, rewrite?: boolean | AxiosHeaderMatcher): AxiosHeaders;
   getUserAgent(parser?: RegExp): RegExpExecArray | null;
   getUserAgent(matcher?: AxiosHeaderMatcher): AxiosHeaderValue;

--- a/lib/core/AxiosHeaders.js
+++ b/lib/core/AxiosHeaders.js
@@ -284,7 +284,7 @@ class AxiosHeaders {
   }
 }
 
-AxiosHeaders.accessor(['Content-Type', 'Content-Length', 'Accept', 'Accept-Encoding', 'User-Agent', 'Authorization']);
+AxiosHeaders.accessor(['Content-Type', 'Content-Length', 'Content-Encoding', 'Accept', 'Accept-Encoding', 'User-Agent', 'Authorization']);
 
 // reserved names hotfix
 utils.reduceDescriptors(AxiosHeaders.prototype, ({value}, key) => {

--- a/test/module/typings/esm/index.ts
+++ b/test/module/typings/esm/index.ts
@@ -624,6 +624,7 @@ for (const [header, value] of headers) {
   headers.y = 2;
 
   headers.get('x');
+  if (headers.getContentType() === 'application/json') {}
 })();
 
 // AxiosHeaders instance assigment

--- a/test/unit/core/AxiosHeaders.js
+++ b/test/unit/core/AxiosHeaders.js
@@ -315,6 +315,27 @@ describe('AxiosHeaders', function () {
       assert.strictEqual(typeof headers.hasFoo, 'function');
       assert.strictEqual(headers.hasFoo(), true);
     });
+
+    it('should support accessors for common headers by default', function () {
+      const headers = new AxiosHeaders({
+        'content-type': 'application/json',
+        'Content-Length': '100',
+        'Accept': '*/*',
+        'Accept-encoding': 'gzip deflate',
+      });
+
+      assert.strictEqual(headers.getContentType(), 'application/json');
+      assert.strictEqual(headers.getContentLength(), '100');
+      assert.strictEqual(headers.getAccept(), '*/*');
+      assert.strictEqual(headers.getAcceptEncoding(), 'gzip deflate');
+      assert.strictEqual(headers.getUserAgent(), undefined);
+      assert.strictEqual(headers.getAuthorization(), undefined);
+
+      headers.setUserAgent('Axios');
+      headers.setUserAgent('Axios2', false);
+      assert.strictEqual(headers.getUserAgent(), 'Axios');
+      assert.strictEqual(headers.hasUserAgent('Axios'), true);
+    });
   });
 
   it('should be caseless', function () {

--- a/test/unit/core/AxiosHeaders.js
+++ b/test/unit/core/AxiosHeaders.js
@@ -326,6 +326,7 @@ describe('AxiosHeaders', function () {
 
       assert.strictEqual(headers.getContentType(), 'application/json');
       assert.strictEqual(headers.getContentLength(), '100');
+      assert.strictEqual(headers.getContentEncoding(), undefined);
       assert.strictEqual(headers.getAccept(), '*/*');
       assert.strictEqual(headers.getAcceptEncoding(), 'gzip deflate');
       assert.strictEqual(headers.getUserAgent(), undefined);


### PR DESCRIPTION
Fixes the TypeScript definitions for `AxiosHeaders`:
1. Adds `Content-Encoding` header as an accessor. The `{get,set,has}ContentEncoding` methods declared in the types and [documented in the README](https://github.com/axios/axios/blob/4355a6d3bccdc6a33e7cef8bf4fafedad65e12ce/README.md#shortcuts) did not actually exist at runtime and would throw an error. Now the runtime behavior matches the types.
2. Adds missing types for the `{get,set,has}AcceptEncoding` methods created by the `Accept-Encoding` accessor
3. Fixes return type of the no-arg overload for `get` accessors. For example, `headers.getContentType()` returns the value of the content-type header. The return type was incorrectly declared as `RegExpExecArray | null` when *not* passing a `RegExp`.
