### PR TITLE
We can add a proper license badge logo for the mit license #7070

### DIFF
--- a/README.md
+++ b/README.md
@@ -1753,5 +1753,7 @@ axios is heavily inspired by the [$http service](https://docs.angularjs.org/api/
 
 ## License
 
-![License](https://img.shields.io/badge/license-MIT-blue.svg?style=plastic)  
-[MIT](LICENSE)
+## License
+
+[![License](https://img.shields.io/badge/license-MIT-blue.svg?style=plastic)](https://github.com/axios/axios/blob/v1.x/LICENSE)
+

--- a/README.md
+++ b/README.md
@@ -1753,4 +1753,5 @@ axios is heavily inspired by the [$http service](https://docs.angularjs.org/api/
 
 ## License
 
+![License](https://img.shields.io/badge/license-MIT-blue.svg?style=plastic)  
 [MIT](LICENSE)


### PR DESCRIPTION
Is your feature request related to a problem? Please describe.
I am a hacktoberfest contributer please assign these task to me. I will add a proper license badge for these in the readme file.

<img width="1890" height="872" alt="Screenshot 2025-10-01 234346" src="https://github.com/user-attachments/assets/6477853e-1385-4c8c-8249-c40f258a4261" />
