### PR TITLE
Fix/types lowercase response headers

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -91,7 +91,7 @@ export type RawAxiosRequestHeaders = Partial<RawAxiosHeaders & {
 
 export type AxiosRequestHeaders = RawAxiosRequestHeaders & AxiosHeaders;
 
-type CommonResponseHeadersList = 'Server' | 'Content-Type' | 'Content-Length' | 'Cache-Control'| 'Content-Encoding';
+type CommonResponseHeadersList = 'server' | 'content-type' | 'content-length' | 'cache-control'| 'content-encoding';
 
 type RawCommonResponseHeaders = {
   [Key in CommonResponseHeadersList]: AxiosHeaderValue;

--- a/lib/adapters/fetch.js
+++ b/lib/adapters/fetch.js
@@ -262,7 +262,7 @@ const factory = (env) => {
 const seedCache = new Map();
 
 export const getFetch = (config) => {
-  let env = config ? config.env : {};
+  const env = Object.assign({}, globalFetchAPI, config && config.env);
   const {fetch, Request, Response} = env;
   const seeds = [
     Request, Response, fetch


### PR DESCRIPTION
### Summary

This PR corrects the TypeScript types for common response headers to use lowercase keys, aligning them with Axios's documented runtime behavior. This solution explicitly addresses the maintainer's feedback on issue #7110 by ensuring the type system correctly handles any header casing.

### Problem

At runtime, Axios normalizes all incoming response header keys to lowercase (e.g., `content-type`). However, the `CommonResponseHeadersList` type definition used TitleCase keys (e.g., `'Content-Type'`).

This created a discrepancy where TypeScript would incorrectly approve of accessing a TitleCase header, which would be `undefined` at runtime.

```typescript
// Previously, this was considered valid by TypeScript but failed at runtime
const titleCase = response.headers['Content-Type']; // undefined