### PR TITLE
fix: unsettled promise when request is aborted and compression is used and maxRedirects is set to 0

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -597,7 +597,7 @@ export default isHttpAdapterSupported && function httpAdapter(config) {
         });
 
         responseStream.on('error', function handleStreamError(err) {
-          if (req.destroyed) return;
+          if (rejected) return;
           reject(AxiosError.from(err, null, config, lastRequest));
         });
 

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -912,7 +912,7 @@ export default isHttpAdapterSupported &&
           });
 
           responseStream.on('error', function handleStreamError(err) {
-            if (req.destroyed) return;
+            if (rejected) return;
             reject(AxiosError.from(err, null, config, lastRequest, response));
           });
 

--- a/test/unit/adapters/http.js
+++ b/test/unit/adapters/http.js
@@ -690,6 +690,27 @@ describe('supports http with nodejs', function () {
 
             await axios.get(LOCAL_SERVER_URL);
           });
+
+          it("should throw an error if http server aborts and maxRedirects is 0", async () => {
+            server = await startHTTPServer(async function (req, res) {
+              res.setHeader('Content-Encoding', type);
+              res.setHeader('Transfer-Encoding', 'chunked');
+              res.removeHeader('Content-Length');
+              res.write(await zipped);
+              setTimeout(() => {
+                res.socket.destroy();
+              }, 10);
+            });
+
+            try {
+              await axios.get(LOCAL_SERVER_URL, {
+                maxRedirects: 0,
+              });
+              assert.fail("expected aborted error");
+            } catch (err) {
+              assert.equal(err.message, `aborted`);
+            }
+          });
         });
       }
 

--- a/test/unit/adapters/http.js
+++ b/test/unit/adapters/http.js
@@ -708,7 +708,7 @@ describe('supports http with nodejs', function () {
               });
               assert.fail("expected aborted error");
             } catch (err) {
-              assert.equal(err.message, `aborted`);
+              assert.match(err.message, /aborted|Premature close/);
             }
           });
         });

--- a/tests/unit/adapters/http.test.js
+++ b/tests/unit/adapters/http.test.js
@@ -823,6 +823,28 @@ describe('supports http with nodejs', () => {
               await stopHTTPServer(server);
             }
           });
+
+          it('should reject when the server aborts mid-stream and maxRedirects is 0', async () => {
+            const server = await startHTTPServer(
+              async (req, res) => {
+                res.setHeader('Content-Encoding', type);
+                res.setHeader('Transfer-Encoding', 'chunked');
+                res.removeHeader('Content-Length');
+                res.write(await zipped);
+                setTimeout(() => res.socket.destroy(), 10);
+              },
+              { port: SERVER_PORT }
+            );
+
+            try {
+              await assert.rejects(
+                axios.get(`http://localhost:${server.address().port}`, { maxRedirects: 0 }),
+                (err) => err && err.code === 'ECONNRESET'
+              );
+            } finally {
+              await stopHTTPServer(server);
+            }
+          });
         });
       }
     });


### PR DESCRIPTION
The axios request is left in an unsettled state (waits forever) when using compression and maxRedirects is set to 0 and the request gets aborted after some chunks are sent.

The problem is that the response `abort` event is not being emitted and the request state inside the `responseStream.on('error')` callback is `destroyed: true, aborted: false`.

I see that previoysly axios was checking `req.aborted` instead of `req.destroyed` inside the `responseStream.on('error')` callback, but since node deprecated the `req.aborted`, it was changed to `req.destroyed` in #4787.

We could change that back to `req.aborted`, but I think checking `rejected` would be a better option, so we can be sure that we are catching all the errors (in case there are some more weird cases).

Failing tests before:

```
  1) supports http with nodejs
       compression
         algorithms
           gzip decompression
             should throw an error if http server aborts and maxRedirects is 0:
     Error: Timeout of 30000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/Users/ebeigarts/code/axios/test/unit/adapters/http.js)
      at listOnTimeout (node:internal/timers:608:17)
      at process.processTimers (node:internal/timers:543:7)

  2) supports http with nodejs
       compression
         algorithms
           GZIP decompression
             should throw an error if http server aborts and maxRedirects is 0:
     Error: Timeout of 30000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/Users/ebeigarts/code/axios/test/unit/adapters/http.js)
      at listOnTimeout (node:internal/timers:608:17)
      at process.processTimers (node:internal/timers:543:7)

  3) supports http with nodejs
       compression
         algorithms
           compress decompression
             should throw an error if http server aborts and maxRedirects is 0:
     Error: Timeout of 30000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/Users/ebeigarts/code/axios/test/unit/adapters/http.js)
      at listOnTimeout (node:internal/timers:608:17)
      at process.processTimers (node:internal/timers:543:7)

  4) supports http with nodejs
       compression
         algorithms
           deflate decompression
             should throw an error if http server aborts and maxRedirects is 0:
     Error: Timeout of 30000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/Users/ebeigarts/code/axios/test/unit/adapters/http.js)
      at listOnTimeout (node:internal/timers:608:17)
      at process.processTimers (node:internal/timers:543:7)

  5) supports http with nodejs
       compression
         algorithms
           deflate-raw decompression
             should throw an error if http server aborts and maxRedirects is 0:
     Error: Timeout of 30000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/Users/ebeigarts/code/axios/test/unit/adapters/http.js)
      at listOnTimeout (node:internal/timers:608:17)
      at process.processTimers (node:internal/timers:543:7)

  6) supports http with nodejs
       compression
         algorithms
           br decompression
             should throw an error if http server aborts and maxRedirects is 0:
     Error: Timeout of 30000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/Users/ebeigarts/code/axios/test/unit/adapters/http.js)
      at listOnTimeout (node:internal/timers:608:17)
      at process.processTimers (node:internal/timers:543:7)
```