### PR TITLE
fix(core): fix IE11 support by removing the isEmptyObject util 

### DIFF
--- a/lib/core/mergeConfig.js
+++ b/lib/core/mergeConfig.js
@@ -18,8 +18,6 @@ module.exports = function mergeConfig(config1, config2) {
   function getMergedValue(target, source) {
     if (utils.isPlainObject(target) && utils.isPlainObject(source)) {
       return utils.merge(target, source);
-    } else if (utils.isEmptyObject(source)) {
-      return utils.merge({}, target);
     } else if (utils.isPlainObject(source)) {
       return utils.merge({}, source);
     } else if (utils.isArray(source)) {
@@ -62,6 +60,10 @@ module.exports = function mergeConfig(config1, config2) {
     }
   }
 
+  function assignProps(prop) {
+    return Object.assign({}, config1[prop], config2[prop]);
+  }
+
   var mergeMap = {
     'url': valueFromConfig2,
     'method': valueFromConfig2,
@@ -90,7 +92,8 @@ module.exports = function mergeConfig(config1, config2) {
     'cancelToken': defaultToConfig2,
     'socketPath': defaultToConfig2,
     'responseEncoding': defaultToConfig2,
-    'validateStatus': mergeDirectKeys
+    'validateStatus': mergeDirectKeys,
+    'headers': assignProps
   };
 
   utils.forEach(Object.keys(config1).concat(Object.keys(config2)), function computeConfigValue(prop) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -125,16 +125,6 @@ function isPlainObject(val) {
 }
 
 /**
- * Determine if a value is a empty Object
- *
- * @param {Object} val The value to test
- * @return {boolean} True if value is a empty Object, otherwise false
- */
-function isEmptyObject(val) {
-  return val && Object.keys(val).length === 0 && Object.getPrototypeOf(val) === Object.prototype;
-}
-
-/**
  * Determine if a value is a Date
  *
  * @function
@@ -493,7 +483,6 @@ module.exports = {
   isNumber: isNumber,
   isObject: isObject,
   isPlainObject: isPlainObject,
-  isEmptyObject: isEmptyObject,
   isUndefined: isUndefined,
   isDate: isDate,
   isFile: isFile,

--- a/test/specs/core/mergeConfig.spec.js
+++ b/test/specs/core/mergeConfig.spec.js
@@ -257,22 +257,6 @@ describe('core::mergeConfig', function() {
         .toEqual({validateStatus: {a: 1, b: 2, c: 2}});
     });
 
-    it('should merge if config1 is class object', function() {
-      class Header {};
-      var validateStatus = new Header();
-      validateStatus["X-Foo"] = "bar";
-      var merged = mergeConfig({validateStatus: validateStatus}, {validateStatus: {}});
-      expect(JSON.stringify(merged.validateStatus)).toBe(JSON.stringify(validateStatus));
-    });
-
-    it('should merge if config2 is class object', function() {
-      class Header {};
-      var validateStatus = new Header();
-      validateStatus["X-Foo"] = "bar";
-      var merged = mergeConfig({validateStatus: {}}, {validateStatus: validateStatus});
-      expect(JSON.stringify(merged.validateStatus)).toBe(JSON.stringify(validateStatus));
-    });
-
     it('should clone config2 if is plain object', function() {
       var config1 = {validateStatus: [1, 2, 3]};
       var config2 = {validateStatus: {a: 1, b: 2}};
@@ -321,6 +305,24 @@ describe('core::mergeConfig', function() {
       expect(mergeConfig({validateStatus: 'str'}, config2).validateStatus).toBe('str');
       expect(mergeConfig({validateStatus: obj}, config2).validateStatus).toBe(obj);
       expect(mergeConfig({validateStatus: null}, config2).validateStatus).toBe(null);
+    });
+  });
+
+  describe('headers config', function() {
+    it('should merge if config1 is a class object', function() {
+      class Header {};
+      var headers = new Header();
+      headers["X-Foo"] = "bar";
+      var merged = mergeConfig({headers}, {headers: {}});
+      expect(JSON.stringify(merged.headers)).toBe(JSON.stringify(headers));
+    });
+
+    it('should merge if config2 is a class object', function() {
+      class Header {};
+      var headers = new Header();
+      headers["X-Foo"] = "bar";
+      var merged = mergeConfig({headers: {}}, {headers});
+      expect(JSON.stringify(merged.headers)).toBe(JSON.stringify(headers));
     });
   });
 });


### PR DESCRIPTION
The utility doesn't check whether the passed object is actually an object, which causes an error in IE11. It was used inside mergeConfig to merge custom objects in a rather strange way, so mergeConfig has been reworked, and the utility has been completely removed as it is no longer needed. For compatibility reasons, the functionality has been re-implemented, but only for the headers config. This functionality is not available at all in the 1.x branch and its usefulness is questionable.

**BREAKING CHANGE:** merging custom objects is now supported only for the header config.

Fixes #7111
Ref #4871
