### PR TITLE
add allowAbsoluteUrls type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -135,6 +135,7 @@ export interface AxiosRequestConfig<D = any> {
   url?: string;
   method?: Method | string;
   baseURL?: string;
+  allowAbsoluteUrls?: boolean;
   transformRequest?: AxiosRequestTransformer | AxiosRequestTransformer[];
   transformResponse?: AxiosResponseTransformer | AxiosResponseTransformer[];
   headers?: AxiosRequestHeaders;


### PR DESCRIPTION
* Follow up to https://github.com/axios/axios/pull/6829
* add allowAbsoluteUrls attribute to the `AxiosRequestConfig<D=any>` interface


Issue: https://github.com/axios/axios/issues/6850