### PR TITLE
fix(core): properly propagate async errors in interceptor chain

### DIFF
--- a/lib/core/Axios.js
+++ b/lib/core/Axios.js
@@ -160,7 +160,18 @@ class Axios {
       promise = Promise.resolve(config);
 
       while (i < len) {
-        promise = promise.then(chain[i++], chain[i++]);
+        const onFulfilled = chain[i++];
+        const onRejected = chain[i++];
+        promise = promise.then(async (config) => {
+          try {
+            return await onFulfilled(config);
+          } catch (error) {
+            if (!onRejected) {
+              throw error;
+            }
+            return onRejected(error);
+          }
+        });
       }
 
       return promise;

--- a/test/specs/interceptors.spec.js
+++ b/test/specs/interceptors.spec.js
@@ -599,4 +599,70 @@ describe('interceptors', function () {
 
     expect(instance.interceptors.response.handlers.length).toBe(0);
   });
+
+  it('should call onRequestError when a sync request interceptor throws', function () {
+    const callOrder = [];
+    const instance = axios.create({
+      baseURL: 'http://test.com/'
+    });  
+
+    instance.interceptors.request.use(
+      function () {
+        callOrder.push('request fulfilled');
+        throw new Error('async fail');
+      },
+      function (error) {
+        callOrder.push('request rejected');
+        return Promise.reject(error);
+      },
+      { synchronous: true }
+    );
+
+    instance.interceptors.response.use(
+      function (response) {
+        callOrder.push('response fulfilled');
+        return response;
+      },
+      function (error) {
+        callOrder.push('response rejected');
+        return Promise.reject(error);
+      },
+      { synchronous: true }
+    );
+    instance.get('/foo').catch(function () {
+      expect(callOrder).toEqual(['request fulfilled', 'request rejected']);
+    });
+  });
+
+  it('should call onRequestError when an async request interceptor throws', function () {
+    const callOrder = [];
+    const instance = axios.create({
+      baseURL: 'http://test.com/'
+    });  
+
+    instance.interceptors.request.use(
+      async function () {
+        callOrder.push('request fulfilled');
+        throw new Error('async fail');
+      },
+      function (error) {
+        callOrder.push('request rejected');
+        return Promise.reject(error);
+      }
+    );
+
+    instance.interceptors.response.use(
+      function (response) {
+        callOrder.push('response fulfilled');
+        return response;
+      },
+      function (error) {
+        callOrder.push('response rejected');
+        return Promise.reject(error);
+      }
+    );
+    instance.get('/foo').catch(function () {
+      expect(callOrder).toEqual(['request fulfilled', 'request rejected']);
+    });
+  });
 });


### PR DESCRIPTION
Describe your pull request here.

Fixes: https://github.com/axios/axios/issues/7044

It adds test cases and a fix to ensure `onRequestError` is triggered consistently when a request interceptor throws an error — both in **synchronous** and **asynchronous** modes.

Previously, Axios correctly handled synchronous interceptor errors but did not call `onRequestError` for asynchronous interceptors.

## ✅ Changes

- Added two new test cases:
  - One for **synchronous** interceptor error handling.
  - One for **asynchronous** interceptor error handling.
- Updated core logic to ensure consistent behavior for async interceptors.
- Verified that all existing tests continue to pass.


## 🧪 Behavior Before

| Mode | Behavior |
|------|-----------|
| **Synchronous** | `onRequestError` called ✅ |
| **Asynchronous** | `onRequestError` not called ❌ |

---

## 🧠 Behavior After

| Mode | Behavior |
|------|-----------|
| **Synchronous** | `onRequestError` called ✅ |
| **Asynchronous** | `onRequestError` called ✅ |

---


