### PR TITLE
Standardize timeout error message in composeSignals to match adapters

### DIFF
--- a/lib/helpers/composeSignals.js
+++ b/lib/helpers/composeSignals.js
@@ -21,7 +21,7 @@ const composeSignals = (signals, timeout) => {
 
     let timer = timeout && setTimeout(() => {
       timer = null;
-      onabort(new AxiosError(`timeout ${timeout} of ms exceeded`, AxiosError.ETIMEDOUT))
+      onabort(new AxiosError(`timeout of ${timeout}ms exceeded`, AxiosError.ETIMEDOUT))
     }, timeout)
 
     const unsubscribe = () => {

--- a/test/unit/helpers/composeSignals.js
+++ b/test/unit/helpers/composeSignals.js
@@ -32,7 +32,7 @@ describe('helpers::composeSignals', () => {
       signal.addEventListener('abort', resolve);
     });
 
-    assert.match(String(signal.reason), /timeout 100 of ms exceeded/);
+    assert.match(String(signal.reason), /timeout of 100ms exceeded/);
   });
 
   it('should return undefined if signals and timeout are not provided', async () => {


### PR DESCRIPTION
Issue: #7080 

Align the timeout error message thrown by `composeSignals` with `xhr` and `http` adapters for consistency. The message now reads: “timeout of {timeout}ms exceeded”.

## Changes
Update timeout message in `lib/helpers/composeSignals.js` to “timeout of {timeout}ms exceeded”.
Update assertion in `test/unit/helpers/composeSignals.js` to match the new message.

- [x] Code updated
- [x] Tests updated
- [x] No breaking changes
- [x] Matches adapter messages (xhr, http)