### PR TITLE
Fix boolean values causing error when performing POST multipart/form-data

### DIFF
--- a/lib/helpers/toFormData.js
+++ b/lib/helpers/toFormData.js
@@ -120,6 +120,10 @@ function toFormData(obj, formData, options) {
       return value.toISOString();
     }
 
+    if (utils.isBoolean(value)) {
+      return value.toString();
+    }
+
     if (!useBlob && utils.isBlob(value)) {
       throw new AxiosError('Blob is not supported. Use a Buffer instead.');
     }


### PR DESCRIPTION
This pull request fixes an error that happens when trying to perform POST request with 'multipart/form-data' header set and passing a boolean value in data as such:

```
const res = await axios.postForm(
    'http://localhost:3000/webhook',
    {
        parameter: false,
    }
);

```

```
node:internal/modules/run_main:122
    triggerUncaughtException(
    ^

TypeError: data should be a string, Buffer or Uint8Array
```

After some research, I have found out that internally, [form-data](https://github.com/form-data/form-data#readme) module is used to create form data

Unlike [standard](https://developer.mozilla.org/en-US/docs/Web/API/FormData/append#examples),  this module's append method does not cast booleans to strings, which causes unexpected behavior 

https://github.com/form-data/form-data/issues/137



