### PR TITLE
Fix(url): Normalize Slashes and whitespace in combineURLs

### DIFF
--- a/lib/helpers/combineURLs.js
+++ b/lib/helpers/combineURLs.js
@@ -10,6 +10,7 @@
  */
 export default function combineURLs(baseURL, relativeURL) {
   return relativeURL
-    ? baseURL.replace(/\/?\/$/, '') + '/' + relativeURL.replace(/^\/+/, '')
+    // Remove trailing slashes from baseURL and leading slashes from relativeURL
+    ? baseURL.replace(/\/+$|^\s+|\s+$/g, '').replace(/\/+$/,'') + '/' + relativeURL.replace(/^\/+/, '')
     : baseURL;
 }


### PR DESCRIPTION
Description:
- fix for combineURLs — trims whitespace and normalizes slashes so base/relative combinations are predictable.
Why:
- Prevents issues when inputs include extra spaces or unexpected slashes.
Tests (optional):
- base: 'https://example.com/' + relative: '/foo' -> 'https://example.com/foo'
- base: 'https://example.com ' + relative: 'bar' -> 'https://example.com/bar'
