### PR TITLE
Fix config method undefined

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -170,7 +170,7 @@ export default isHttpAdapterSupported && function httpAdapter(config) {
   return wrapAsync(async function dispatchHttpRequest(resolve, reject, onDone) {
     let {data, lookup, family} = config;
     const {responseType, responseEncoding} = config;
-    const method = config.method.toUpperCase();
+    const method = (config.method || 'get').toUpperCase();
     let isDone;
     let rejected = false;
     let req;

--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -32,7 +32,7 @@ export default isXHRAdapterSupported && function (config) {
 
     let request = new XMLHttpRequest();
 
-    request.open(_config.method.toUpperCase(), _config.url, true);
+    request.open((_config.method || 'get').toUpperCase(), _config.url, true);
 
     // Set the request timeout in MS
     request.timeout = _config.timeout;

--- a/test/unit/adapters/http.js
+++ b/test/unit/adapters/http.js
@@ -2332,4 +2332,22 @@ describe('supports http with nodejs', function () {
       }, /ENOTFOUND/);
     });
   });
+
+  describe('config.method handling', function () {
+    it('should throw TypeError when config.method is undefined', async function () {
+      server = await startHTTPServer();
+      
+      const httpAdapter = (await import('../../../lib/adapters/http.js')).default;
+      
+      const config = {
+        url: 'http://localhost:4444',
+        method: undefined // This will cause the TypeError
+      };
+
+      // This should throw a TypeError: Cannot read properties of undefined
+      await assert.rejects(async () => {
+        await httpAdapter(config);
+      }, /TypeError.*toUpperCase|Cannot read properties of undefined/);
+    });
+  });
 });

--- a/test/unit/adapters/http.js
+++ b/test/unit/adapters/http.js
@@ -2334,20 +2334,19 @@ describe('supports http with nodejs', function () {
   });
 
   describe('config.method handling', function () {
-    it('should throw TypeError when config.method is undefined', async function () {
+    it('should handle undefined config.method gracefully', async function () {
       server = await startHTTPServer();
       
       const httpAdapter = (await import('../../../lib/adapters/http.js')).default;
       
       const config = {
         url: 'http://localhost:4444',
-        method: undefined // This will cause the TypeError
+        method: undefined // This should default to GET
       };
 
-      // This should throw a TypeError: Cannot read properties of undefined
-      await assert.rejects(async () => {
-        await httpAdapter(config);
-      }, /TypeError.*toUpperCase|Cannot read properties of undefined/);
+      // This should not throw an error and should default to GET method
+      const response = await httpAdapter(config);
+      assert.ok(response);
     });
   });
 });


### PR DESCRIPTION
Add defensive checks in http and xhr adapters to handle cases where config.method is undefined, preventing TypeError on toUpperCase() call.

Fixes #6960

