### PR TITLE
Backport `maxContentLength` vulnerability fix to v0.x

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -18,6 +18,7 @@ var CanceledError = require('../cancel/CanceledError');
 var platform = require('../platform');
 var fromDataURI = require('../helpers/fromDataURI');
 var stream = require('stream');
+var estimateDataURLDecodedBytes = require('../helpers/estimateDataURLDecodedBytes.js');
 
 var isHttps = /https:?/;
 
@@ -114,6 +115,21 @@ module.exports = function httpAdapter(config) {
     var protocol = parsed.protocol || supportedProtocols[0];
 
     if (protocol === 'data:') {
+      // Apply the same semantics as HTTP: only enforce if a finite, non-negative cap is set.
+      if (config.maxContentLength > -1) {
+        // Use the exact string passed to fromDataURI (config.url); fall back to fullPath if needed.
+        var dataUrl = String(config.url || fullPath || '');
+        var estimated = estimateDataURLDecodedBytes(dataUrl);
+
+        if (estimated > config.maxContentLength) {
+          return reject(new AxiosError(
+            'maxContentLength size of ' + config.maxContentLength + ' exceeded',
+            AxiosError.ERR_BAD_RESPONSE,
+            config
+          ));
+        }
+      }
+
       var convertedData;
 
       if (method !== 'GET') {

--- a/lib/helpers/estimateDataURLDecodedBytes.js
+++ b/lib/helpers/estimateDataURLDecodedBytes.js
@@ -1,0 +1,73 @@
+/**
+ * Estimate decoded byte length of a data:// URL *without* allocating large buffers.
+ * - For base64: compute exact decoded size using length and padding;
+ *               handle %XX at the character-count level (no string allocation).
+ * - For non-base64: use UTF-8 byteLength of the encoded body as a safe upper bound.
+ *
+ * @param {string} url
+ * @returns {number}
+ */
+export default function estimateDataURLDecodedBytes(url) {
+  if (!url || typeof url !== 'string') return 0;
+  if (!url.startsWith('data:')) return 0;
+
+  const comma = url.indexOf(',');
+  if (comma < 0) return 0;
+
+  const meta = url.slice(5, comma);
+  const body = url.slice(comma + 1);
+  const isBase64 = /;base64/i.test(meta);
+
+  if (isBase64) {
+    let effectiveLen = body.length;
+    const len = body.length; // cache length
+
+    for (let i = 0; i < len; i++) {
+      if (body.charCodeAt(i) === 37 /* '%' */ && i + 2 < len) {
+        const a = body.charCodeAt(i + 1);
+        const b = body.charCodeAt(i + 2);
+        const isHex =
+          ((a >= 48 && a <= 57) || (a >= 65 && a <= 70) || (a >= 97 && a <= 102)) &&
+          ((b >= 48 && b <= 57) || (b >= 65 && b <= 70) || (b >= 97 && b <= 102));
+
+        if (isHex) {
+          effectiveLen -= 2;
+          i += 2;
+        }
+      }
+    }
+
+    let pad = 0;
+    let idx = len - 1;
+
+    const tailIsPct3D = (j) =>
+      j >= 2 &&
+      body.charCodeAt(j - 2) === 37 && // '%'
+      body.charCodeAt(j - 1) === 51 && // '3'
+      (body.charCodeAt(j) === 68 || body.charCodeAt(j) === 100); // 'D' or 'd'
+
+    if (idx >= 0) {
+      if (body.charCodeAt(idx) === 61 /* '=' */) {
+        pad++;
+        idx--;
+      } else if (tailIsPct3D(idx)) {
+        pad++;
+        idx -= 3;
+      }
+    }
+
+    if (pad === 1 && idx >= 0) {
+      if (body.charCodeAt(idx) === 61 /* '=' */) {
+        pad++;
+      } else if (tailIsPct3D(idx)) {
+        pad++;
+      }
+    }
+
+    const groups = Math.floor(effectiveLen / 4);
+    const bytes = groups * 3 - (pad || 0);
+    return bytes > 0 ? bytes : 0;
+  }
+
+  return Buffer.byteLength(body, 'utf8');
+}

--- a/lib/helpers/estimateDataURLDecodedBytes.js
+++ b/lib/helpers/estimateDataURLDecodedBytes.js
@@ -7,7 +7,7 @@
  * @param {string} url
  * @returns {number}
  */
-export default function estimateDataURLDecodedBytes(url) {
+function estimateDataURLDecodedBytes(url) {
   if (!url || typeof url !== 'string') return 0;
   if (!url.startsWith('data:')) return 0;
 
@@ -71,3 +71,5 @@ export default function estimateDataURLDecodedBytes(url) {
 
   return Buffer.byteLength(body, 'utf8');
 }
+
+module.exports = estimateDataURLDecodedBytes;

--- a/lib/helpers/estimateDataURLDecodedBytes.js
+++ b/lib/helpers/estimateDataURLDecodedBytes.js
@@ -40,11 +40,12 @@ function estimateDataURLDecodedBytes(url) {
     var pad = 0;
     var idx = len - 1;
 
-    var tailIsPct3D = (j) =>
-      j >= 2 &&
-      body.charCodeAt(j - 2) === 37 && // '%'
-      body.charCodeAt(j - 1) === 51 && // '3'
-      (body.charCodeAt(j) === 68 || body.charCodeAt(j) === 100); // 'D' or 'd'
+    function tailIsPct3D(j) {
+      return j >= 2 &&
+        body.charCodeAt(j - 2) === 37 && // '%'
+        body.charCodeAt(j - 1) === 51 && // '3'
+        (body.charCodeAt(j) === 68 || body.charCodeAt(j) === 100); // 'D' or 'd'
+    }
 
     if (idx >= 0) {
       if (body.charCodeAt(idx) === 61 /* '=' */) {

--- a/lib/helpers/estimateDataURLDecodedBytes.js
+++ b/lib/helpers/estimateDataURLDecodedBytes.js
@@ -11,22 +11,22 @@ function estimateDataURLDecodedBytes(url) {
   if (!url || typeof url !== 'string') return 0;
   if (!url.startsWith('data:')) return 0;
 
-  const comma = url.indexOf(',');
+  var comma = url.indexOf(',');
   if (comma < 0) return 0;
 
-  const meta = url.slice(5, comma);
-  const body = url.slice(comma + 1);
-  const isBase64 = /;base64/i.test(meta);
+  var meta = url.slice(5, comma);
+  var body = url.slice(comma + 1);
+  var isBase64 = /;base64/i.test(meta);
 
   if (isBase64) {
     let effectiveLen = body.length;
-    const len = body.length; // cache length
+    var len = body.length; // cache length
 
     for (let i = 0; i < len; i++) {
       if (body.charCodeAt(i) === 37 /* '%' */ && i + 2 < len) {
-        const a = body.charCodeAt(i + 1);
-        const b = body.charCodeAt(i + 2);
-        const isHex =
+        var a = body.charCodeAt(i + 1);
+        var b = body.charCodeAt(i + 2);
+        var isHex =
           ((a >= 48 && a <= 57) || (a >= 65 && a <= 70) || (a >= 97 && a <= 102)) &&
           ((b >= 48 && b <= 57) || (b >= 65 && b <= 70) || (b >= 97 && b <= 102));
 
@@ -40,7 +40,7 @@ function estimateDataURLDecodedBytes(url) {
     let pad = 0;
     let idx = len - 1;
 
-    const tailIsPct3D = (j) =>
+    var tailIsPct3D = (j) =>
       j >= 2 &&
       body.charCodeAt(j - 2) === 37 && // '%'
       body.charCodeAt(j - 1) === 51 && // '3'
@@ -64,8 +64,8 @@ function estimateDataURLDecodedBytes(url) {
       }
     }
 
-    const groups = Math.floor(effectiveLen / 4);
-    const bytes = groups * 3 - (pad || 0);
+    var groups = Math.floor(effectiveLen / 4);
+    var bytes = groups * 3 - (pad || 0);
     return bytes > 0 ? bytes : 0;
   }
 

--- a/lib/helpers/estimateDataURLDecodedBytes.js
+++ b/lib/helpers/estimateDataURLDecodedBytes.js
@@ -19,10 +19,10 @@ function estimateDataURLDecodedBytes(url) {
   var isBase64 = /;base64/i.test(meta);
 
   if (isBase64) {
-    let effectiveLen = body.length;
+    var effectiveLen = body.length;
     var len = body.length; // cache length
 
-    for (let i = 0; i < len; i++) {
+    for (var i = 0; i < len; i++) {
       if (body.charCodeAt(i) === 37 /* '%' */ && i + 2 < len) {
         var a = body.charCodeAt(i + 1);
         var b = body.charCodeAt(i + 2);
@@ -37,8 +37,8 @@ function estimateDataURLDecodedBytes(url) {
       }
     }
 
-    let pad = 0;
-    let idx = len - 1;
+    var pad = 0;
+    var idx = len - 1;
 
     var tailIsPct3D = (j) =>
       j >= 2 &&

--- a/test/unit/helpers/estimateDataURLDecodedBytes.spec.js
+++ b/test/unit/helpers/estimateDataURLDecodedBytes.spec.js
@@ -1,0 +1,30 @@
+var assert = require('assert');
+var estimateDataURLDecodedBytes = require('../../../lib/helpers/estimateDataURLDecodedBytes');
+
+describe('estimateDataURLDecodedBytes', () => {
+  it('should return 0 for non-data URLs', () => {
+    assert.strictEqual(estimateDataURLDecodedBytes('http://example.com'), 0);
+  });
+
+  it('should calculate length for simple non-base64 data URL', () => {
+    const url = 'data:,Hello';
+    assert.strictEqual(estimateDataURLDecodedBytes(url), Buffer.byteLength('Hello', 'utf8'));
+  });
+
+  it('should calculate decoded length for base64 data URL', () => {
+    const str = 'Hello';
+    const b64 = Buffer.from(str, 'utf8').toString('base64');
+    const url = `data:text/plain;base64,${b64}`;
+    assert.strictEqual(estimateDataURLDecodedBytes(url), str.length);
+  });
+
+  it('should handle base64 with = padding', () => {
+    const url = 'data:text/plain;base64,TQ=='; // "M"
+    assert.strictEqual(estimateDataURLDecodedBytes(url), 1);
+  });
+
+  it('should handle base64 with %3D padding', () => {
+    const url = 'data:text/plain;base64,TQ%3D%3D'; // "M"
+    assert.strictEqual(estimateDataURLDecodedBytes(url), 1);
+  });
+});


### PR DESCRIPTION
Backports fix for https://github.com/advisories/GHSA-4hjh-wcwx-xvwj on v1.x (#7011) to v0.x.