### PR TITLE
feat(theme): add light/dark mode toggle

### DIFF
--- a/sandbox/client.html
+++ b/sandbox/client.html
@@ -2,35 +2,183 @@
 <html>
 <head>
   <title>AXIOS | Sandbox</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta charset="UTF-8">
   <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css"/>
-  <style type="text/css">
+  <style>
+    /* =============================
+       Theme Variables 
+    ==============================*/
+    :root {
+      --bg-color: #ffffff;
+      --text-color: #212529;
+      --card-bg: #ffffff;
+      --border-color: #dee2e6;
+      --input-bg: #ffffff;
+      --input-border: #ced4da;
+      --pre-bg: #f8f9fa;
+      --pre-border: #dee2e6;
+    }
+
+    [data-theme="dark"] {
+      --bg-color: #121212;
+      --text-color: #ffffff;
+      --card-bg: #1e1e1e;
+      --border-color: #333333;
+      --input-bg: #2d2d2d;
+      --input-border: #444444;
+      --pre-bg: #2d2d2d;
+      --pre-border: #444444;
+    }
+
+    body {
+      background-color: var(--bg-color);
+      color: var(--text-color);
+      transition: background-color 0.3s ease, color 0.3s ease;
+    }
+
+    .well {
+      background-color: var(--card-bg);
+      border: 1px solid var(--border-color);
+      border-radius: 0.375rem;
+      padding: 1.5rem;
+      margin-bottom: 1.5rem;
+      transition: background-color 0.3s ease, border-color 0.3s ease;
+      width: 100%;
+      max-width: 100%;
+    }
+
+    .form-control {
+      background-color: var(--input-bg);
+      border-color: var(--input-border);
+      color: var(--text-color);
+      transition: background-color 0.3s ease, border-color 0.3s ease, color 0.3s ease;
+    }
+
+    .form-control:focus {
+      background-color: var(--input-bg);
+      border-color: #86b7fe;
+      color: var(--text-color);
+      box-shadow: 0 0 0 0.25rem rgba(13, 110, 253, 0.25);
+    }
+
     pre {
       min-height: 39px;
-      overflow: auto;
+      overflow-x: auto;
+      white-space: pre-wrap;
+      word-wrap: break-word;
+      background-color: var(--pre-bg);
+      border: 1px solid var(--pre-border);
+      color: var(--text-color);
+      transition: background-color 0.3s ease, border-color 0.3s ease, color 0.3s ease;
+      padding: 0.75rem;
     }
-    .header{
+
+    .header {
       display: flex;
       flex-direction: row;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 2rem;
+      flex-wrap: wrap;
+      gap: 1rem;
     }
-    .box{
+
+    .header-left {
+      display: flex;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+    }
+
+    .box {
       display: grid;
       grid-template-columns: 1fr 1fr;
       grid-gap: 25px;
     }
-    .well {
-      max-width: 400px;
+
+    /* =============================
+       Theme Toggle Styles 
+    ==============================*/
+    .theme-toggle {
+      position: relative;
+      width: 60px;
+      height: 30px;
+      background-color: #ccc;
+      border-radius: 30px;
+      cursor: pointer;
+      transition: background-color 0.3s ease;
+      border: none;
+      outline: none;
     }
+
+    .theme-toggle.dark {
+      background-color: #4CAF50;
+    }
+
+    .theme-toggle::after {
+      content: '';
+      position: absolute;
+      width: 26px;
+      height: 26px;
+      border-radius: 50%;
+      background-color: white;
+      top: 2px;
+      left: 2px;
+      transition: transform 0.3s ease;
+    }
+
+    .theme-toggle.dark::after {
+      transform: translateX(30px);
+    }
+
+    .theme-toggle-container {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+    }
+
+    .theme-icon {
+      font-size: 20px;
+      user-select: none;
+      display: inline-block;
+      line-height: 1;
+    }
+
+    .btn {
+      margin-top: 6px;
+    }
+
     @media screen and (max-width: 1000px) {
       .box {
         grid-template-columns: 1fr;
+      }
+    }
+
+    @media screen and (max-width: 576px) {
+      .header {
+        flex-direction: column;
+        align-items: flex-start;
+      }
+      .theme-toggle-container {
+        align-self: flex-start;
       }
     }
   </style>
 </head>
 <body class="container">
 <div class="header">
-  <img src="https://axios-http.com/assets/logo.svg" alt="axios" width="100" height="60">
-  <h1> &nbsp;| Sandbox</h1>
+  <div class="header-left">
+    <img src="https://axios-http.com/assets/logo.svg" alt="axios" width="100" height="60">
+    <h1> &nbsp;| Sandbox</h1>
+  </div>
+  
+  <!-- Theme Toggle -->
+  <div class="theme-toggle-container">
+    <span class="theme-icon">☀️</span>
+    <button id="themeToggle" class="theme-toggle" aria-label="Toggle dark mode"></button>
+    <span class="theme-icon">🌙</span>
+  </div>
 </div>
 
 <div class="box">
@@ -88,6 +236,47 @@
 
 <script src="/axios.js"></script>
 <script>
+  // =============================
+  // Theme Toggle Functionality
+  // =============================
+  (function() {
+    const themeToggle = document.getElementById('themeToggle');
+    const html = document.documentElement;
+
+    const savedTheme = localStorage.getItem('theme');
+    const systemPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+
+    let currentTheme = savedTheme || (systemPrefersDark ? 'dark' : 'light');
+
+    function applyTheme(theme) {
+      if (theme === 'dark') {
+        html.setAttribute('data-theme', 'dark');
+        themeToggle.classList.add('dark');
+      } else {
+        html.removeAttribute('data-theme');
+        themeToggle.classList.remove('dark');
+      }
+    }
+
+    applyTheme(currentTheme);
+
+    themeToggle.addEventListener('click', function() {
+      currentTheme = currentTheme === 'dark' ? 'light' : 'dark';
+      applyTheme(currentTheme);
+      localStorage.setItem('theme', currentTheme);
+    });
+
+    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function(e) {
+      if (!localStorage.getItem('theme')) {
+        currentTheme = e.matches ? 'dark' : 'light';
+        applyTheme(currentTheme);
+      }
+    });
+  })();
+
+  // =============================
+  // Original Axios Sandbox Code
+  // =============================
   (function () {
     var url = document.getElementById('url');
     var method = document.getElementById('method');


### PR DESCRIPTION
Currently, the app only supports a single theme.
This commit introduces a theme toggle (switch in the header/navbar) that allows users to switch between light mode and dark mode.

- Default theme respects user's system preference
- Toggle button added to navbar
- Improved accessibility and user experience

Closes #7086
