### PR TITLE
fix: correct response headers TypeScript types to use lowercase keys [Hacktoberfest]

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -91,7 +91,7 @@ export type RawAxiosRequestHeaders = Partial<RawAxiosHeaders & {
 
 export type AxiosRequestHeaders = RawAxiosRequestHeaders & AxiosHeaders;
 
-type CommonResponseHeadersList = 'Server' | 'Content-Type' | 'Content-Length' | 'Cache-Control'| 'Content-Encoding';
+type CommonResponseHeadersList = 'server' | 'content-type' | 'content-length' | 'cache-control' | 'content-encoding';
 
 type RawCommonResponseHeaders = {
   [Key in CommonResponseHeadersList]: AxiosHeaderValue;


### PR DESCRIPTION

  - Branch: fix/response-headers-lowercase-typing
  - Single line change: Updated header names to lowercase
  - Zero breaking changes: All existing code continues to work
  - Create PR at: https://github.com/abhishekmaniy/axios/pull/new/fix/respons
  e-headers-lowercase-typing

  Suggested PR Description:

  ## Summary
  Fix response headers TypeScript types to use lowercase keys matching
  runtime behavior.

  ## Problem
  Response headers are normalized to lowercase at runtime (as documented),
  but TypeScript types incorrectly used Title Case headers, causing
  type/runtime mismatches.

  ## Solution
  Change `CommonResponseHeadersList` to use lowercase header names:
  - `'Server'` → `'server'`
  - `'Content-Type'` → `'content-type'`
  - `'Content-Length'` → `'content-length'`
  - etc.

  ## Test case
  ```typescript
  const response = await axios.head(url);
  // ✅ Now properly typed and has runtime value
  const length = response.headers['content-length'];
  // ❌ Title Case headers are undefined at runtime
  const titleCase = response.headers['Content-Length']; // undefined

  Fixes the TypeScript/runtime mismatch reported in the issue.

  This minimal fix aligns the TypeScript definitions with axios's documented
  and actual runtime behavior!