### PR TITLE
fix(fetch): prevent TypeError when config.env is undefined

### DIFF
--- a/lib/adapters/fetch.js
+++ b/lib/adapters/fetch.js
@@ -262,7 +262,7 @@ const factory = (env) => {
 const seedCache = new Map();
 
 export const getFetch = (config) => {
-  let env = config ? config.env : {};
+  const env = Object.assign({}, globalFetchAPI, config && config.env);
   const {fetch, Request, Response} = env;
   const seeds = [
     Request, Response, fetch


### PR DESCRIPTION
Closes #7153

---

### 🐛 The Problem

This PR fixes a regression introduced in `v1.12.2` that caused a `TypeError` when using the fetch adapter, particularly in environments like service workers.

If a request was made with a `config` object that did not have an `.env` property, the adapter would attempt to destructure an `undefined` value, causing the request to fail.

### 💡 The Solution

The fix ensures the `env` variable within the fetch adapter is always initialized as an object. It safely merges the `globalFetchAPI` with `config && config.env`, preventing the error and restoring the correct fallback behavior.

### ✅ Verification

The core Node.js test suite passes with this change. The fix has also been manually verified in the sandbox environment, confirming that basic requests no longer cause a crash.