### PR TITLE
feat(adapter): add optional proxyFromEnvAdapter for automatic proxy detection (HTTP(S)_PROXY/NO_PROXY)

### DIFF
--- a/lib/helpers/proxyFromEnvAdapter.js
+++ b/lib/helpers/proxyFromEnvAdapter.js
@@ -1,0 +1,114 @@
+// lib/helpers/proxyFromEnvAdapter.js
+const { getProxyForUrl } = require('proxy-from-env');
+const { HttpProxyAgent } = require('http-proxy-agent');
+const { HttpsProxyAgent } = require('https-proxy-agent');
+const { URL } = require('url');
+
+/**
+ * Create an Axios adapter wrapper that auto-injects proxy agents from environment
+ * into axios config when user didn't provide manual proxy/agent config.
+ *
+ * Usage:
+ *   const adapterWithAutoProxy = proxyFromEnvAdapter(originalAdapter)
+ *   axios.defaults.adapter = adapterWithAutoProxy
+ *
+ * Rules:
+ * - If config.proxy is explicitly set (including false), or config.httpAgent/httpsAgent
+ *   or config.agent provided, do nothing (manual config wins).
+ * - Uses proxy-from-env's getProxyForUrl(url) which respects NO_PROXY.
+ * - Uses http-proxy-agent for http:, https-proxy-agent for https: (for target scheme).
+ * - Caches agents per proxy URL to reuse agents (Map).
+ */
+function proxyFromEnvAdapter(adapter) {
+  if (!adapter) {
+    throw new Error('proxyFromEnvAdapter requires an underlying adapter');
+  }
+
+  // Cache of created agents: key = proxyUrl (string) + '|' + scheme
+  const agentCache = new Map();
+
+  function getAgentForProxy(proxyUrl, scheme) {
+    const key = `${proxyUrl}|${scheme}`;
+    if (agentCache.has(key)) return agentCache.get(key);
+
+    const agent = (scheme === 'http:')
+      ? new HttpProxyAgent(proxyUrl)
+      : new HttpsProxyAgent(proxyUrl);
+
+    // store and return
+    agentCache.set(key, agent);
+    return agent;
+  }
+
+  function getRequestUrl(config) {
+    // Try to resolve the final absolute URL for the request (axios config typically has url + baseURL)
+    // If url is absolute, URL constructor handles it. If relative, baseURL required.
+    // Fall back to config.baseURL if present; if neither, return null to skip proxy detection.
+    try {
+      if (!config.url) return null;
+
+      // If url is already absolute, new URL(url) works, otherwise use baseURL or undefined.
+      if (/^https?:\/\//i.test(config.url)) {
+        return new URL(config.url);
+      }
+
+      const base = config.baseURL || null;
+      if (!base) return null; // can't resolve relative URL without base
+      return new URL(config.url, base);
+    } catch (err) {
+      // On any parse error, return null to avoid accidentally injecting proxy
+      return null;
+    }
+  }
+
+  return async function wrappedAdapter(config) {
+    // Manual overrides: Respect user's explicit config.
+    // If user set proxy explicitly (includes proxy: false), or provided httpAgent/httpsAgent or agent, do nothing.
+    if (
+      Object.prototype.hasOwnProperty.call(config, 'proxy') && config.proxy !== undefined
+      || config.httpAgent
+      || config.httpsAgent
+      || config.agent
+    ) {
+      return adapter(config);
+    }
+
+    // Build the request URL
+    const reqUrl = getRequestUrl(config);
+    if (!reqUrl) {
+      // cannot determine URL (relative without base) — don't auto-configure proxy
+      return adapter(config);
+    }
+
+    const fullUrl = reqUrl.toString();
+    // Use proxy-from-env which respects NO_PROXY internally
+    const proxyForUrl = getProxyForUrl(fullUrl);
+
+    if (!proxyForUrl) {
+      // no proxy for this URL according to env/NO_PROXY
+      return adapter(config);
+    }
+
+    // create/reuse agent based on request scheme (http: vs https:)
+    const scheme = reqUrl.protocol; // 'http:' or 'https:'
+    const agent = getAgentForProxy(proxyForUrl, scheme);
+
+    // We must set correct config field: axios uses httpAgent for http and httpsAgent for https
+    const newConfig = Object.assign({}, config);
+
+    if (scheme === 'http:') {
+      // For HTTP, axios expects httpAgent
+      newConfig.httpAgent = newConfig.httpAgent || agent;
+    } else if (scheme === 'https:') {
+      // For HTTPS, axios expects httpsAgent
+      newConfig.httpsAgent = newConfig.httpsAgent || agent;
+    } else {
+      // unknown scheme: don't modify
+    }
+
+    // Important: do not set 'proxy' property (we're using node agent approach)
+    return adapter(newConfig);
+  };
+}
+
+module.exports = proxyFromEnvAdapter;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8138,6 +8138,7 @@
       "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
       "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "cross-spawn": "^7.0.1"
       },

--- a/test/helpers/proxyFromEnvAdapter.test.js
+++ b/test/helpers/proxyFromEnvAdapter.test.js
@@ -1,0 +1,40 @@
+// test/proxyFromEnvAdapter.test.js
+const assert = require('assert');
+const { getProxyForUrl } = require('proxy-from-env');
+const proxyFromEnvAdapter = require('../lib/helpers/proxyFromEnvAdapter');
+
+describe('proxyFromEnvAdapter', () => {
+  const dummyAdapter = async (config) => ({ config }); // returns config for inspection
+  const wrapped = proxyFromEnvAdapter(dummyAdapter);
+
+  afterEach(() => {
+    delete process.env.HTTP_PROXY;
+    delete process.env.HTTPS_PROXY;
+    delete process.env.NO_PROXY;
+  });
+
+  it('should not override manual httpAgent/httpsAgent/config.proxy', async () => {
+    const customAgent = {};
+    const res = await wrapped({ url: 'http://example.com', httpAgent: customAgent });
+    assert.strictEqual(res.config.httpAgent, customAgent);
+  });
+
+  it('should inject httpAgent when HTTP_PROXY is set and request is http', async () => {
+    process.env.HTTP_PROXY = 'http://127.0.0.1:3128';
+    const res = await wrapped({ url: 'http://example.com' });
+    assert(res.config.httpAgent, 'httpAgent should be set');
+  });
+
+  it('should inject httpsAgent when HTTPS_PROXY is set and request is https', async () => {
+    process.env.HTTPS_PROXY = 'http://127.0.0.1:3128';
+    const res = await wrapped({ url: 'https://example.com' });
+    assert(res.config.httpsAgent, 'httpsAgent should be set');
+  });
+
+  it('should respect NO_PROXY and not set agent when host excluded', async () => {
+    process.env.HTTP_PROXY = 'http://127.0.0.1:3128';
+    process.env.NO_PROXY = 'example.com';
+    const res = await wrapped({ url: 'http://example.com' });
+    assert(!res.config.httpAgent);
+  });
+});


### PR DESCRIPTION
### feat(adapter): add optional proxyFromEnvAdapter for automatic proxy detection (HTTP(S)_PROXY/NO_PROXY)

#### Describe your pull request
This PR introduces a lightweight, opt-in adapter `proxyFromEnvAdapter` that automatically detects and applies proxy settings from environment variables (`HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY`).

It uses **proxy-from-env** for detection and applies the correct **http-proxy-agent** or **https-proxy-agent** depending on the request scheme.  
Manual configurations (e.g., `proxy: false`, `httpAgent`, or `httpsAgent`) are always respected.

#### Key Features
- ✅ Automatic detection of proxy from environment variables
- ✅ Respects `NO_PROXY` for excluded hosts
- ✅ Manual overrides always take priority
- ✅ Reuses cached proxy agents for better performance
- ✅ Zero breaking changes — works as a drop-in wrapper

#### Implementation Summary
- Added helper file: `lib/helpers/proxyFromEnvAdapter.js`
- Added tests: `test/proxyFromEnvAdapter.test.js`
- No modifications made to Axios core — this adapter wraps existing ones.

#7058 

#### Usage Example
```js
const axios = require('axios');
const httpAdapter = require('axios/lib/adapters/http');
const proxyFromEnvAdapter = require('./lib/helpers/proxyFromEnvAdapter');

axios.defaults.adapter = proxyFromEnvAdapter(httpAdapter);

How It Works :

Detects proxies via proxy-from-env (HTTP_PROXY, HTTPS_PROXY, NO_PROXY).
Chooses http-proxy-agent or https-proxy-agent based on URL scheme.
Injects the proper agent only if no manual proxy or agent exists.
Caches agents by proxy URL to reuse connections.

Tests :

 [ ] Skips auto-injection when manual proxy/agent is defined
 [ ] Adds httpAgent for HTTP and httpsAgent for HTTPS requests
 [ ] Respects NO_PROXY
 [ ] Works with relative URLs and baseURL
 [ ] Verifies caching behavior

Development & Testing :

npm run test      # Runs all Jasmine and Mocha tests
npm run build     # Bundles the source using rollup
npm run examples  # Opens example server for manual testing
npm start         # Runs sandbox client

Checklist :

 [ ] Code follows Node style guide
 [ ] Commit message follows Conventional Commits
 [ ] All tests updated and passing on GitHub Actions
 [ ] Documentation consistent with API
 [ ] Ready for review
