### PR TITLE
feat: use a Map instead of Array to remove items when using eject

### DIFF
--- a/lib/core/InterceptorManager.js
+++ b/lib/core/InterceptorManager.js
@@ -4,7 +4,7 @@ import utils from './../utils.js';
 
 class InterceptorManager {
   constructor() {
-    this.handlers = [];
+    this.handlers = new Map();
   }
 
   /**
@@ -16,13 +16,14 @@ class InterceptorManager {
    * @return {Number} An ID used to remove interceptor later
    */
   use(fulfilled, rejected, options) {
-    this.handlers.push({
+    const newSize = this.handlers.size + 1;
+    this.handlers.set(newSize,{
       fulfilled,
       rejected,
       synchronous: options ? options.synchronous : false,
       runWhen: options ? options.runWhen : null
     });
-    return this.handlers.length - 1;
+    return newSize;
   }
 
   /**
@@ -33,8 +34,8 @@ class InterceptorManager {
    * @returns {Boolean} `true` if the interceptor was removed, `false` otherwise
    */
   eject(id) {
-    if (this.handlers[id]) {
-      this.handlers[id] = null;
+    if (this.handlers.get(id)) {
+      this.handlers.delete(id);
     }
   }
 
@@ -45,7 +46,7 @@ class InterceptorManager {
    */
   clear() {
     if (this.handlers) {
-      this.handlers = [];
+      this.handlers.clear();
     }
   }
 
@@ -60,11 +61,9 @@ class InterceptorManager {
    * @returns {void}
    */
   forEach(fn) {
-    utils.forEach(this.handlers, function forEachHandler(h) {
-      if (h !== null) {
-        fn(h);
-      }
-    });
+    for (let h of this.handlers.values()) {
+        fn(h)
+    }
   }
 }
 


### PR DESCRIPTION
I change the handler type from Array to Map. this way every time someone need to remove a value, it will be deleted and not stored as a null value in an array 
