### PR TITLE
[fix] Loud comment to ensure comments are preserved in the minified file

### DIFF
--- a/dist/axios.js
+++ b/dist/axios.js
@@ -1,4 +1,4 @@
-// Axios v1.7.9 Copyright (c) 2024 Matt Zabriskie and contributors
+/*! Axios v1.7.9 Copyright (c) 2024 Matt Zabriskie and contributors */
 (function (global, factory) {
   typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
   typeof define === 'function' && define.amd ? define(factory) :

--- a/dist/esm/axios.js
+++ b/dist/esm/axios.js
@@ -1,4 +1,4 @@
-// Axios v1.7.9 Copyright (c) 2024 Matt Zabriskie and contributors
+/*! Axios v1.7.9 Copyright (c) 2024 Matt Zabriskie and contributors */
 function bind(fn, thisArg) {
   return function wrap() {
     return fn.apply(thisArg, arguments);


### PR DESCRIPTION
This PR involves a minor change and fixes issue #6751 
https://github.com/axios/axios/issues/6751

Description of the fix:
Loud comments have been added to certain files so that the minified versions of the file preserve the License comment.
