### PR TITLE
docs: Modify upgrade guide for 0.28.1's breaking change

### DIFF
--- a/UPGRADE_GUIDE.md
+++ b/UPGRADE_GUIDE.md
@@ -167,3 +167,24 @@ require(['bower_components/axios/dist/axios'], function (axios) {
 // CommonJS
 var axios = require('axios/dist/axios');
 ```
+
+## 0.28.x -> 0.28.1
+
+The way to pass in a custom parameter serializer has changed
+
+0.28.0
+```js
+axios.create({
+    paramsSerializer: (params) => {
+        return qs.stringify(params, { arrayFormat: 'repeat', skipNulls: true })
+    }, ...config);
+```
+now the serializer needs to be in under a new key:
+
+0.28.1
+```js
+axios.create({
+    paramsSerializer: {
+        serialize: (params) => qs.stringify(params, { arrayFormat: 'repeat', skipNulls: true }),
+    }, ...config);
+```


### PR DESCRIPTION
v0.28.1 introduced a breaking change to how custom serializers are passed to the axios object. This updates the upgrade doc to reflect this change.

I am new to this repository, so hopefully this helps. I spent a good part of day trying to track down this breaking change, and there are a number of existing issues and posts about a similar finding. Hopefully adding this to the upgrade guide will be useful. 
I'm more than happy to change the text or do some other fix. Hope this helps.
