### PR TITLE
fix: add missing type for allowAbsoluteUrls

### DIFF
--- a/index.d.cts
+++ b/index.d.cts
@@ -376,6 +376,7 @@ declare namespace axios {
     url?: string;
     method?: Method | string;
     baseURL?: string;
+    allowAbsoluteUrls?: boolean,
     transformRequest?: AxiosRequestTransformer | AxiosRequestTransformer[];
     transformResponse?: AxiosResponseTransformer | AxiosResponseTransformer[];
     headers?: (RawAxiosRequestHeaders & MethodsHeaders) | AxiosHeaders;

--- a/index.d.cts
+++ b/index.d.cts
@@ -376,7 +376,7 @@ declare namespace axios {
     url?: string;
     method?: Method | string;
     baseURL?: string;
-    allowAbsoluteUrls?: boolean,
+    allowAbsoluteUrls?: boolean;
     transformRequest?: AxiosRequestTransformer | AxiosRequestTransformer[];
     transformResponse?: AxiosResponseTransformer | AxiosResponseTransformer[];
     headers?: (RawAxiosRequestHeaders & MethodsHeaders) | AxiosHeaders;

--- a/index.d.ts
+++ b/index.d.ts
@@ -317,7 +317,7 @@ export interface AxiosRequestConfig<D = any> {
   url?: string;
   method?: Method | string;
   baseURL?: string;
-  allowAbsoluteUrls?: boolean,
+  allowAbsoluteUrls?: boolean;
   transformRequest?: AxiosRequestTransformer | AxiosRequestTransformer[];
   transformResponse?: AxiosResponseTransformer | AxiosResponseTransformer[];
   headers?: (RawAxiosRequestHeaders & MethodsHeaders) | AxiosHeaders;

--- a/index.d.ts
+++ b/index.d.ts
@@ -317,6 +317,7 @@ export interface AxiosRequestConfig<D = any> {
   url?: string;
   method?: Method | string;
   baseURL?: string;
+  allowAbsoluteUrls?: boolean,
   transformRequest?: AxiosRequestTransformer | AxiosRequestTransformer[];
   transformResponse?: AxiosResponseTransformer | AxiosResponseTransformer[];
   headers?: (RawAxiosRequestHeaders & MethodsHeaders) | AxiosHeaders;

--- a/test/module/typings/cjs/index.ts
+++ b/test/module/typings/cjs/index.ts
@@ -3,6 +3,7 @@ import axios = require('axios');
 const config: axios.AxiosRequestConfig = {
   url: '/user',
   method: 'get',
+  allowAbsoluteUrls: false,
   baseURL: 'https://api.example.com/',
   transformRequest: (data: any) => '{"foo":"bar"}',
   transformResponse: [

--- a/test/module/typings/esm/index.ts
+++ b/test/module/typings/esm/index.ts
@@ -27,6 +27,7 @@ const config: AxiosRequestConfig = {
   url: '/user',
   method: 'get',
   baseURL: 'https://api.example.com/',
+  allowAbsoluteUrls: false,
   transformRequest: (data: any) => '{"foo":"bar"}',
   transformResponse: [
     (data: any) => ({ baz: 'qux' })


### PR DESCRIPTION
Adds the `allowAbsoluteUrls` field to the types and to the type tests.

Fixes #6817. 

It's my first PR to axios so I don't really know that much about how types are generated it. Hoping it's enough with changing it these two places.