### PR TITLE
fix(sandbox): Improper Encoding or Escaping of Output as DOM text reinterpreted as HTML

### DIFF
--- a/sandbox/client.html
+++ b/sandbox/client.html
@@ -111,7 +111,7 @@
       try {
         return params.value.length === 0 ? null : JSON.parse(params.value);
       } catch (e) {
-        error.innerHTML = "Invalid JSON in Params";
+        error.textContent = "Invalid JSON in Params";
         return null;
       }
     }
@@ -120,7 +120,7 @@
       try {
         return data.value.length === 0 ? null : JSON.parse(data.value);
       } catch (e) {
-        error.innerHTML = "Invalid JSON in Data";
+        error.textContent = "Invalid JSON in Data";
         return null;
       }
     }
@@ -129,7 +129,7 @@
       try {
         return headers.value.length === 0 ? null : JSON.parse(headers.value);
       } catch (e) {
-        error.innerHTML = "Invalid JSON in Headers";
+        error.textContent = "Invalid JSON in Headers";
         return null;
       }
     }
@@ -161,7 +161,7 @@
       event.preventDefault();
 
       if (url.value === '') {
-        error.innerHTML = 'Please enter a valid URL';
+        error.textContent = 'Please enter a valid URL';
         return;
       }
 
@@ -173,19 +173,19 @@
         headers: getHeaders()
       };
 
-      request.innerHTML = JSON.stringify(options, null, 2);
+      request.textContent = JSON.stringify(options, null, 2);
 
       axios(options)
         .then(function (res) {
           response.innerHTML = JSON.stringify(res.data, null, 2);
-          error.innerHTML = "None";
+          error.textContent = "None";
         })
         .catch(function (err) {
           if (err.response) {
-            error.innerHTML = JSON.stringify(err.response.data, null, 2);
+            error.textContent = JSON.stringify(err.response.data, null, 2);
             response.innerHTML = "Error in Response";
           } else {
-            error.innerHTML = err.message;
+            error.textContent = err.message;
             response.innerHTML = "No Response Data";
           }
         });


### PR DESCRIPTION
https://github.com/axios/axios/blob/e7b7253f876a5e55d5cc39ef37d15d6d72ec6a5b/sandbox/client.html#L176-L176

Extracting text from a DOM node and interpreting it as HTML can lead to a cross-site scripting vulnerability. A webpage with this vulnerability reads text from the DOM, and afterwards adds the text as HTML to the DOM. Using text from the DOM as HTML effectively unescapes the text, and thereby invalidates any escaping done on the text. If an attacker is able to control the safe sanitized text, then this vulnerability can be exploited to perform a cross-site scripting attack.



fix the issue, we need to ensure that the content assigned to `innerHTML` is properly escaped to prevent it from being interpreted as HTML. Instead of using `innerHTML`, we can use `textContent`, which treats the input as plain text and does not interpret it as HTML. This change ensures that any potentially malicious input is rendered as text rather than executed as code.

The specific changes are:
- Replace `innerHTML` with `textContent` on line 176 to safely display the serialized JSON string.
- Similarly, replace `innerHTML` with `textContent` on lines 114, 123, 132, 164, 181, 185, and 188 to ensure all error and response messages are safely rendered as plain text.
