### PR TITLE
docs: fix mismatched return type

### DIFF
--- a/lib/core/InterceptorManager.js
+++ b/lib/core/InterceptorManager.js
@@ -30,7 +30,7 @@ class InterceptorManager {
    *
    * @param {Number} id The ID that was returned by `use`
    *
-   * @returns {Boolean} `true` if the interceptor was removed, `false` otherwise
+   * @returns {void}
    */
   eject(id) {
     if (this.handlers[id]) {


### PR DESCRIPTION
### Summary

This PR fixes an incorrect return type for `eject(id)` method in `InterceptorManager` class.  The method doesn't return anything yet it was expected to return a `boolean` value. I have corrected it to return `void`.