### PR TITLE
feat(http): add support for zstd decompression in HTTP adapter

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -36,7 +36,14 @@ const brotliOptions = {
   finishFlush: zlib.constants.BROTLI_OPERATION_FLUSH
 }
 
+const zstdOptions = {
+  flush: zlib.constants.ZSTD_e_flush,
+  finishFlush: zlib.constants.ZSTD_e_flush
+}
+
 const isBrotliSupported = utils.isFunction(zlib.createBrotliDecompress);
+
+const isZstdSupported = utils.isFunction(zlib.createZstdDecompress);
 
 const {http: httpFollow, https: httpsFollow} = followRedirects;
 
@@ -524,6 +531,13 @@ export default isHttpAdapterSupported && function httpAdapter(config) {
             streams.push(zlib.createBrotliDecompress(brotliOptions));
             delete res.headers['content-encoding'];
           }
+          break;
+        case 'zstd':
+          if (isZstdSupported) {
+            streams.push(zlib.createZstdDecompress(zstdOptions));
+            delete res.headers['content-encoding'];
+          }
+          break;
         }
       }
 


### PR DESCRIPTION
#### Instructions

zstd has become stable since node v22.15.0, Chrome v123 and Firefox v126, we should support it.

https://nodejs.org/en/blog/release/v22.15.0