### PR TITLE
feat: add Undici adapter

### DIFF
--- a/index.d.cts
+++ b/index.d.cts
@@ -359,7 +359,7 @@ declare namespace axios {
 
   type Milliseconds = number;
 
-  type AxiosAdapterName = 'fetch' | 'xhr' | 'http' | (string & {});
+  type AxiosAdapterName = 'fetch' | 'xhr' | 'http' | 'undici' | (string & {});
 
   type AxiosAdapterConfig = AxiosAdapter | AxiosAdapterName;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -302,7 +302,7 @@ export interface AxiosProgressEvent {
 
 type Milliseconds = number;
 
-type AxiosAdapterName = 'fetch' | 'xhr' | 'http' | (string & {});
+type AxiosAdapterName = 'fetch' | 'xhr' | 'http' | 'undici' | (string & {});
 
 type AxiosAdapterConfig = AxiosAdapter | AxiosAdapterName;
 

--- a/lib/adapters/adapters.js
+++ b/lib/adapters/adapters.js
@@ -2,12 +2,14 @@ import utils from '../utils.js';
 import httpAdapter from './http.js';
 import xhrAdapter from './xhr.js';
 import fetchAdapter from './fetch.js';
+import undiciAdapter from './undici.js';
 import AxiosError from "../core/AxiosError.js";
 
 const knownAdapters = {
   http: httpAdapter,
   xhr: xhrAdapter,
-  fetch: fetchAdapter
+  fetch: fetchAdapter,
+  undici: undiciAdapter
 }
 
 utils.forEach(knownAdapters, (fn, value) => {

--- a/lib/adapters/undici.js
+++ b/lib/adapters/undici.js
@@ -1,0 +1,229 @@
+import platform from "../platform/index.js";
+import utils from "../utils.js";
+import AxiosError from "../core/AxiosError.js";
+import composeSignals from "../helpers/composeSignals.js";
+import {trackStream} from "../helpers/trackStream.js";
+import AxiosHeaders from "../core/AxiosHeaders.js";
+import {progressEventReducer, progressEventDecorator, asyncDecorator} from "../helpers/progressEventReducer.js";
+import resolveConfig from "../helpers/resolveConfig.js";
+import settle from "../core/settle.js";
+
+const isFetchSupported = typeof fetch === 'function' && typeof Request === 'function' && typeof Response === 'function';
+const isReadableStreamSupported = isFetchSupported && typeof ReadableStream === 'function';
+
+// used only inside the fetch adapter
+const encodeText = isFetchSupported && (typeof TextEncoder === 'function' ?
+    ((encoder) => (str) => encoder.encode(str))(new TextEncoder()) :
+    async (str) => new Uint8Array(await new Response(str).arrayBuffer())
+);
+
+const test = (fn, ...args) => {
+  try {
+    return !!fn(...args);
+  } catch (e) {
+    return false
+  }
+}
+
+const supportsRequestStream = isReadableStreamSupported && test(() => {
+  let duplexAccessed = false;
+
+  const hasContentType = new Request(platform.origin, {
+    body: new ReadableStream(),
+    method: 'POST',
+    get duplex() {
+      duplexAccessed = true;
+      return 'half';
+    },
+  }).headers.has('Content-Type');
+
+  return duplexAccessed && !hasContentType;
+});
+
+const DEFAULT_CHUNK_SIZE = 64 * 1024;
+
+const supportsResponseStream = isReadableStreamSupported &&
+  test(() => utils.isReadableStream(new Response('').body));
+
+
+const resolvers = {
+  stream: supportsResponseStream && ((res) => res.body)
+};
+
+isFetchSupported && (((res) => {
+  ['text', 'arrayBuffer', 'blob', 'formData', 'stream'].forEach(type => {
+    !resolvers[type] && (resolvers[type] = utils.isFunction(res[type]) ? (res) => res[type]() :
+      (_, config) => {
+        throw new AxiosError(`Response type '${type}' is not supported`, AxiosError.ERR_NOT_SUPPORT, config);
+      })
+  });
+})(new Response));
+
+const getBodyLength = async (body) => {
+  if (body == null) {
+    return 0;
+  }
+
+  if(utils.isBlob(body)) {
+    return body.size;
+  }
+
+  if(utils.isSpecCompliantForm(body)) {
+    const _request = new Request(platform.origin, {
+      method: 'POST',
+      body,
+    });
+    return (await _request.arrayBuffer()).byteLength;
+  }
+
+  if(utils.isArrayBufferView(body) || utils.isArrayBuffer(body)) {
+    return body.byteLength;
+  }
+
+  if(utils.isURLSearchParams(body)) {
+    body = body + '';
+  }
+
+  if(utils.isString(body)) {
+    return (await encodeText(body)).byteLength;
+  }
+}
+
+const resolveBodyLength = async (headers, body) => {
+  const length = utils.toFiniteNumber(headers.getContentLength());
+
+  return length == null ? getBodyLength(body) : length;
+}
+
+export default isFetchSupported && (async (config) => {
+  let {
+    url,
+    method,
+    data,
+    signal,
+    cancelToken,
+    timeout,
+    onDownloadProgress,
+    onUploadProgress,
+    responseType,
+    headers,
+    withCredentials = 'same-origin',
+    fetchOptions
+  } = resolveConfig(config);
+
+  responseType = responseType ? (responseType + '').toLowerCase() : 'text';
+
+  let composedSignal = composeSignals([signal, cancelToken && cancelToken.toAbortSignal()], timeout);
+
+  let request;
+
+  const unsubscribe = composedSignal && composedSignal.unsubscribe && (() => {
+      composedSignal.unsubscribe();
+  });
+
+  let requestContentLength;
+
+  try {
+    if (
+      onUploadProgress && supportsRequestStream && method !== 'get' && method !== 'head' &&
+      (requestContentLength = await resolveBodyLength(headers, data)) !== 0
+    ) {
+      let _request = new Request(url, {
+        method: 'POST',
+        body: data,
+        duplex: "half"
+      });
+
+      let contentTypeHeader;
+
+      if (utils.isFormData(data) && (contentTypeHeader = _request.headers.get('content-type'))) {
+        headers.setContentType(contentTypeHeader)
+      }
+
+      if (_request.body) {
+        const [onProgress, flush] = progressEventDecorator(
+          requestContentLength,
+          progressEventReducer(asyncDecorator(onUploadProgress))
+        );
+
+        data = trackStream(_request.body, DEFAULT_CHUNK_SIZE, onProgress, flush);
+      }
+    }
+
+    if (!utils.isString(withCredentials)) {
+      withCredentials = withCredentials ? 'include' : 'omit';
+    }
+
+    // Cloudflare Workers throws when credentials are defined
+    // see https://github.com/cloudflare/workerd/issues/902
+    const isCredentialsSupported = "credentials" in Request.prototype;
+    request = new Request(url, {
+      ...fetchOptions,
+      signal: composedSignal,
+      method: method.toUpperCase(),
+      headers: headers.normalize().toJSON(),
+      body: data,
+      duplex: "half",
+      credentials: isCredentialsSupported ? withCredentials : undefined
+    });
+
+    let response = await fetch(request);
+
+    const isStreamResponse = supportsResponseStream && (responseType === 'stream' || responseType === 'response');
+
+    if (supportsResponseStream && (onDownloadProgress || (isStreamResponse && unsubscribe))) {
+      const options = {};
+
+      ['status', 'statusText', 'headers'].forEach(prop => {
+        options[prop] = response[prop];
+      });
+
+      const responseContentLength = utils.toFiniteNumber(response.headers.get('content-length'));
+
+      const [onProgress, flush] = onDownloadProgress && progressEventDecorator(
+        responseContentLength,
+        progressEventReducer(asyncDecorator(onDownloadProgress), true)
+      ) || [];
+
+      response = new Response(
+        trackStream(response.body, DEFAULT_CHUNK_SIZE, onProgress, () => {
+          flush && flush();
+          unsubscribe && unsubscribe();
+        }),
+        options
+      );
+    }
+
+    responseType = responseType || 'text';
+
+    let responseData = await resolvers[utils.findKey(resolvers, responseType) || 'text'](response, config);
+
+    !isStreamResponse && unsubscribe && unsubscribe();
+
+    return await new Promise((resolve, reject) => {
+      settle(resolve, reject, {
+        data: responseData,
+        headers: AxiosHeaders.from(response.headers),
+        status: response.status,
+        statusText: response.statusText,
+        config,
+        request
+      })
+    })
+  } catch (err) {
+    unsubscribe && unsubscribe();
+
+    if (err && err.name === 'TypeError' && /Load failed|fetch/i.test(err.message)) {
+      throw Object.assign(
+        new AxiosError('Network Error', AxiosError.ERR_NETWORK, config, request),
+        {
+          cause: err.cause || err
+        }
+      )
+    }
+
+    throw AxiosError.from(err, err && err.code, config, request);
+  }
+});
+
+

--- a/lib/adapters/undici.js
+++ b/lib/adapters/undici.js
@@ -7,6 +7,7 @@ import AxiosHeaders from "../core/AxiosHeaders.js";
 import {progressEventReducer, progressEventDecorator, asyncDecorator} from "../helpers/progressEventReducer.js";
 import resolveConfig from "../helpers/resolveConfig.js";
 import settle from "../core/settle.js";
+import undici from "undici";
 
 const isFetchSupported = typeof fetch === 'function' && typeof Request === 'function' && typeof Response === 'function';
 const isReadableStreamSupported = isFetchSupported && typeof ReadableStream === 'function';
@@ -157,7 +158,7 @@ export default isFetchSupported && (async (config) => {
     // Cloudflare Workers throws when credentials are defined
     // see https://github.com/cloudflare/workerd/issues/902
     const isCredentialsSupported = "credentials" in Request.prototype;
-    request = new Request(url, {
+    request = [url, {
       ...fetchOptions,
       signal: composedSignal,
       method: method.toUpperCase(),
@@ -165,9 +166,9 @@ export default isFetchSupported && (async (config) => {
       body: data,
       duplex: "half",
       credentials: isCredentialsSupported ? withCredentials : undefined
-    });
+    }];
 
-    let response = await fetch(request);
+    let response = await undici.fetch(...request);
 
     const isStreamResponse = supportsResponseStream && (responseType === 'stream' || responseType === 'response');
 
@@ -206,8 +207,7 @@ export default isFetchSupported && (async (config) => {
         headers: AxiosHeaders.from(response.headers),
         status: response.status,
         statusText: response.statusText,
-        config,
-        request
+        config
       })
     })
   } catch (err) {
@@ -215,14 +215,14 @@ export default isFetchSupported && (async (config) => {
 
     if (err && err.name === 'TypeError' && /Load failed|fetch/i.test(err.message)) {
       throw Object.assign(
-        new AxiosError('Network Error', AxiosError.ERR_NETWORK, config, request),
+        new AxiosError('Network Error', AxiosError.ERR_NETWORK, config),
         {
           cause: err.cause || err
         }
       )
     }
 
-    throw AxiosError.from(err, err && err.code, config, request);
+    throw AxiosError.from(err, err && err.code, config);
   }
 });
 

--- a/lib/adapters/undici.js
+++ b/lib/adapters/undici.js
@@ -7,13 +7,12 @@ import AxiosHeaders from "../core/AxiosHeaders.js";
 import {progressEventReducer, progressEventDecorator, asyncDecorator} from "../helpers/progressEventReducer.js";
 import resolveConfig from "../helpers/resolveConfig.js";
 import settle from "../core/settle.js";
-import undici from "undici";
+import undici, {Request, Response} from "undici";
 
-const isFetchSupported = typeof fetch === 'function' && typeof Request === 'function' && typeof Response === 'function';
-const isReadableStreamSupported = isFetchSupported && typeof ReadableStream === 'function';
+const isReadableStreamSupported = typeof ReadableStream === 'function';
 
 // used only inside the fetch adapter
-const encodeText = isFetchSupported && (typeof TextEncoder === 'function' ?
+const encodeText = (typeof TextEncoder === 'function' ?
     ((encoder) => (str) => encoder.encode(str))(new TextEncoder()) :
     async (str) => new Uint8Array(await new Response(str).arrayBuffer())
 );
@@ -55,7 +54,7 @@ const resolvers = {
   text: (res) => res.text(),
 };
 
-isFetchSupported && (((res) => {
+(((res) => {
   ['formData', 'stream'].forEach(type => {
     !resolvers[type] && (resolvers[type] = utils.isFunction(res[type]) ? (res) => res[type]() :
       (_, config) => {
@@ -157,7 +156,7 @@ export default (async (config) => {
       withCredentials = withCredentials ? 'include' : 'omit';
     }
 
-    const useUndiciFetch = isFetchSupported && (
+    const useUndiciFetch = (
       responseType === 'stream' ||
       responseType === 'response' ||
       responseType === 'formdata' ||

--- a/lib/adapters/undici.js
+++ b/lib/adapters/undici.js
@@ -111,8 +111,7 @@ export default (async (config) => {
     onUploadProgress,
     responseType,
     headers,
-    withCredentials = 'same-origin',
-    fetchOptions
+    withCredentials = 'same-origin'
   } = resolveConfig(config);
 
   responseType = responseType ? (responseType + '').toLowerCase() : 'text';
@@ -165,26 +164,26 @@ export default (async (config) => {
 
     let response;
 
+    const requestOptions = {
+      signal: composedSignal,
+      method: method.toUpperCase(),
+      headers: headers.normalize().toJSON(),
+      body: data,
+    };
+
     if (useUndiciFetch) {
       // Cloudflare Workers throws when credentials are defined
       // see https://github.com/cloudflare/workerd/issues/902
       const isCredentialsSupported = "credentials" in Request.prototype;
       response = await undici.fetch(url, {
-        ...fetchOptions,
-        signal: composedSignal,
-        method: method.toUpperCase(),
-        headers: headers.normalize().toJSON(),
-        body: data,
+        ...requestOptions,
         duplex: "half",
         credentials: isCredentialsSupported ? withCredentials : undefined
       });
     } else {
       response = await undici.request(url, {
-        ...fetchOptions,
-        signal: composedSignal,
-        method: method.toUpperCase(),
-        headers: headers.normalize().toJSON(),
-        body: data
+        ...requestOptions,
+        maxRedirections: config.maxRedirects,
       });
     }
 

--- a/lib/adapters/undici.js
+++ b/lib/adapters/undici.js
@@ -9,10 +9,10 @@ import resolveConfig from "../helpers/resolveConfig.js";
 import settle from "../core/settle.js";
 import undici, {Request, Response} from "undici";
 
-const isReadableStreamSupported = typeof ReadableStream === 'function';
+const isReadableStreamSupported = platform.isNode && typeof ReadableStream === 'function';
 
 // used only inside the fetch adapter
-const encodeText = (typeof TextEncoder === 'function' ?
+const encodeText = platform.isNode && (typeof TextEncoder === 'function' ?
     ((encoder) => (str) => encoder.encode(str))(new TextEncoder()) :
     async (str) => new Uint8Array(await new Response(str).arrayBuffer())
 );
@@ -54,7 +54,7 @@ const resolvers = {
   text: (res) => res.text(),
 };
 
-(((res) => {
+platform.isNode && (((res) => {
   ['formData', 'stream'].forEach(type => {
     !resolvers[type] && (resolvers[type] = utils.isFunction(res[type]) ? (res) => res[type]() :
       (_, config) => {
@@ -99,7 +99,7 @@ const resolveBodyLength = async (headers, body) => {
   return length == null ? getBodyLength(body) : length;
 }
 
-export default (async (config) => {
+export default platform.isNode && (async (config) => {
   let {
     url,
     method,

--- a/lib/adapters/undici.js
+++ b/lib/adapters/undici.js
@@ -220,6 +220,15 @@ export default (async (config) => {
       config
     );
 
+    // convert Undici FormData to native FormData
+    if (responseType === 'formdata') {
+      const formData = new FormData();
+      for (const entry of responseData) {
+        formData.append(...entry);
+      }
+      responseData = formData;
+    }
+
     !isStreamResponse && unsubscribe && unsubscribe();
 
     return await new Promise((resolve, reject) => {

--- a/lib/adapters/undici.js
+++ b/lib/adapters/undici.js
@@ -227,16 +227,13 @@ export default isFetchSupported && (async (config) => {
         config
       })
     })
-  } catch (err) {
+  } catch (_err) {
     unsubscribe && unsubscribe();
 
+    let err = _err;
+
     if (err && err.name === 'TypeError' && /Load failed|fetch/i.test(err.message)) {
-      throw Object.assign(
-        new AxiosError('Network Error', AxiosError.ERR_NETWORK, config),
-        {
-          cause: err.cause || err
-        }
-      )
+      err = _err.cause;
     }
 
     throw AxiosError.from(err, err && err.code, config);

--- a/lib/adapters/undici.js
+++ b/lib/adapters/undici.js
@@ -100,7 +100,7 @@ const resolveBodyLength = async (headers, body) => {
   return length == null ? getBodyLength(body) : length;
 }
 
-export default isFetchSupported && (async (config) => {
+export default (async (config) => {
   let {
     url,
     method,
@@ -157,7 +157,12 @@ export default isFetchSupported && (async (config) => {
       withCredentials = withCredentials ? 'include' : 'omit';
     }
 
-    const useUndiciFetch = responseType === 'stream' || responseType === 'response' || responseType === 'formdata';
+    const useUndiciFetch = isFetchSupported && (
+      responseType === 'stream' ||
+      responseType === 'response' ||
+      responseType === 'formdata' ||
+      onDownloadProgress
+    );
 
     let response;
 

--- a/lib/adapters/undici.js
+++ b/lib/adapters/undici.js
@@ -48,11 +48,15 @@ const supportsResponseStream = isReadableStreamSupported &&
 
 
 const resolvers = {
-  stream: supportsResponseStream && ((res) => res.body)
+  stream: supportsResponseStream && ((res) => res.body),
+  arraybuffer: (res) => res.arrayBuffer(),
+  blob: (res) => res.blob(),
+  json: (res) => res.json(),
+  text: (res) => res.text(),
 };
 
 isFetchSupported && (((res) => {
-  ['text', 'arrayBuffer', 'blob', 'formData', 'stream'].forEach(type => {
+  ['formData', 'stream'].forEach(type => {
     !resolvers[type] && (resolvers[type] = utils.isFunction(res[type]) ? (res) => res[type]() :
       (_, config) => {
         throw new AxiosError(`Response type '${type}' is not supported`, AxiosError.ERR_NOT_SUPPORT, config);
@@ -116,8 +120,6 @@ export default isFetchSupported && (async (config) => {
 
   let composedSignal = composeSignals([signal, cancelToken && cancelToken.toAbortSignal()], timeout);
 
-  let request;
-
   const unsubscribe = composedSignal && composedSignal.unsubscribe && (() => {
       composedSignal.unsubscribe();
   });
@@ -155,20 +157,32 @@ export default isFetchSupported && (async (config) => {
       withCredentials = withCredentials ? 'include' : 'omit';
     }
 
-    // Cloudflare Workers throws when credentials are defined
-    // see https://github.com/cloudflare/workerd/issues/902
-    const isCredentialsSupported = "credentials" in Request.prototype;
-    request = [url, {
-      ...fetchOptions,
-      signal: composedSignal,
-      method: method.toUpperCase(),
-      headers: headers.normalize().toJSON(),
-      body: data,
-      duplex: "half",
-      credentials: isCredentialsSupported ? withCredentials : undefined
-    }];
+    const useUndiciFetch = responseType === 'stream' || responseType === 'response' || responseType === 'formdata';
 
-    let response = await undici.fetch(...request);
+    let response;
+
+    if (useUndiciFetch) {
+      // Cloudflare Workers throws when credentials are defined
+      // see https://github.com/cloudflare/workerd/issues/902
+      const isCredentialsSupported = "credentials" in Request.prototype;
+      response = await undici.fetch(url, {
+        ...fetchOptions,
+        signal: composedSignal,
+        method: method.toUpperCase(),
+        headers: headers.normalize().toJSON(),
+        body: data,
+        duplex: "half",
+        credentials: isCredentialsSupported ? withCredentials : undefined
+      });
+    } else {
+      response = await undici.request(url, {
+        ...fetchOptions,
+        signal: composedSignal,
+        method: method.toUpperCase(),
+        headers: headers.normalize().toJSON(),
+        body: data
+      });
+    }
 
     const isStreamResponse = supportsResponseStream && (responseType === 'stream' || responseType === 'response');
 
@@ -197,7 +211,10 @@ export default isFetchSupported && (async (config) => {
 
     responseType = responseType || 'text';
 
-    let responseData = await resolvers[utils.findKey(resolvers, responseType) || 'text'](response, config);
+    let responseData = await resolvers[utils.findKey(resolvers, responseType) || 'text'](
+      useUndiciFetch ? response : response.body,
+      config
+    );
 
     !isStreamResponse && unsubscribe && unsubscribe();
 

--- a/lib/defaults/index.js
+++ b/lib/defaults/index.js
@@ -37,7 +37,7 @@ const defaults = {
 
   transitional: transitionalDefaults,
 
-  adapter: ['xhr', 'http', 'fetch'],
+  adapter: ['xhr', 'http', 'fetch', 'undici'],
 
   transformRequest: [function transformRequest(data, headers) {
     const contentType = headers.getContentType() || '';

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,8 @@
         "stream-throttle": "^0.1.3",
         "string-replace-async": "^3.0.2",
         "terser-webpack-plugin": "^4.2.3",
-        "typescript": "^4.9.5"
+        "typescript": "^4.9.5",
+        "undici": "^7.8.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -22849,6 +22850,16 @@
       "integrity": "sha512-Ia0sQNrMPXXkqVFt6w6M1n1oKo3NfKs+mvaV811Jwir7vAk9a6PVV9VPYf6X3BU97QiLEmuW3uXH9u87zDFfdw==",
       "dev": true
     },
+    "node_modules/undici": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.8.0.tgz",
+      "integrity": "sha512-vFv1GA99b7eKO1HG/4RPu2Is3FBTWBrmzqzO0mz+rLxN3yXkE4mqRcb8g8fHxzX4blEysrNZLqg5RbJLqX5buA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz",
@@ -42759,6 +42770,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/undertaker-registry/-/undertaker-registry-1.0.1.tgz",
       "integrity": "sha512-UR1khWeAjugW3548EfQmL9Z7pGMlBgXteQpr1IZeZBtnkCJQJIJ1Scj0mb9wQaPvUZ9Q17XqW6TIaPchJkyfqw==",
+      "dev": true
+    },
+    "undici": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.8.0.tgz",
+      "integrity": "sha512-vFv1GA99b7eKO1HG/4RPu2Is3FBTWBrmzqzO0mz+rLxN3yXkE4mqRcb8g8fHxzX4blEysrNZLqg5RbJLqX5buA==",
       "dev": true
     },
     "unicode-canonical-property-names-ecmascript": {

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "@commitlint/cli": "^17.8.1",
     "@commitlint/config-conventional": "^17.8.1",
     "@release-it/conventional-changelog": "^5.1.1",
+    "@rollup/plugin-alias": "^5.1.0",
     "@rollup/plugin-babel": "^5.3.1",
     "@rollup/plugin-commonjs": "^15.1.0",
     "@rollup/plugin-json": "^4.1.0",
@@ -136,7 +137,7 @@
     "string-replace-async": "^3.0.2",
     "terser-webpack-plugin": "^4.2.3",
     "typescript": "^4.9.5",
-    "@rollup/plugin-alias": "^5.1.0"
+    "undici": "^7.8.0"
   },
   "browser": {
     "./lib/adapters/http.js": "./lib/helpers/null.js",

--- a/test/unit/adapters/undici.js
+++ b/test/unit/adapters/undici.js
@@ -1,0 +1,391 @@
+import assert from 'assert';
+import {
+  startHTTPServer,
+  stopHTTPServer,
+  LOCAL_SERVER_URL,
+  setTimeoutAsync,
+  makeReadableStream,
+  generateReadable,
+  makeEchoStream
+} from '../../helpers/server.js';
+import axios from '../../../index.js';
+import stream from "stream";
+import {AbortController} from "abortcontroller-polyfill/dist/cjs-ponyfill.js";
+import util from "util";
+
+const pipelineAsync = util.promisify(stream.pipeline);
+
+const undiciAxios = axios.create({
+  baseURL: LOCAL_SERVER_URL,
+  adapter: 'undici'
+});
+
+let server;
+
+describe('supports undici with nodejs', function () {
+
+  afterEach(async function () {
+    await stopHTTPServer(server);
+
+    server = null;
+  });
+
+  describe('responses', async () => {
+    it(`should support text response type`, async () => {
+      const originalData = 'my data';
+
+      server = await startHTTPServer((req, res) => res.end(originalData));
+
+      const {data} = await undiciAxios.get('/', {
+        responseType: 'text'
+      });
+
+      assert.deepStrictEqual(data, originalData);
+    });
+
+    it(`should support arraybuffer response type`, async () => {
+      const originalData = 'my data';
+
+      server = await startHTTPServer((req, res) => res.end(originalData));
+
+      const {data} = await undiciAxios.get('/', {
+        responseType: 'arraybuffer'
+      });
+
+      assert.deepStrictEqual(data, Uint8Array.from(await new TextEncoder().encode(originalData)).buffer);
+    });
+
+    it(`should support blob response type`, async () => {
+      const originalData = 'my data';
+
+      server = await startHTTPServer((req, res) => res.end(originalData));
+
+      const {data} = await undiciAxios.get('/', {
+        responseType: 'blob'
+      });
+
+      assert.deepStrictEqual(data, new Blob([originalData]));
+    });
+
+    it(`should support stream response type`, async () => {
+      const originalData = 'my data';
+
+      server = await startHTTPServer((req, res) => res.end(originalData));
+
+      const {data} = await undiciAxios.get('/', {
+        responseType: 'stream'
+      });
+
+      assert.ok(data instanceof ReadableStream, 'data is not instanceof ReadableStream');
+
+      let response = new Response(data);
+
+      assert.deepStrictEqual(await response.text(), originalData);
+    });
+
+    it(`should support formData response type`, async function () {
+      this.timeout(5000);
+
+      const originalData = new FormData();
+
+      originalData.append('x', '123');
+
+      server = await startHTTPServer(async (req, res) => {
+
+        const response = await new Response(originalData);
+
+        res.setHeader('Content-Type', response.headers.get('Content-Type'));
+
+        res.end(await response.text());
+      });
+
+      const {data} = await undiciAxios.get('/', {
+        responseType: 'formdata'
+      });
+
+      assert.ok(data instanceof FormData, 'data is not instanceof FormData');
+
+      assert.deepStrictEqual(Object.fromEntries(data.entries()), Object.fromEntries(originalData.entries()));
+    });
+
+    it(`should support json response type`, async () => {
+      const originalData = {x: 'my data'};
+
+      server = await startHTTPServer((req, res) => res.end(JSON.stringify(originalData)));
+
+      const {data} = await undiciAxios.get('/', {
+        responseType: 'json'
+      });
+
+      assert.deepStrictEqual(data, originalData);
+    });
+  });
+
+  describe("progress", () => {
+    describe('upload', function () {
+      it('should support upload progress capturing', async function () {
+        this.timeout(15000);
+
+        server = await startHTTPServer({
+          rate: 100 * 1024
+        });
+
+        let content = '';
+        const count = 10;
+        const chunk = "test";
+        const chunkLength = Buffer.byteLength(chunk);
+        const contentLength = count * chunkLength;
+
+        const readable = stream.Readable.from(async function* () {
+          let i = count;
+
+          while (i-- > 0) {
+            await setTimeoutAsync(1100);
+            content += chunk;
+            yield chunk;
+          }
+        }());
+
+        const samples = [];
+
+        const {data} = await undiciAxios.post('/', readable, {
+          onUploadProgress: ({loaded, total, progress, bytes, upload}) => {
+            console.log(`Upload Progress ${loaded} from ${total} bytes (${(progress * 100).toFixed(1)}%)`);
+
+            samples.push({
+              loaded,
+              total,
+              progress,
+              bytes,
+              upload
+            });
+          },
+          headers: {
+            'Content-Length': contentLength
+          },
+          responseType: 'text'
+        });
+
+        await setTimeoutAsync(500);
+
+        assert.strictEqual(data, content);
+
+        assert.deepStrictEqual(samples, Array.from(function* () {
+          for (let i = 1; i <= 10; i++) {
+            yield ({
+              loaded: chunkLength * i,
+              total: contentLength,
+              progress: (chunkLength * i) / contentLength,
+              bytes: 4,
+              upload: true
+            });
+          }
+        }()));
+      });
+
+      it('should not fail with get method', async() => {
+        server = await startHTTPServer((req, res) => res.end('OK'));
+
+        const {data} = await undiciAxios.get('/', {
+          onUploadProgress() {
+
+          }
+        });
+
+        assert.strictEqual(data, 'OK');
+      });
+    });
+
+    describe('download', function () {
+      it('should support download progress capturing', async function () {
+        this.timeout(15000);
+
+        server = await startHTTPServer({
+          rate: 100 * 1024
+        });
+
+        let content = '';
+        const count = 10;
+        const chunk = "test";
+        const chunkLength = Buffer.byteLength(chunk);
+        const contentLength = count * chunkLength;
+
+        const readable = stream.Readable.from(async function* () {
+          let i = count;
+
+          while (i-- > 0) {
+            await setTimeoutAsync(1100);
+            content += chunk;
+            yield chunk;
+          }
+        }());
+
+        const samples = [];
+
+        const {data} = await undiciAxios.post('/', readable, {
+          onDownloadProgress: ({loaded, total, progress, bytes, download}) => {
+            console.log(`Download Progress ${loaded} from ${total} bytes (${(progress * 100).toFixed(1)}%)`);
+
+            samples.push({
+              loaded,
+              total,
+              progress,
+              bytes,
+              download
+            });
+          },
+          headers: {
+            'Content-Length': contentLength
+          },
+          responseType: 'text',
+          maxRedirects: 0
+        });
+
+        await setTimeoutAsync(500);
+
+        assert.strictEqual(data, content);
+
+        assert.deepStrictEqual(samples, Array.from(function* () {
+          for (let i = 1; i <= 10; i++) {
+            yield ({
+              loaded: chunkLength * i,
+              total: contentLength,
+              progress: (chunkLength * i) / contentLength,
+              bytes: 4,
+              download: true
+            });
+          }
+        }()));
+      });
+    });
+  });
+
+  it('should support basic auth', async () => {
+    server = await startHTTPServer((req, res) => res.end(req.headers.authorization));
+
+    const user = 'foo';
+    const headers = {Authorization: 'Bearer 1234'};
+    const res = await axios.get('http://' + user + '@localhost:4444/', {headers: headers});
+
+    const base64 = Buffer.from(user + ':', 'utf8').toString('base64');
+    assert.equal(res.data, 'Basic ' + base64);
+  });
+
+  it("should support stream.Readable as a payload", async () => {
+    server = await startHTTPServer();
+
+    const {data} = await undiciAxios.post('/', stream.Readable.from('OK'));
+
+    assert.strictEqual(data, 'OK');
+  });
+
+  describe('request aborting', function() {
+    it('should be able to abort the request stream', async function () {
+      server = await startHTTPServer({
+        rate: 100000,
+        useBuffering: true
+      });
+
+      const controller = new AbortController();
+
+      setTimeout(() => {
+        controller.abort();
+      }, 500);
+
+      await assert.rejects(async () => {
+        await undiciAxios.post('/', makeReadableStream(), {
+          responseType: 'stream',
+          signal: controller.signal
+        });
+      }, /CanceledError/);
+    });
+
+    it('should be able to abort the response stream', async function () {
+      server = await startHTTPServer((req, res) => {
+        pipelineAsync(generateReadable(10000, 10), res);
+      });
+
+      const controller = new AbortController();
+
+      setTimeout(() => {
+        controller.abort(new Error('test'));
+      }, 800);
+
+      const {data} = await undiciAxios.get('/', {
+        responseType: 'stream',
+        signal: controller.signal
+      });
+
+      await assert.rejects(async () => {
+        await data.pipeTo(makeEchoStream());
+      }, /^(AbortError|CanceledError):/);
+    });
+  });
+
+  it('should support a timeout', async () => {
+    server = await startHTTPServer(async(req, res) => {
+      await setTimeoutAsync(1000);
+      res.end('OK');
+    });
+
+    const timeout = 500;
+
+    const ts = Date.now();
+
+    await assert.rejects(async() => {
+      await undiciAxios('/', {
+        timeout
+      })
+    }, /timeout/);
+
+    const passed = Date.now() - ts;
+
+    assert.ok(passed >= timeout - 5, `early cancellation detected (${passed} ms)`);
+  });
+
+
+  it('should combine baseURL and url', async () => {
+    server = await startHTTPServer();
+
+    const res = await undiciAxios('/foo');
+
+    assert.equal(res.config.baseURL, LOCAL_SERVER_URL);
+    assert.equal(res.config.url, '/foo');
+  });
+
+  it('should support params', async() => {
+    server = await startHTTPServer((req, res) => res.end(req.url));
+
+    const {data} = await undiciAxios.get('/?test=1', {
+      params: {
+        foo: 1,
+        bar: 2
+      }
+    });
+
+    assert.strictEqual(data, '/?test=1&foo=1&bar=2');
+  });
+
+  it('should handle failed error as an AxiosError with ERR_NETWORK code', async () => {
+    try{
+      await undiciAxios('http://notExistsUrl.in.nowhere');
+      assert.fail('should fail');
+    } catch (err) {
+      assert.strictEqual(String(err), 'AxiosError: Network Error');
+      assert.strictEqual(err.cause && err.cause.code, 'ENOTFOUND');
+    }
+  });
+
+  it('should get response headers', async () => {
+    server = await startHTTPServer((req, res) => {
+      res.setHeader('foo', 'bar');
+      res.end(req.url)
+    });
+
+    const {headers} = await undiciAxios.get('/', {
+      responseType: 'stream'
+    });
+
+    assert.strictEqual(headers.get('foo'), 'bar');
+  });
+});

--- a/test/unit/adapters/undici.js
+++ b/test/unit/adapters/undici.js
@@ -400,4 +400,19 @@ describe('supports undici with nodejs', function () {
 
     assert.strictEqual(headers.get('foo'), 'bar');
   });
+
+  it('should support max redirects', async function () {
+    var i = 1;
+    server = await startHTTPServer((req, res) => {
+      res.setHeader('Location', '/' + i);
+      res.statusCode = 302;
+      res.end();
+      i++;
+    });
+
+    await undiciAxios.get('/', {
+      maxRedirects: 3
+    });
+    assert.equal(i, 5);
+  });
 });

--- a/test/unit/adapters/undici.js
+++ b/test/unit/adapters/undici.js
@@ -366,18 +366,21 @@ describe('supports undici with nodejs', function () {
     assert.strictEqual(data, '/?test=1&foo=1&bar=2');
   });
 
-  it('should handle failed error as an AxiosError with ERR_NETWORK code', async () => {
+  it('should handle failed error from stream response as an AxiosError with ERR_NETWORK code', async () => {
     try{
-      await undiciAxios('http://notExistsUrl.in.nowhere');
+      await undiciAxios('http://notExistsUrl.in.nowhere', {
+        responseType: 'stream'
+      });
       assert.fail('should fail');
     } catch (err) {
       assert.strictEqual(String(err), 'Error: getaddrinfo ENOTFOUND notexistsurl.in.nowhere');
       assert.strictEqual(err.cause && err.cause.code, 'ENOTFOUND');
     }
+  });
+
+  it('should handle failed error from text response as an AxiosError with ERR_NETWORK code', async () => {
     try{
-      await undiciAxios('http://notExistsUrl.in.nowhere', {
-        responseType: 'stream'
-      });
+      await undiciAxios('http://notExistsUrl.in.nowhere');
       assert.fail('should fail');
     } catch (err) {
       assert.strictEqual(String(err), 'Error: getaddrinfo ENOTFOUND notexistsurl.in.nowhere');

--- a/test/unit/adapters/undici.js
+++ b/test/unit/adapters/undici.js
@@ -12,6 +12,7 @@ import axios from '../../../index.js';
 import stream from "stream";
 import {AbortController} from "abortcontroller-polyfill/dist/cjs-ponyfill.js";
 import util from "util";
+import {FormData as UndiciFormData} from "undici";
 
 const pipelineAsync = util.promisify(stream.pipeline);
 
@@ -103,7 +104,7 @@ describe('supports undici with nodejs', function () {
         responseType: 'formdata'
       });
 
-      assert.ok(data instanceof FormData, 'data is not instanceof FormData');
+      assert.ok(data instanceof UndiciFormData, 'data is not instanceof FormData');
 
       assert.deepStrictEqual(Object.fromEntries(data.entries()), Object.fromEntries(originalData.entries()));
     });

--- a/test/unit/adapters/undici.js
+++ b/test/unit/adapters/undici.js
@@ -372,7 +372,16 @@ describe('supports undici with nodejs', function () {
       await undiciAxios('http://notExistsUrl.in.nowhere');
       assert.fail('should fail');
     } catch (err) {
-      assert.strictEqual(String(err), 'AxiosError: Network Error');
+      assert.strictEqual(String(err), 'Error: getaddrinfo ENOTFOUND notexistsurl.in.nowhere');
+      assert.strictEqual(err.cause && err.cause.code, 'ENOTFOUND');
+    }
+    try{
+      await undiciAxios('http://notExistsUrl.in.nowhere', {
+        responseType: 'stream'
+      });
+      assert.fail('should fail');
+    } catch (err) {
+      assert.strictEqual(String(err), 'Error: getaddrinfo ENOTFOUND notexistsurl.in.nowhere');
       assert.strictEqual(err.cause && err.cause.code, 'ENOTFOUND');
     }
   });

--- a/test/unit/adapters/undici.js
+++ b/test/unit/adapters/undici.js
@@ -12,7 +12,6 @@ import axios from '../../../index.js';
 import stream from "stream";
 import {AbortController} from "abortcontroller-polyfill/dist/cjs-ponyfill.js";
 import util from "util";
-import {FormData as UndiciFormData} from "undici";
 
 const pipelineAsync = util.promisify(stream.pipeline);
 
@@ -104,7 +103,7 @@ describe('supports undici with nodejs', function () {
         responseType: 'formdata'
       });
 
-      assert.ok(data instanceof UndiciFormData, 'data is not instanceof FormData');
+      assert.ok(data instanceof FormData, 'data is not instanceof FormData');
 
       assert.deepStrictEqual(Object.fromEntries(data.entries()), Object.fromEntries(originalData.entries()));
     });


### PR DESCRIPTION
This PR adds initial support for [Undici](https://undici.nodejs.org/#/) adapter.

Codebase and tests are based on `fetch` adapter implementation.

It uses [`undici.request`](https://github.com/nodejs/undici#undicirequesturl-options-promise) as default client since [it’s almost 3x faster than any other HTTP client](https://x.com/matteocollina/status/1748028768436838517), including those using native Fetch.

When that’s not possible (streams, form data processing and progress tracking), it falls back to [`undici.fetch`](https://github.com/nodejs/undici#undicifetchinput-init-promise).

Things currently not fleshed out:

* [ ] Documentation regarding usage
  * It’s on developers to install Undici as package, so we should probably throw if Undici is not available
* [ ] Which versions of Undici are we supporting
  * I’m voting for latest and anything not compatible throws error
* [ ] Types for request options
  * `undici.fetch` and `undici.request` implementation have different options so maybe we should pick subset of common options (currently `fetchOptions` is used)
* [ ] [Specification compliance](https://github.com/nodejs/undici#specification-compliance) section
  * Specifically part regarding GC and response body consumption
* [ ] Errors
  * `undici.fetch` and `undici.request` have different errors for same requests (fetch needs to follow Fetch specification), so I’ve tried to remove differences by discarding Fetch-specific logic regarding network error
  * Is there anything here that needs to be carefully considered?