### PR TITLE
fix(canceled-error): break cyclic reference to prevent JSON.stringify…

### DIFF
--- a/lib/cancel/CanceledError.js
+++ b/lib/cancel/CanceledError.js
@@ -16,6 +16,21 @@ function CanceledError(message, config, request) {
   // eslint-disable-next-line no-eq-null,eqeqeq
   AxiosError.call(this, message == null ? 'canceled' : message, AxiosError.ERR_CANCELED, config, request);
   this.name = 'CanceledError';
+
+  //Clone the config to break cyclic references
+  if(config && typeof config === 'object') {
+    this.config = { ...config };
+
+    //If cancelToken exists , clone it and remove the 'reason' property to break the cycle.
+    if(this.config.cancelToken && typeof this.config.cancelToken === 'object') {
+      this.config.cancelToken = { ...this.config.cancelToken };
+      if(this.config.cancelToken.reason) {
+        delete this.config.cancelToken.reason;
+      }
+    }
+  } else {
+    this.config = config;
+  }
 }
 
 utils.inherits(CanceledError, AxiosError, {


### PR DESCRIPTION
The cyclic reference between error.config and config.cancelToken (where cancelToken.reason points back to config) caused JSON.stringify to overflow. This commit clones the config and cancelToken objects and deletes the 'reason' property to break the cycle while preserving that cancelToken was provided.

Fixes #6815

<!-- Click "Preview" for a more readable version -->



Describe your pull request here.
