### PR TITLE
fix(xhr/fetch): pass `allowAbsoluteUrls` to `buildFullPath` in `xhr` and `fetch` adapters

### DIFF
--- a/lib/helpers/resolveConfig.js
+++ b/lib/helpers/resolveConfig.js
@@ -14,7 +14,7 @@ export default (config) => {
 
   newConfig.headers = headers = AxiosHeaders.from(headers);
 
-  newConfig.url = buildURL(buildFullPath(newConfig.baseURL, newConfig.url), config.params, config.paramsSerializer);
+  newConfig.url = buildURL(buildFullPath(newConfig.baseURL, newConfig.url, newConfig.allowAbsoluteUrls), config.params, config.paramsSerializer);
 
   // HTTP basic authentication
   if (auth) {

--- a/test/specs/options.spec.js
+++ b/test/specs/options.spec.js
@@ -109,7 +109,7 @@ describe('options', function () {
     instance.get('http://someotherurl.com/');
 
     getAjaxRequest().then(function (request) {
-      expect(request.url).toBe('http://someotherurl.com/');
+      expect(request.url).toBe('http://someurl.com/http://someotherurl.com/');
       done();
     });
 


### PR DESCRIPTION
This PR ensures `config.allowAbsoluteUrls` takes effect in the `xhr` and `fetch` adapters. It is similar to https://github.com/axios/axios/pull/6810 (which was only for the `http` adapter).

Resolves https://github.com/axios/axios/issues/6806.