### PR TITLE
Include License Header in Minified JavaScript File

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -60,7 +60,7 @@ const buildConfig = ({es5, browser = true, minifiedVersion = true, alias, ...con
 
 export default async () => {
   const year = new Date().getFullYear();
-  const banner = `// Axios v${lib.version} Copyright (c) ${year} ${lib.author} and contributors`;
+  const banner = `/*! Axios v${lib.version} Copyright (c) ${year} ${lib.author} and contributors */`;
 
   return [
     // browser ESM bundle for CDN


### PR DESCRIPTION
Fixes issue #6751 by ensuring that the license header is included in the minified JavaScript file.