### PR TITLE
feat(core): add opt-in retry support with backoff, Retry-After, and cancellation

### DIFF
--- a/index.d.cts
+++ b/index.d.cts
@@ -368,6 +368,21 @@ declare namespace axios {
     lengthComputable: boolean;
   }
 
+  type RetryBackoffMode = 'exponential' | 'linear' | 'fixed' | 'none';
+  type RetryJitterMode = 'full' | 'equal' | 'none';
+
+  interface RetryConfig {
+    retries?: number | ((error: any, attempt: number) => number);
+    retryDelay?: number | ((error: any, attempt: number, response?: AxiosResponse) => number);
+    retryCondition?: (error: any, attempt: number, response?: AxiosResponse) => boolean;
+    shouldResetTimeout?: boolean;
+    methods?: string[];
+    respectRetryAfter?: boolean;
+    backoff?: RetryBackoffMode;
+    jitter?: RetryJitterMode;
+    maxRetryAfter?: number;
+  }
+
   type Milliseconds = number;
 
   type AxiosAdapterName = 'fetch' | 'xhr' | 'http' | (string & {});
@@ -436,6 +451,7 @@ declare namespace axios {
         ((hostname: string, options: object) => Promise<[address: LookupAddressEntry | LookupAddressEntry[], family?: AddressFamily] | LookupAddress>);
     withXSRFToken?: boolean | ((config: InternalAxiosRequestConfig) => boolean | undefined);
     fetchOptions?: Omit<RequestInit, 'body' | 'headers' | 'method' | 'signal'> | Record<string, any>;
+    retry?: RetryConfig;
   }
 
   // Alias

--- a/index.d.ts
+++ b/index.d.ts
@@ -299,6 +299,21 @@ export interface AxiosProgressEvent {
   event?: BrowserProgressEvent;
   lengthComputable: boolean;
 }
+export type RetryBackoffMode = 'exponential' | 'linear' | 'fixed' | 'none';
+export type RetryJitterMode = 'full' | 'equal' | 'none';
+
+export interface RetryConfig {
+  retries?: number | ((error: any, attempt: number) => number);
+  retryDelay?: number | ((error: any, attempt: number, response?: AxiosResponse) => number);
+  retryCondition?: (error: any, attempt: number, response?: AxiosResponse) => boolean;
+  shouldResetTimeout?: boolean;
+  methods?: string[];
+  respectRetryAfter?: boolean;
+  backoff?: RetryBackoffMode;
+  jitter?: RetryJitterMode;
+  maxRetryAfter?: number;
+}
+
 
 type Milliseconds = number;
 
@@ -369,6 +384,7 @@ export interface AxiosRequestConfig<D = any> {
   withXSRFToken?: boolean | ((config: InternalAxiosRequestConfig) => boolean | undefined);
   parseReviver?: (this: any, key: string, value: any) => any;
   fetchOptions?: Omit<RequestInit, 'body' | 'headers' | 'method' | 'signal'> | Record<string, any>;
+    retry?: RetryConfig;
 }
 
 // Alias

--- a/lib/core/dispatchRequest.js
+++ b/lib/core/dispatchRequest.js
@@ -6,6 +6,15 @@ import defaults from '../defaults/index.js';
 import CanceledError from '../cancel/CanceledError.js';
 import AxiosHeaders from '../core/AxiosHeaders.js';
 import adapters from "../adapters/adapters.js";
+import utils from '../utils.js';
+import {
+  getRetryConfig,
+  shouldRetryDefault,
+  getRetryAfterDelay,
+  computeBackoffDelay,
+  delayWithCancellation,
+  composeAttemptSignal
+} from "../helpers/retry.js";
 
 /**
  * Throws a `CanceledError` if cancellation has been requested.
@@ -31,7 +40,7 @@ function throwIfCancellationRequested(config) {
  *
  * @returns {Promise} The Promise to be fulfilled
  */
-export default function dispatchRequest(config) {
+export default async function dispatchRequest(config) {
   throwIfCancellationRequested(config);
 
   config.headers = AxiosHeaders.from(config.headers);
@@ -48,34 +57,109 @@ export default function dispatchRequest(config) {
 
   const adapter = adapters.getAdapter(config.adapter || defaults.adapter, config);
 
-  return adapter(config).then(function onAdapterResolution(response) {
+  const retryCfg = getRetryConfig(config);
+  const tryMethods = retryCfg.methods || [];
+  const method = String(config.method || 'get').toLowerCase();
+  const totalAttempts = 1 + (tryMethods.includes(method) ? retryCfg.retries : 0);
+
+  const startedAt = Date.now();
+  let attempt = 0;
+  let lastError;
+
+  while (attempt < totalAttempts) {
+    attempt++;
+
     throwIfCancellationRequested(config);
 
-    // Transform response data
-    response.data = transformData.call(
-      config,
-      config.transformResponse,
-      response
-    );
+    const originalTimeout = config.timeout;
+    const timeoutForAttempt = retryCfg.shouldResetTimeout ? originalTimeout : (function () {
+      if (!originalTimeout) return originalTimeout;
+      const elapsed = Date.now() - startedAt;
+      const remaining = Math.max(0, parseInt(originalTimeout, 10) - elapsed);
+      return remaining || 0;
+    }());
 
-    response.headers = AxiosHeaders.from(response.headers);
+    const attemptConfig = {
+      ...config,
+      signal: composeAttemptSignal(config.signal, timeoutForAttempt)
+    };
 
-    return response;
-  }, function onAdapterRejection(reason) {
-    if (!isCancel(reason)) {
-      throwIfCancellationRequested(config);
+    try {
+      const response = await adapter(attemptConfig);
 
-      // Transform response data
-      if (reason && reason.response) {
-        reason.response.data = transformData.call(
+      // transform on success
+      response.data = transformData.call(
+        config,
+        config.transformResponse,
+        response
+      );
+      response.headers = AxiosHeaders.from(response.headers);
+
+      return response;
+    } catch (err) {
+      lastError = err;
+
+      if (isCancel(err)) {
+        // Do not retry canceled requests
+        throw err;
+      }
+
+      // transform error response data before deciding to retry
+      if (err && err.response) {
+        err.response.data = transformData.call(
           config,
           config.transformResponse,
-          reason.response
+          err.response
         );
-        reason.response.headers = AxiosHeaders.from(reason.response.headers);
+        err.response.headers = AxiosHeaders.from(err.response.headers);
       }
-    }
 
-    return Promise.reject(reason);
-  });
+      if (attempt >= totalAttempts) {
+        break;
+      }
+
+      const userRetryCondition = retryCfg.retryCondition;
+      const shouldRetry = typeof userRetryCondition === 'function'
+        ? !!userRetryCondition(err, attempt, err && err.response)
+        : shouldRetryDefault(err, attempt);
+
+      if (!shouldRetry) {
+        break;
+      }
+
+      let delay = 0;
+      if (retryCfg.respectRetryAfter && err && err.response) {
+        const ra = getRetryAfterDelay(err.response.headers);
+        if (typeof ra === 'number') {
+          delay = ra;
+          if (retryCfg.maxRetryAfter && delay > retryCfg.maxRetryAfter) {
+            delay = retryCfg.maxRetryAfter;
+          }
+        }
+      }
+
+      if (!delay) {
+        const retryDelay = retryCfg.retryDelay;
+        if (typeof retryDelay === 'function') {
+          delay = Math.max(0, Number(retryDelay(err, attempt, err && err.response)) || 0);
+        } else if (utils.toFiniteNumber(retryDelay)) {
+          delay = utils.toFiniteNumber(retryDelay);
+        } else {
+          delay = computeBackoffDelay(attempt, undefined, retryCfg.backoff, retryCfg.jitter);
+        }
+      }
+
+      // Wait with cancellation support
+      const waitSignal = composeAttemptSignal(config.signal);
+      try {
+        await delayWithCancellation(delay, waitSignal);
+      } catch (e) {
+        // canceled while waiting
+        throw e;
+      }
+      // loop continues to next attempt
+    }
+  }
+
+  return Promise.reject(lastError);
 }

--- a/lib/helpers/retry.js
+++ b/lib/helpers/retry.js
@@ -1,0 +1,107 @@
+'use strict';
+
+import utils from '../utils.js';
+import AxiosError from '../core/AxiosError.js';
+import AxiosHeaders from '../core/AxiosHeaders.js';
+import composeSignals from './composeSignals.js';
+
+export const DEFAULT_BASE_DELAY_MS = 100;
+
+export const DEFAULT_IDEMPOTENT_METHODS = ['get', 'head', 'options', 'trace'];
+
+export function parseRetryAfterHeader(header, now = new Date()) {
+  if (!header) return undefined;
+  const secs = Number(header);
+  if (!Number.isNaN(secs)) return Math.max(0, secs * 1000);
+  const date = new Date(header);
+  const ms = date - now;
+  return Number.isFinite(ms) ? Math.max(0, ms) : undefined;
+}
+
+export function computeBackoffDelay(attempt, base = DEFAULT_BASE_DELAY_MS, mode = 'exponential', jitter = 'full') {
+  let delay;
+  switch (mode) {
+    case 'fixed':
+      delay = base;
+      break;
+    case 'linear':
+      delay = base * attempt;
+      break;
+    case 'none':
+      delay = 0;
+      break;
+    case 'exponential':
+    default:
+      delay = base * attempt * attempt;
+  }
+  if (delay <= 0) return 0;
+  if (jitter === 'none') return delay;
+  const rand = Math.random();
+  return jitter === 'equal' ? delay - delay * 0.5 + rand * (delay * 0.5) : rand * delay; // full
+}
+
+export function isRetryableNetworkError(error) {
+  const code = error && (error.code || (error.cause && error.cause.code));
+  const retryable = ['ECONNRESET', 'ETIMEDOUT', 'ENOTFOUND', 'EAI_AGAIN'];
+  return error && (error.isAxiosError || error instanceof Error) && (
+    error.code === AxiosError.ERR_NETWORK || (code && retryable.includes(code))
+  );
+}
+
+export function isRetryableResponse(response) {
+  if (!response) return false;
+  const status = response.status;
+  return status === 429 || status === 503;
+}
+
+export function getRetryAfterDelay(headers, now = new Date()) {
+  const h = AxiosHeaders.from(headers);
+  const value = h && (h.get('retry-after') || h.get('Retry-After'));
+  return parseRetryAfterHeader(value, now);
+}
+
+export function shouldRetryDefault(error, attempt) {
+  if (error && error.response) {
+    return isRetryableResponse(error.response);
+  }
+  return isRetryableNetworkError(error);
+}
+
+export function getRetryConfig(config) {
+  const retry = config && config.retry || {};
+  return {
+    retries: utils.toFiniteNumber(retry.retries) || 0,
+    retryDelay: retry.retryDelay,
+    retryCondition: retry.retryCondition,
+    shouldResetTimeout: !!retry.shouldResetTimeout,
+    methods: Array.isArray(retry.methods) ? retry.methods.map(m => String(m).toLowerCase()) : DEFAULT_IDEMPOTENT_METHODS,
+    respectRetryAfter: utils.isBoolean(retry.respectRetryAfter) ? retry.respectRetryAfter : true,
+    backoff: retry.backoff || 'exponential',
+    jitter: retry.jitter || 'full',
+    maxRetryAfter: utils.toFiniteNumber(retry.maxRetryAfter)
+  }
+}
+
+export async function delayWithCancellation(ms, signal) {
+  if (!ms || ms <= 0) return;
+  return await new Promise((resolve, reject) => {
+    let timer = setTimeout(resolve, ms);
+    if (signal) {
+      const onabort = () => {
+        clearTimeout(timer);
+        timer = null;
+        const reason = signal.reason instanceof Error ? signal.reason : new AxiosError('canceled', AxiosError.ECANCELED);
+        reject(reason);
+      };
+      if (signal.aborted) return onabort();
+      signal.addEventListener('abort', onabort, { once: true });
+    }
+  });
+}
+
+export function composeAttemptSignal(originalSignal, timeoutMs) {
+  const signal = composeSignals([originalSignal], timeoutMs);
+  return signal || originalSignal;
+}
+
+


### PR DESCRIPTION
This PR adds an opt-in, built-in retry mechanism with configurable policy and consistent behavior across adapters. It supports transient network errors, 429/503 with `Retry-After`, multiple backoff strategies (with jitter), timeout strategies, and proper cancellation during backoff and attempts.

## Changes

- core
`lib/core/dispatchRequest.js`: wrap request dispatch in an opt-in retry loop respecting `retry` config, `Retry-After`, backoff, cancellation, and timeout strategies.

- helpers
`lib/helpers/retry.js`: utilities for backoff computation, `Retry-After` parsing, retryable error detection, cancellable delay, and composed attempt signals.

- types
`index.d.ts`, `index.d.cts`: add `RetryConfig` and `retry?: RetryConfig` to `AxiosRequestConfig`.

- tests
`test/unit/adapters/http.js`: add retry success and cancellation-during-backoff tests.
`test/unit/adapters/fetch.js`: add retry success and cancellation-during-backoff tests.
`test/specs/adapter.spec.js` (XHR): add retry success and cancellation-during-backoff tests.

## Behavior
- Default disabled (`retries: 0`).
- Retry condition defaults: network errors (ERR_NETWORK, ECONNRESET, ETIMEDOUT, ENOTFOUND) and HTTP 429/503.
- `Retry-After` respected (seconds or HTTP-date), bounded by `maxRetryAfter` if provided.
- Cancellation is honored immediately during backoff and in-flight.
- `shouldResetTimeout=false` shares a global timeout budget across attempts; `true` resets per attempt.

## Tests
- http/fetch/xhr adapters:
429/503 retry → success
Cancellation during backoff
- Additional coverage can be added in follow-ups:
DNS/ETIMEDOUT simulations
`shouldResetTimeout` true/false timing assertions
Custom `retryCondition` and `retryDelay` functions

Checklist
- [x] Core logic implemented (opt-in)
- [x] Helpers for backoff and Retry-After
- [x] Types added to index.d.ts and index.d.cts
- [x] Unit tests added for http/fetch/xhr
- [x] No breaking changes
- [ ] Documentation updates (seperate PR - #7083 )