### PR TITLE
fix: react native package exports support

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,12 +9,12 @@
         "require": "./index.d.cts",
         "default": "./index.d.ts"
       },
-      "browser": {
-        "require": "./dist/browser/axios.cjs",
+      "node": {
+        "require": "./dist/node/axios.cjs",
         "default": "./index.js"
       },
       "default": {
-        "require": "./dist/node/axios.cjs",
+        "require": "./dist/browser/axios.cjs",
         "default": "./index.js"
       }
     },


### PR DESCRIPTION
Currently, if package exports are used in [react native](https://reactnative.dev/blog/2023/06/21/package-exports-support#enabling-package-exports-beta). Axios breaks since node specific modules are imported.

This is because react native by default matches three conditional exports `['require', 'import', 'react-native']`. And if they are not present, it falls back to `default`.

Currently `default` matches `"./dist/node/axios.cjs"`  and so node specific modules are imported to react native.

In this PR, we move node imports to [node specifc conditional export](https://nodejs.org/api/packages.html#conditional-exports), which will match any node environment that supports package exports. And also makes sure that both browser and react-native will match the default. 
