### PR TITLE
fix(core): set default for allowAbsoluteUrls and use strict equality …

### DIFF
--- a/lib/core/buildFullPath.js
+++ b/lib/core/buildFullPath.js
@@ -13,9 +13,12 @@ import combineURLs from '../helpers/combineURLs.js';
  *
  * @returns {string} The combined full path
  */
-export default function buildFullPath(baseURL, requestedURL, allowAbsoluteUrls) {
+export default function buildFullPath(baseURL, requestedURL, allowAbsoluteUrls = true) {
+  // requestedURL is relative when it's not an absolute URL
   let isRelativeUrl = !isAbsoluteURL(requestedURL);
-  if (baseURL && (isRelativeUrl || allowAbsoluteUrls == false)) {
+  // If a baseURL is provided, combine when the request is relative
+  // or when absolute URLs are explicitly disabled (allowAbsoluteUrls === false).
+  if (baseURL && (isRelativeUrl || allowAbsoluteUrls === false)) {
     return combineURLs(baseURL, requestedURL);
   }
   return requestedURL;


### PR DESCRIPTION
The buildFullPath helper currently didn't set a default for the allowAbsoluteUrls parameter and used a loose equality check when deciding whether to combine baseURL and requestedURL. This can lead to surprising behavior when callers omit the parameter or pass falsy values.

I edited buildFullPath.js to:
export default function buildFullPath(baseURL, requestedURL, allowAbsoluteUrls = true) { ... }
use allowAbsoluteUrls === false in the conditional
