### PR TITLE
fix(core): fix the Axios constructor implementation to treat the config argument as optional;

### DIFF
--- a/lib/core/Axios.js
+++ b/lib/core/Axios.js
@@ -20,7 +20,7 @@ const validators = validator.validators;
  */
 class Axios {
   constructor(instanceConfig) {
-    this.defaults = instanceConfig;
+    this.defaults = instanceConfig || {};
     this.interceptors = {
       request: new InterceptorManager(),
       response: new InterceptorManager()

--- a/test/unit/core/Axios.js
+++ b/test/unit/core/Axios.js
@@ -43,5 +43,11 @@ describe('Axios', function () {
         }
       })
     });
-  })
+  });
+
+  it('should not throw if the config argument is omitted', () => {
+    const axios = new Axios();
+
+    assert.deepStrictEqual(axios.defaults, {});
+  });
 });


### PR DESCRIPTION
Fixes #6879 