### PR TITLE
fix(http): preserve partial response on aborted streams by capturing …

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -581,16 +581,40 @@ export default isHttpAdapterSupported && function httpAdapter(config) {
           }
         });
 
+        // Add partial capture setup
+        const partialBuffers = [];
+        const savedStatus = res.statusCode;
+        const savedStatusText = res.statusMessage;
+        const savedHeaders = res.headers;
+
+        responseStream.on('data', function handleStreamData(chunk) {
+          partialBuffers.push(chunk);
+          // ...existing code for buffering and maxContentLength...
+        });
+
         responseStream.on('aborted', function handlerStreamAborted() {
           if (rejected) {
             return;
           }
-
-          const err = new AxiosError(
-            'stream has been aborted',
+          const partialData = Buffer.concat(partialBuffers);
+          const partial = (responseType === 'arraybuffer')
+            ? partialData
+            : partialData.toString(responseEncoding);
+          const partialResponse = {
+            data: partial,
+            status: savedStatus,
+            statusText: savedStatusText,
+            headers: new AxiosHeaders(savedHeaders),
+            config,
+            request: lastRequest,
+            isPartial: true
+          };
+          const err = AxiosError.from(
+            new Error('stream has been aborted'),
             AxiosError.ERR_BAD_RESPONSE,
             config,
-            lastRequest
+            lastRequest,
+            partialResponse
           );
           responseStream.destroy(err);
           reject(err);
@@ -598,6 +622,22 @@ export default isHttpAdapterSupported && function httpAdapter(config) {
 
         responseStream.on('error', function handleStreamError(err) {
           if (req.destroyed) return;
+          if (partialBuffers.length) {
+            const partialData = Buffer.concat(partialBuffers);
+            const partial = (responseType === 'arraybuffer')
+              ? partialData
+              : partialData.toString(responseEncoding);
+            const partialResponse = {
+              data: partial,
+              status: savedStatus,
+              statusText: savedStatusText,
+              headers: new AxiosHeaders(savedHeaders),
+              config,
+              request: lastRequest,
+              isPartial: true
+            };
+            return reject(AxiosError.from(err, null, config, lastRequest, partialResponse));
+          }
           reject(AxiosError.from(err, null, config, lastRequest));
         });
 


### PR DESCRIPTION
fix(http): preserve partial response on aborted streams

Capture status, statusText, headers, and buffered chunks once headers arrive.
On 'aborted' or 'error', build a partial response and pass it to AxiosError.from(...)
so err.response is populated for mid‑stream aborts, enabling better retries and debugging.

Refs: #6935 
contributing for hactoberfest 2025