### PR TITLE
fix(fetch): prevent TypeError when config.env is undefined

### DIFF
--- a/lib/adapters/fetch.js
+++ b/lib/adapters/fetch.js
@@ -262,7 +262,7 @@ const factory = (env) => {
 const seedCache = new Map();
 
 export const getFetch = (config) => {
-  let env = config ? config.env : {};
+  let env = (config && config.env) || {};
   const {fetch, Request, Response} = env;
   const seeds = [
     Request, Response, fetch


### PR DESCRIPTION

This fix ensures the env variable within the fetch adapter is always initialized as an object, preventing crashes in environments like service workers when config.env is undefined.
Closes #7153

