### PR TITLE
fix(package): add RN specific entry point;

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,10 @@
         "require": "./index.d.cts",
         "default": "./index.d.ts"
       },
+      "react-native": {
+        "require": "./dist/browser/axios.cjs",
+        "default": "./dist/esm/axios.js"
+      },
       "browser": {
         "require": "./dist/browser/axios.cjs",
         "default": "./index.js"
@@ -139,6 +143,11 @@
     "@rollup/plugin-alias": "^5.1.0"
   },
   "browser": {
+    "./lib/adapters/http.js": "./lib/helpers/null.js",
+    "./lib/platform/node/index.js": "./lib/platform/browser/index.js",
+    "./lib/platform/node/classes/FormData.js": "./lib/helpers/null.js"
+  },
+  "react-native": {
     "./lib/adapters/http.js": "./lib/helpers/null.js",
     "./lib/platform/node/index.js": "./lib/platform/browser/index.js",
     "./lib/platform/node/classes/FormData.js": "./lib/helpers/null.js"


### PR DESCRIPTION
Adds a module entry point for React Native, as Metro bundler may ignore the browser field in package.json, resulting in an attempt to import unwanted server code into a React Native app.

Fixes #6899 