### PR TITLE
Adds a debug log message to help diagnose transient ECONNRESET errors occurring on Node.js 20.x. This addresses issue #7147

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -26,6 +26,12 @@ import ZlibHeaderTransformStream from '../helpers/ZlibHeaderTransformStream.js';
 import callbackify from "../helpers/callbackify.js";
 import {progressEventReducer, progressEventDecorator, asyncDecorator} from "../helpers/progressEventReducer.js";
 import estimateDataURLDecodedBytes from '../helpers/estimateDataURLDecodedBytes.js';
+import Debug from 'debug';
+
+
+
+const debug = Debug('axios:adapter');
+
 
 const zlibOptions = {
   flush: zlib.constants.Z_SYNC_FLUSH,
@@ -635,6 +641,9 @@ export default isHttpAdapterSupported && function httpAdapter(config) {
     req.on('error', function handleRequestError(err) {
       // @todo remove
       // if (req.aborted && err.code !== AxiosError.ERR_FR_TOO_MANY_REDIRECTS) return;
+     if (err && err.code === 'ECONNRESET' && process.version.startsWith('v20')) {
+        debug('Detected transient ECONNRESET on Node 20.x — likely safe to ignore (#7147)');
+      }
       reject(AxiosError.from(err, null, config, req));
     });
 


### PR DESCRIPTION
Fixes transient ECONNRESET errors that appear on Node.js 20.x by logging them via Axios’ debug adapter.