### PR TITLE
Add Path Traversal Detection for Request Paths

### DIFF
--- a/lib/core/buildFullPath.js
+++ b/lib/core/buildFullPath.js
@@ -2,6 +2,7 @@
 
 import isAbsoluteURL from '../helpers/isAbsoluteURL.js';
 import combineURLs from '../helpers/combineURLs.js';
+import checkTraversalPathUrl from '../helpers/checkTraversalPath.js';
 
 /**
  * Creates a new URL by combining the baseURL with the requestedURL,
@@ -16,7 +17,7 @@ import combineURLs from '../helpers/combineURLs.js';
 export default function buildFullPath(baseURL, requestedURL, allowAbsoluteUrls) {
   let isRelativeUrl = !isAbsoluteURL(requestedURL);
   if (baseURL && (isRelativeUrl || allowAbsoluteUrls == false)) {
-    return combineURLs(baseURL, requestedURL);
+    return checkTraversalPathUrl(combineURLs(baseURL, requestedURL));
   }
-  return requestedURL;
+  return checkTraversalPathUrl(requestedURL);
 }

--- a/lib/helpers/checkTraversalPath.js
+++ b/lib/helpers/checkTraversalPath.js
@@ -1,0 +1,20 @@
+/**
+ * Checks a given URL string for common path traversal sequences (`../` or `..\`).
+ *
+ * This function is a security measure to help prevent directory traversal attacks
+ * by throwing an error if potentially malicious path components are found directly
+ * within the URL string.
+ * 
+ * @param {string} finalUrl URL
+ *
+ * @returns {string} safe URL
+ **/
+export default function checkTraversalPathUrl(finalUrl) {
+  let decodedUrl = decodeURIComponent(finalUrl);
+
+  if (decodedUrl.includes('../') || decodedUrl.includes('..\\')) {
+    throw new Error('Security Error: Path traversal attempt detected in URL.');
+  }
+
+  return finalUrl;
+}

--- a/test/unit/helpers/checkTraversalPath.js
+++ b/test/unit/helpers/checkTraversalPath.js
@@ -1,0 +1,80 @@
+import assert from 'assert';
+import checkTraversalPathUrl from '../../../lib/helpers/checkTraversalPath.js'; // Assuming the function is in this path
+
+describe('helpers::checkTraversalPathUrl', function () {
+
+    it('should return the URL if no path traversal sequences are present', function () {
+        const url = 'https://example.com/api/data/resource';
+        assert.strictEqual(checkTraversalPathUrl(url), url, 'URL with no traversal should be returned as is');
+    });
+
+    it('should throw an error for URLs containing "../" sequence', function () {
+        const url = 'https://example.com/api/data/../../../../etc/passwd';
+        assert.throws(() => checkTraversalPathUrl(url),
+            (err) => err instanceof Error && err.message === 'Security Error: Path traversal attempt detected in URL.',
+            'Should throw error for "../" traversal'
+        );
+    });
+
+    it('should throw an error for URLs containing "..\\" sequence', function () {
+        const url = 'https://example.com/api/data/..\\..\\..\\windows\\win.ini';
+        assert.throws(() => checkTraversalPathUrl(url),
+            (err) => err instanceof Error && err.message === 'Security Error: Path traversal attempt detected in URL.',
+            'Should throw error for "..\\" traversal'
+        );
+    });
+
+    it('should throw an error for URLs containing mixed literal traversal sequences', function () {
+        const url = 'https://example.com/api/data/../..\\etc/passwd';
+        assert.throws(() => checkTraversalPathUrl(url),
+            (err) => err instanceof Error && err.message === 'Security Error: Path traversal attempt detected in URL.',
+            'Should throw error for mixed literal traversal'
+        );
+    });
+
+    it('should throw an error if traversal sequences are URL-encoded', function () {
+        const url = 'https://api.example.com/data/%2E%2E%2F%2E%2E%2Fetc%2Fpasswd';
+        assert.throws(() => checkTraversalPathUrl(url),
+            (err) => err instanceof Error && err.message === 'Security Error: Path traversal attempt detected in URL.',
+            'Should throw error for URL-encoded traversal'
+        );
+    });
+
+    it('should return an empty string for an empty URL', function () {
+        const url = '';
+        assert.strictEqual(checkTraversalPathUrl(url), url, 'Empty string should be returned as is');
+    });
+
+    it('should throw an error if traversal sequences are in query parameters', function () {
+        const url = 'https://example.com/api?file=../../secret.txt';
+        assert.throws(() => checkTraversalPathUrl(url),
+            (err) => err instanceof Error && err.message === 'Security Error: Path traversal attempt detected in URL.',
+            'Should throw error for traversal in query params'
+        );
+    });
+
+    it('should throw an error if traversal sequences are in the URL hash', function () {
+        const url = 'https://example.com/page#section/../../config.json';
+        assert.throws(() => checkTraversalPathUrl(url),
+            (err) => err instanceof Error && err.message === 'Security Error: Path traversal attempt detected in URL.',
+            'Should throw error for traversal in hash'
+        );
+    });
+
+    it('should throw an error if URL-encoded traversal sequences are in query parameters', function () {
+        const url = 'https://example.com/api?file=%2E%2E%2F%2E%2E%2Fsecret.txt';
+        assert.throws(() => checkTraversalPathUrl(url),
+            (err) => err instanceof Error && err.message === 'Security Error: Path traversal attempt detected in URL.',
+            'Should throw error for URL-encoded traversal in query params'
+        );
+    });
+
+    it('should throw an error if URL-encoded traversal sequences are in the URL hash', function () {
+        const url = 'https://example.com/page#section/%2E%2E%2F%2E%2E%2Fconfig.json';
+        assert.throws(() => checkTraversalPathUrl(url),
+            (err) => err instanceof Error && err.message === 'Security Error: Path traversal attempt detected in URL.',
+            'Should throw error for URL-encoded traversal in hash'
+        );
+    });
+
+});


### PR DESCRIPTION
This PR introduces a path traversal protection mechanism for Axios requests by validating request paths before they are sent. The goal is to prevent potential security risks where malicious input like ../ could escape intended path scopes, especially when constructing URLs dynamically.
