### PR TITLE
chore: replace twitter.com with x.com

### DIFF
--- a/examples/get/index.html
+++ b/examples/get/index.html
@@ -19,7 +19,7 @@
                 '<div class="col-md-3">' +
                   '<strong>' + person.name + '</strong>' +
                   '<div>GitHub: <a href="https://github.com/' + person.github + '" target="_blank">' + person.github + '</a></div>' +
-                  '<div>Twitter: <a href="https://twitter.com/' + person.twitter + '" target="_blank">' + person.twitter + '</a></div>' +
+                  '<div>Twitter: <a href="https://x.com/' + person.twitter + '" target="_blank">' + person.twitter + '</a></div>' +
                 '</div>' +
               '</li><br/>'
             );


### PR DESCRIPTION
Replace outdated twitter link getter