### PR TITLE
feat: add disableDefaultUserAgent Option

### DIFF
--- a/dist/node/axios.cjs
+++ b/dist/node/axios.cjs
@@ -2830,7 +2830,9 @@ const httpAdapter = isHttpAdapterSupported && function httpAdapter(config) {
     // See https://github.com/axios/axios/issues/69
     // User-Agent is specified; handle case where no UA header is desired
     // Only set header if it hasn't been set in config
-    headers.set('User-Agent', 'axios/' + VERSION, false);
+    if (!config.disableDefaultUserAgent) {
+      headers.set("User-Agent", "axios/" + VERSION, false);
+    }
 
     const {onUploadProgress, onDownloadProgress} = config;
     const maxRate = config.maxRate;

--- a/index.d.ts
+++ b/index.d.ts
@@ -359,6 +359,7 @@ export interface AxiosRequestConfig<D = any> {
       ((hostname: string, options: object) => Promise<[address: LookupAddressEntry | LookupAddressEntry[], family?: AddressFamily] | LookupAddress>);
   withXSRFToken?: boolean | ((config: InternalAxiosRequestConfig) => boolean | undefined);
   fetchOptions?: Record<string, any>;
+  disableDefaultUserAgent?: boolean;
 }
 
 // Alias

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -285,7 +285,9 @@ export default isHttpAdapterSupported && function httpAdapter(config) {
     // See https://github.com/axios/axios/issues/69
     // User-Agent is specified; handle case where no UA header is desired
     // Only set header if it hasn't been set in config
-    headers.set('User-Agent', 'axios/' + VERSION, false);
+    if(!config.disableDefaultUserAgent) {
+      headers.set('User-Agent', 'axios/' + VERSION, false);
+    }
 
     const {onUploadProgress, onDownloadProgress} = config;
     const maxRate = config.maxRate;


### PR DESCRIPTION
issue: #6780

I simply implemented the option I wanted.

How about adding an option like this?
```javascript
async function main() {
  const response = await axios.get('http://localhost:3333', {disableDefaultUserAgent:true})
  console.log(response)
}
main()
```