### PR TITLE
[Types]:  Improve TypeScript Language Server Suggestions for Adapter Names

### DIFF
--- a/index.d.cts
+++ b/index.d.cts
@@ -359,7 +359,7 @@ declare namespace axios {
 
   type Milliseconds = number;
 
-  type AxiosAdapterName = 'fetch' | 'xhr' | 'http' | string;
+  type AxiosAdapterName = 'fetch' | 'xhr' | 'http' | (string & {});
 
   type AxiosAdapterConfig = AxiosAdapter | AxiosAdapterName;
 


### PR DESCRIPTION
## What is this?
This PR addresses a TypeScript limitation that affects developer experience when working with Axios adapters. Currently, when defining custom adapters, developers lose language server suggestions for built-in adapter names ('fetch', 'xhr', 'http') due to TypeScript's type reduction behavior. This change implements a type-system workaround to preserve these the suggestions while maintaining full type safety and backward compatibility.

## Changes
### Code Changes:
1. **In `index.d.cts`**:
   - Modified `AxiosAdapterName` type definition to use the `string & {}` pattern:
     ```typescript
     - type AxiosAdapterName = 'fetch' | 'xhr' | 'http' | string;
     + type AxiosAdapterName = 'fetch' | 'xhr' | 'http' | (string & {});
     ```
   - This change preserves type hints for built-in adapters while still allowing custom adapter names
   - The modification leverages TypeScript's type system to prevent aggressive union type reduction
   - No runtime behavior changes - purely a type-level enhancement

## Technical Context
The change addresses the default TypeScript behavior where union types with `string` get reduced to just the looser `string`, losing specific literal suggestions. The `string & {}` pattern is a [documented](https://github.com/microsoft/TypeScript/issues/29729#issuecomment-505826972) workaround that prevents this reduction while maintaining the same type-safety guarantees.
