### PR TITLE
fix: use synchronous decompression for large responses (#7008)

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -521,27 +521,40 @@ export default isHttpAdapterSupported && function httpAdapter(config) {
         case 'gzip':
         case 'x-gzip':
         case 'compress':
-        case 'x-compress':
-          // add the unzipper to the body stream processing pipeline
-          streams.push(zlib.createUnzip(zlibOptions));
+        case 'x-compress': {
+          // Use synchronous decompression for large responses (>1MB)
+          if (res.headers['content-length'] && Number(res.headers['content-length']) > 1024 * 1024) {
+            // Mark to decompress synchronously after collecting all chunks
+            res._decompressSync = true;
+          } else {
+            // Normal streamed decompression for small responses
+            streams.push(zlib.createUnzip(zlibOptions));
+          }
 
-          // remove the content-encoding in order to not confuse downstream operations
           delete res.headers['content-encoding'];
           break;
-        case 'deflate':
-          streams.push(new ZlibHeaderTransformStream());
+        }
 
-          // add the unzipper to the body stream processing pipeline
-          streams.push(zlib.createUnzip(zlibOptions));
+        case 'deflate': {
+          if (res.headers['content-length'] && Number(res.headers['content-length']) > 1024 * 1024) {
+            res._decompressSync = true;
+          } else {
+            streams.push(new ZlibHeaderTransformStream());
+            streams.push(zlib.createUnzip(zlibOptions));
+          }
 
-          // remove the content-encoding in order to not confuse downstream operations
           delete res.headers['content-encoding'];
           break;
-        case 'br':
+        }
+
+        case 'br': {
           if (isBrotliSupported) {
+            // Optional: For Brotli, you can also do sync decompression if needed
             streams.push(zlib.createBrotliDecompress(brotliOptions));
             delete res.headers['content-encoding'];
           }
+          break;
+        }
         }
       }
 
@@ -601,29 +614,55 @@ export default isHttpAdapterSupported && function httpAdapter(config) {
           reject(AxiosError.from(err, null, config, lastRequest));
         });
 
-        responseStream.on('end', function handleStreamEnd() {
-          try {
-            let responseData = responseBuffer.length === 1 ? responseBuffer[0] : Buffer.concat(responseBuffer);
-            if (responseType !== 'arraybuffer') {
-              responseData = responseData.toString(responseEncoding);
-              if (!responseEncoding || responseEncoding === 'utf8') {
-                responseData = utils.stripBOM(responseData);
-              }
-            }
-            response.data = responseData;
-          } catch (err) {
-            return reject(AxiosError.from(err, null, config, response.request, response));
-          }
-          settle(resolve, reject, response);
-        });
+       responseStream.on('end', function handleStreamEnd() {
+  try {
+    let responseData;
+
+    if (res._decompressSync) {
+      // For large responses (>1MB), decompress synchronously
+      const buffer = responseBuffer.length === 1 ? responseBuffer[0] : Buffer.concat(responseBuffer);
+
+      const encoding = (res.headers['content-encoding'] || '').toLowerCase();
+      if (encoding === 'gzip' || encoding === 'x-gzip') {
+        responseData = zlib.gunzipSync(buffer);
+      } else if (encoding === 'deflate') {
+        responseData = zlib.inflateSync(buffer);
+      } else {
+        responseData = buffer;
       }
 
-      emitter.once('abort', err => {
-        if (!responseStream.destroyed) {
-          responseStream.emit('error', err);
-          responseStream.destroy();
+      if (responseType !== 'arraybuffer') {
+        responseData = responseData.toString(responseEncoding || 'utf8');
+        if (!responseEncoding || responseEncoding === 'utf8') {
+          responseData = utils.stripBOM(responseData);
         }
-      });
+      }
+    } else {
+      // Small responses or streamed decompression
+      responseData = responseBuffer.length === 1 ? responseBuffer[0] : Buffer.concat(responseBuffer);
+      if (responseType !== 'arraybuffer') {
+        responseData = responseData.toString(responseEncoding);
+        if (!responseEncoding || responseEncoding === 'utf8') {
+          responseData = utils.stripBOM(responseData);
+        }
+      }
+    }
+
+    response.data = responseData;
+  } catch (err) {
+    return reject(AxiosError.from(err, null, config, response.request, response));
+  }
+  settle(resolve, reject, response);
+});
+
+
+        emitter.once('abort', err => {
+          if (!responseStream.destroyed) {
+            responseStream.emit('error', err);
+            responseStream.destroy();
+          }
+        });
+      }
     });
 
     emitter.once('abort', err => {


### PR DESCRIPTION
Large JSON responses (>1MB) with axios were taking 20–30s due to async decompression.
This PR adds a `_decompressSync` flag for large responses and decompresses them synchronously,
reducing latency. Small responses continue using streamed decompression.

Fixes #7008

