### PR TITLE
fix: empty window location in certain environments

### DIFF
--- a/lib/platform/common/utils.js
+++ b/lib/platform/common/utils.js
@@ -1,6 +1,7 @@
-const hasBrowserEnv = typeof window !== 'undefined' && typeof document !== 'undefined';
+const hasBrowserEnv =
+  typeof window !== "undefined" && typeof document !== "undefined";
 
-const _navigator = typeof navigator === 'object' && navigator || undefined;
+const _navigator = (typeof navigator === "object" && navigator) || undefined;
 
 /**
  * Determine if we're running in a standard browser environment
@@ -19,8 +20,10 @@ const _navigator = typeof navigator === 'object' && navigator || undefined;
  *
  * @returns {boolean}
  */
-const hasStandardBrowserEnv = hasBrowserEnv &&
-  (!_navigator || ['ReactNative', 'NativeScript', 'NS'].indexOf(_navigator.product) < 0);
+const hasStandardBrowserEnv =
+  hasBrowserEnv &&
+  (!_navigator ||
+    ["ReactNative", "NativeScript", "NS"].indexOf(_navigator.product) < 0);
 
 /**
  * Determine if we're running in a standard browser webWorker environment
@@ -33,19 +36,19 @@ const hasStandardBrowserEnv = hasBrowserEnv &&
  */
 const hasStandardBrowserWebWorkerEnv = (() => {
   return (
-    typeof WorkerGlobalScope !== 'undefined' &&
+    typeof WorkerGlobalScope !== "undefined" &&
     // eslint-disable-next-line no-undef
     self instanceof WorkerGlobalScope &&
-    typeof self.importScripts === 'function'
+    typeof self.importScripts === "function"
   );
 })();
 
-const origin = hasBrowserEnv && window.location.href || 'http://localhost';
+const origin = (hasBrowserEnv && window.location?.href) || "http://localhost";
 
 export {
   hasBrowserEnv,
   hasStandardBrowserWebWorkerEnv,
   hasStandardBrowserEnv,
   _navigator as navigator,
-  origin
-}
+  origin,
+};


### PR DESCRIPTION
Importing axios to handle POST / FormData requests in web workers in certain environments causes the import to fail.

In my case, I'm developing a Chrome extension with WXT. The extension is pre-rendered with Vite.
When axios is used in a background service worker which sends FormData, axios throws an error:
![Screenshot 2025-01-22 at 09 53 44](https://github.com/user-attachments/assets/672e4cd8-da4a-4ae9-9198-bdfa049a299d)
The reason for this is that `window.location` in such scenarios is undefined.
Since we're checking for the window URL using `window.location.href` just to determine the default origin, it's safe to add a conditional check that makes axios run in these environments, while still falling back to `localhost` as the origin in case `window.location` is undefined.

Note that adding the conditional also makes FormData requests (still) fully functional in web workers, and I haven't spotted any regression.