### PR TITLE
fix(buildFullPath): handle `allowAbsoluteUrls: false` without `baseURL`

### DIFF
--- a/lib/core/buildFullPath.js
+++ b/lib/core/buildFullPath.js
@@ -15,7 +15,7 @@ import combineURLs from '../helpers/combineURLs.js';
  */
 export default function buildFullPath(baseURL, requestedURL, allowAbsoluteUrls) {
   let isRelativeUrl = !isAbsoluteURL(requestedURL);
-  if (baseURL && isRelativeUrl || allowAbsoluteUrls == false) {
+  if (baseURL && (isRelativeUrl || allowAbsoluteUrls == false)) {
     return combineURLs(baseURL, requestedURL);
   }
   return requestedURL;

--- a/test/specs/core/buildFullPath.spec.js
+++ b/test/specs/core/buildFullPath.spec.js
@@ -13,6 +13,10 @@ describe('helpers::buildFullPath', function () {
     expect(buildFullPath('https://api.github.com', 'https://api.example.com/users', false)).toBe('https://api.github.com/https://api.example.com/users');
   });
 
+  it('should not combine the URLs when the requestedURL is absolute, allowAbsoluteUrls is false, and the baseURL is not configured', function () {
+    expect(buildFullPath(undefined, 'https://api.example.com/users', false)).toBe('https://api.example.com/users');
+  });
+
   it('should not combine URLs when the baseURL is not configured', function () {
     expect(buildFullPath(undefined, '/users')).toBe('/users');
   });


### PR DESCRIPTION
This PR fixes the logic in `buildFullPath` to properly handle the case where `allowAbsoluteUrls` is `false` and `baseURL` is `undefined`; currently, it throws a `TypeError`.

Resolves https://github.com/axios/axios/issues/6832.