### PR TITLE
fix(http): preserve partial response when stream is aborted after headers

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -472,9 +472,9 @@ export default isHttpAdapterSupported && function httpAdapter(config) {
 
     // Create the request
     req = transport.request(options, function handleResponse(res) {
-      // Capture response metadata early, in case the stream is aborted before completion.
-      // If the response is aborted, we can no longer access `res`, so we store key info here
-      // to construct a meaningful partial response object later.
+      // Capture response metadata early, in case the stream is aborted before completion
+      // If the response is aborted, we can no longer access res, 
+      // so we store key info here to construct a meaningful partial response object later
       responseMeta.headersReceived = true;
       responseMeta.responseStatus = res.statusCode;
       responseMeta.responseStatusText = res.statusMessage;
@@ -588,8 +588,8 @@ export default isHttpAdapterSupported && function httpAdapter(config) {
             return;
           }
 
-          // The stream was aborted before completing.
-          // Construct a partial response using the previously captured responseMeta values.
+          // The stream was aborted before completing
+          // Construct a partial response using the previously captured responseMeta values
           const responseData = Buffer.concat(responseMeta.responseChunks).toString(responseEncoding || 'utf8');
           const partialResponse = {
             data: responseData,

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -168,6 +168,16 @@ const buildAddressEntry = (address, family) => resolveFamily(utils.isObject(addr
 /*eslint consistent-return:0*/
 export default isHttpAdapterSupported && function httpAdapter(config) {
   return wrapAsync(async function dispatchHttpRequest(resolve, reject, onDone) {
+    // responseMeta is used to construct a partial response object if the request is aborted after headers are received
+    const responseMeta = {
+      headersReceived: false,
+      responseChunks: [],
+      responseStatus: undefined,
+      responseStatusText: undefined,
+      responseHeaders: undefined,
+      lastRequest: undefined,
+    }
+
     let {data, lookup, family} = config;
     const {responseType, responseEncoding} = config;
     const method = config.method.toUpperCase();
@@ -462,6 +472,19 @@ export default isHttpAdapterSupported && function httpAdapter(config) {
 
     // Create the request
     req = transport.request(options, function handleResponse(res) {
+      // Capture response metadata early, in case the stream is aborted before completion.
+      // If the response is aborted, we can no longer access `res`, so we store key info here
+      // to construct a meaningful partial response object later.
+      responseMeta.headersReceived = true;
+      responseMeta.responseStatus = res.statusCode;
+      responseMeta.responseStatusText = res.statusMessage;
+      responseMeta.responseHeaders = res.headers;
+      responseMeta.lastRequest = res.req;
+      responseMeta.responseChunks = []; // reset
+      res.on('data', chunk => {
+        responseMeta.responseChunks.push(chunk);
+      });
+
       if (req.destroyed) return;
 
       const streams = [res];
@@ -486,9 +509,6 @@ export default isHttpAdapterSupported && function httpAdapter(config) {
 
       // decompress the response body transparently if required
       let responseStream = res;
-
-      // return the last request in case of redirects
-      const lastRequest = res.req || req;
 
       // if decompress disabled we should not decompress
       if (config.decompress !== false && res.headers['content-encoding']) {
@@ -539,7 +559,7 @@ export default isHttpAdapterSupported && function httpAdapter(config) {
         statusText: res.statusMessage,
         headers: new AxiosHeaders(res.headers),
         config,
-        request: lastRequest
+        request: responseMeta.lastRequest
       };
 
       if (responseType === 'stream') {
@@ -559,7 +579,7 @@ export default isHttpAdapterSupported && function httpAdapter(config) {
             rejected = true;
             responseStream.destroy();
             reject(new AxiosError('maxContentLength size of ' + config.maxContentLength + ' exceeded',
-              AxiosError.ERR_BAD_RESPONSE, config, lastRequest));
+              AxiosError.ERR_BAD_RESPONSE, config, responseMeta.lastRequest));
           }
         });
 
@@ -568,19 +588,35 @@ export default isHttpAdapterSupported && function httpAdapter(config) {
             return;
           }
 
-          const err = new AxiosError(
-            'stream has been aborted',
+          // The stream was aborted before completing.
+          // Construct a partial response using the previously captured responseMeta values.
+          const responseData = Buffer.concat(responseMeta.responseChunks).toString(responseEncoding || 'utf8');
+          const partialResponse = {
+            data: responseData,
+            status: responseMeta.responseStatus,
+            statusText: responseMeta.responseStatusText,
+            headers: new AxiosHeaders(responseMeta.responseHeaders),
+            config,
+            request: responseMeta.lastRequest
+          };
+          
+          // Wrap the partial response in an AxiosError and reject.
+          // This gives users access to any data received before the abort.
+          const err = AxiosError.from(
+            new Error('stream has been aborted'),
             AxiosError.ERR_BAD_RESPONSE,
             config,
-            lastRequest
+            responseMeta.lastRequest,
+            partialResponse
           );
+
           responseStream.destroy(err);
           reject(err);
         });
 
         responseStream.on('error', function handleStreamError(err) {
           if (req.destroyed) return;
-          reject(AxiosError.from(err, null, config, lastRequest));
+          reject(AxiosError.from(err, null, config, responseMeta.lastRequest));
         });
 
         responseStream.on('end', function handleStreamEnd() {
@@ -615,9 +651,22 @@ export default isHttpAdapterSupported && function httpAdapter(config) {
 
     // Handle errors
     req.on('error', function handleRequestError(err) {
-      // @todo remove
-      // if (req.aborted && err.code !== AxiosError.ERR_FR_TOO_MANY_REDIRECTS) return;
-      reject(AxiosError.from(err, null, config, req));
+      if (responseMeta.headersReceived) {
+        const responseData = Buffer.concat(responseMeta.responseChunks).toString(responseEncoding || 'utf8');
+
+        const partialResponse = {
+          data: responseData,
+          status: responseMeta.responseStatus,
+          statusText: responseMeta.responseStatusText,
+          headers: new AxiosHeaders(responseMeta.responseHeaders),
+          config,
+          request: responseMeta.lastRequest || req
+        };
+
+        return reject(AxiosError.from(err, AxiosError.ERR_BAD_RESPONSE, config, req, partialResponse));
+      }
+
+      return reject(AxiosError.from(err, null, config, req));
     });
 
     // set tcp keep alive to prevent drop connection by peer


### PR DESCRIPTION
### Description

Fixes #6675 

This happens because Axios fails to populate `err.response` when a Node.js HTTP stream is aborted **after headers are received** but **before the body is fully read**.

#### Context

When a stream emits the `'aborted'` event after headers are received, the response object becomes inaccessible, leading to a missing `err.response`. This change ensures that partial response data is buffered in advance and included in the resulting error object for better error handling and debugging.

### Fix Summary

- Tracks response metadata (`status`, `statusText`, `headers`, `req`) once headers are received.
- Buffers partial body data for supported response types (`text`, `json`).
- Constructs a `partialResponse` and passes it to `AxiosError.from(...)` inside:
  - `responseStream.on('aborted')`
  - `req.on('error')` (if headers were already received)

### Testing

- Added new unit test: `'should expose partial response on aborted stream'`
- Confirms that `err.response` includes status, headers, and body chunk (if any)

### Further suggestions

This seems to be the first implementation in Axios that manually preserves and surfaces partial response data for error scenarios where the original response object is inaccessible.

- I’m currently capturing `status`, `statusText`, `headers`, and `req` as the most essential fields. Should we consider preserving additional fields (e.g., timing info or raw headers)?
- Would it be valuable to add a `isPartial: true` flag in the error response object to signal consumers that the response is incomplete?