### PR TITLE
fix(http-adapter): add allowAbsoluteUrls to path building

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -228,7 +228,7 @@ export default isHttpAdapterSupported && function httpAdapter(config) {
     }
 
     // Parse url
-    const fullPath = buildFullPath(config.baseURL, config.url);
+    const fullPath = buildFullPath(config.baseURL, config.url, config.allowAbsoluteUrls);
     const parsed = new URL(fullPath, platform.hasBrowserEnv ? platform.origin : undefined);
     const protocol = parsed.protocol || supportedProtocols[0];
 


### PR DESCRIPTION
Consider the `allowAbsoluteUrls` configuration option when building the request path in the `http` adapter. 

Fixes https://github.com/axios/axios/issues/6806
