### PR TITLE
feat(sandbox): add styled footer and theme toggle

### DIFF
--- a/sandbox/client.html
+++ b/sandbox/client.html
@@ -4,13 +4,70 @@
   <title>AXIOS | Sandbox</title>
   <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css"/>
   <style type="text/css">
+    :root {
+      --bg-color: #ffffff;
+      --text-color: #212529;
+      --input-bg: #ffffff;
+      --input-border: #ced4da;
+      --input-text: #212529;
+      --pre-bg: #f8f9fa;
+      --pre-text: #212529;
+      --footer-bg: #f8f9fa;
+      --footer-border: #e9ecef;
+      --link-color: #0d6efd;
+      --btn-bg: #0d6efd;
+      --btn-text: #ffffff;
+    }
+
+    [data-theme="dark"] {
+      --bg-color: #1a1a1a;
+      --text-color: #e9ecef;
+      --input-bg: #2d2d2d;
+      --input-border: #495057;
+      --input-text: #e9ecef;
+      --pre-bg: #2d2d2d;
+      --pre-text: #e9ecef;
+      --footer-bg: #212529;
+      --footer-border: #495057;
+      --link-color: #6ea8fe;
+      --btn-bg: #0d6efd;
+      --btn-text: #ffffff;
+    }
+
+    html, body {
+      height: 100%;
+      min-height: 100%;
+    }
+    body {
+      display: flex;
+      flex-direction: column;
+      min-height: 100vh;
+      box-sizing: border-box;
+      background-color: var(--bg-color);
+      color: var(--text-color);
+      transition: background-color 0.3s ease, color 0.3s ease;
+    }
     pre {
       min-height: 39px;
       overflow: auto;
+      background-color: var(--pre-bg);
+      color: var(--pre-text);
+      border: 1px solid var(--input-border);
+      padding: 10px;
+      border-radius: 4px;
+    }
+    main {
+      flex: 1 0 auto;
     }
     .header{
       display: flex;
       flex-direction: row;
+      align-items: center;
+      justify-content: space-between;
+    }
+    .header-left {
+      display: flex;
+      align-items: center;
     }
     .box{
       display: grid;
@@ -20,6 +77,57 @@
     .well {
       max-width: 400px;
     }
+    .form-control, .form-select {
+      background-color: var(--input-bg);
+      color: var(--input-text);
+      border-color: var(--input-border);
+    }
+    .form-control:focus, .form-select:focus {
+      background-color: var(--input-bg);
+      color: var(--input-text);
+      border-color: var(--link-color);
+    }
+    label {
+      color: var(--text-color);
+    }
+    .btn-primary {
+      background-color: var(--btn-bg);
+      border-color: var(--btn-bg);
+      color: var(--btn-text);
+    }
+    footer.site-footer {
+      flex-shrink: 0;
+      background: var(--footer-bg);
+      border-top: 1px solid var(--footer-border);
+    }
+    .site-footer a {
+      color: var(--link-color);
+      text-decoration: none;
+    }
+    .site-footer a:hover {
+      text-decoration: underline;
+    }
+    .theme-toggle {
+      background: none;
+      border: 2px solid var(--input-border);
+      border-radius: 50%;
+      width: 40px;
+      height: 40px;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      transition: all 0.3s ease;
+      color: var(--text-color);
+    }
+    .theme-toggle:hover {
+      border-color: var(--link-color);
+      transform: rotate(20deg);
+    }
+    .theme-toggle svg {
+      width: 20px;
+      height: 20px;
+    }
     @media screen and (max-width: 1000px) {
       .box {
         grid-template-columns: 1fr;
@@ -27,68 +135,147 @@
     }
   </style>
 </head>
-<body class="container">
-<div class="header">
-  <img src="https://axios-http.com/assets/logo.svg" alt="axios" width="100" height="60">
-  <h1> &nbsp;| Sandbox</h1>
-</div>
-
-<div class="box">
-  <div class="well">
-    <h3>Input</h3>
-    <form role="form" onsubmit="return false;">
-      <div class="form-group">
-        <label for="url">URL</label>
-        <input id="url" type="url" class="form-control" placeholder="/api"/>
-      </div>
-      <div class="form-group">
-        <label for="method">Method</label>
-        <select id="method" class="form-control">
-          <option value="GET">GET</option>
-          <option value="POST">POST</option>
-          <option value="PUT">PUT</option>
-          <option value="DELETE">DELETE</option>
-          <option value="HEAD">HEAD</option>
-          <option value="PATCH">PATCH</option>
-        </select>
-      </div>
-      <div class="form-group">
-        <label for="params">Params</label>
-        <textarea id="params" class="form-control" placeholder='{"foo": "bar", "baz": 123.45}'></textarea>
-      </div>
-      <div class="form-group" style="display: none;">
-        <label for="data">Data</label>
-        <textarea id="data" class="form-control" placeholder='{"foo": "bar", "baz": 123.45}'></textarea>
-      </div>
-      <div class="form-group">
-        <label for="headers">Headers</label>
-        <textarea id="headers" class="form-control" placeholder='{"X-Requested-With": "XMLHttpRequest"}'></textarea>
-      </div>
-      <button id="submit" type="submit" class="btn btn-primary">Send Request</button>
-    </form>
+<body>
+<main class="container">
+  <div class="header my-3">
+    <div class="header-left">
+      <img src="https://axios-http.com/assets/logo.svg" alt="axios" width="100" height="60">
+      <h1 class="h3 mb-0">&nbsp;| Sandbox</h1>
+    </div>
+    <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme" title="Toggle light/dark mode">
+      <svg id="theme-icon-sun" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" style="display: none;">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+      </svg>
+      <svg id="theme-icon-moon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+      </svg>
+    </button>
   </div>
 
-  <div class="response">
+  <div class="box">
     <div class="well">
-      <h3>Request</h3>
-      <pre id="request">No Data</pre>
+      <h3>Input</h3>
+      <form role="form" onsubmit="return false;">
+        <div class="form-group">
+          <label for="url">URL</label>
+          <input id="url" type="url" class="form-control" placeholder="/api"/>
+        </div>
+        <div class="form-group">
+          <label for="method">Method</label>
+          <select id="method" class="form-control">
+            <option value="GET">GET</option>
+            <option value="POST">POST</option>
+            <option value="PUT">PUT</option>
+            <option value="DELETE">DELETE</option>
+            <option value="HEAD">HEAD</option>
+            <option value="PATCH">PATCH</option>
+          </select>
+        </div>
+        <div class="form-group">
+          <label for="params">Params</label>
+          <textarea id="params" class="form-control" placeholder='{"foo": "bar", "baz": 123.45}'></textarea>
+        </div>
+        <div class="form-group" style="display: none;">
+          <label for="data">Data</label>
+          <textarea id="data" class="form-control" placeholder='{"foo": "bar", "baz": 123.45}'></textarea>
+        </div>
+        <div class="form-group">
+          <label for="headers">Headers</label>
+          <textarea id="headers" class="form-control" placeholder='{"X-Requested-With": "XMLHttpRequest"}'></textarea>
+        </div>
+        <button id="submit" type="submit" class="btn btn-primary">Send Request</button>
+      </form>
     </div>
 
-    <div class="well">
-      <h3>Response</h3>
-      <pre id="response">No Data</pre>
-    </div>
+    <div class="response">
+      <div class="well">
+        <h3>Request</h3>
+        <pre id="request">No Data</pre>
+      </div>
 
-    <div class="well">
-      <h3>Error</h3>
-      <pre id="error">None</pre>
+      <div class="well">
+        <h3>Response</h3>
+        <pre id="response">No Data</pre>
+      </div>
+
+      <div class="well">
+        <h3>Error</h3>
+        <pre id="error">None</pre>
+      </div>
     </div>
   </div>
-</div>
+</main>
+
+<footer class="site-footer py-3 mt-4">
+  <div class="container d-flex flex-column flex-md-row align-items-center justify-content-between">
+    <div class="d-flex align-items-center mb-2 mb-md-0">
+      <img src="https://axios-http.com/assets/logo.svg" alt="axios" width="28" height="18" class="me-2">
+      <span class="text-muted">© <span id="year"></span> Axios. All rights reserved.</span>
+    </div>
+    <nav class="nav">
+      <a class="nav-link px-2" href="https://axios-http.com/" target="_blank" rel="noopener">Official Docs</a>
+      <a class="nav-link px-2" href="https://github.com/axios/axios" target="_blank" rel="noopener">GitHub</a>
+      <a class="nav-link px-2" href="mailto:hello@axios-http.com">Contact</a>
+    </nav>
+  </div>
+</footer>
 
 <script src="/axios.js"></script>
 <script>
   (function () {
+    // Set footer year
+    document.getElementById('year').textContent = new Date().getFullYear();
+
+    // Theme toggle functionality
+    const themeToggle = document.getElementById('theme-toggle');
+    const sunIcon = document.getElementById('theme-icon-sun');
+    const moonIcon = document.getElementById('theme-icon-moon');
+    const html = document.documentElement;
+
+    // Get theme from localStorage or system preference
+    function getPreferredTheme() {
+      const savedTheme = localStorage.getItem('theme');
+      if (savedTheme) {
+        return savedTheme;
+      }
+      return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    }
+
+    // Set theme
+    function setTheme(theme) {
+      html.setAttribute('data-theme', theme);
+      localStorage.setItem('theme', theme);
+      
+      // Toggle icons
+      if (theme === 'dark') {
+        sunIcon.style.display = 'block';
+        moonIcon.style.display = 'none';
+      } else {
+        sunIcon.style.display = 'none';
+        moonIcon.style.display = 'block';
+      }
+    }
+
+    // Toggle theme
+    function toggleTheme() {
+      const currentTheme = html.getAttribute('data-theme') || 'light';
+      const newTheme = currentTheme === 'light' ? 'dark' : 'light';
+      setTheme(newTheme);
+    }
+
+    // Initialize theme
+    setTheme(getPreferredTheme());
+
+    // Add event listener
+    themeToggle.addEventListener('click', toggleTheme);
+
+    // Listen for system theme changes
+    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
+      if (!localStorage.getItem('theme')) {
+        setTheme(e.matches ? 'dark' : 'light');
+      }
+    });
+
     var url = document.getElementById('url');
     var method = document.getElementById('method');
     var params = document.getElementById('params');


### PR DESCRIPTION
- Add responsive styled footer with logo, copyright, and navigation links
- Implement light/dark mode toggle with system preference detection
- Add CSS variables for comprehensive theming across all UI elements
- Persist theme choice in localStorage with smooth transitions
- Restructure layout with flexbox to keep footer at page bottom
- Add sun/moon icons with smooth rotation animation on hover
- Ensure accessibility with ARIA labels and semantic HTML

Features:
* Styled footer with Axios logo, dynamic year, and nav links (Docs, GitHub, Contact)
* Theme toggle button in header respecting system preferences
* CSS custom properties for light/dark mode theming
* LocalStorage persistence for user theme preference
* Responsive design for mobile and desktop
* Smooth 0.3s transitions between themes

Resolves #7087

<!-- Click "Preview" for a more readable version -->

#### Instructions

Please read and follow the instructions before creating and submitting a pull request:

- Create an issue explaining the feature. It could save you some effort in case we don't consider it should be included in axios.
- If you're fixing a bug, try to commit the failing test/s and the code fixing it in different commits.
- Ensure you're following our [contributing guide](https://github.com/axios/axios/blob/master/CONTRIBUTING.md).

**⚠️👆 Delete the instructions before submitting the pull request 👆⚠️**

Describe your pull request here.
