### PR TITLE
fix: Don't eagerly dereference `http2` properties

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -1,4 +1,3 @@
-import { connect, constants } from 'http2';
 import utils from './../utils.js';
 import settle from './../core/settle.js';
 import buildFullPath from '../core/buildFullPath.js';
@@ -6,6 +5,7 @@ import buildURL from './../helpers/buildURL.js';
 import proxyFromEnv from 'proxy-from-env';
 import http from 'http';
 import https from 'https';
+import http2 from 'http2';
 import util from 'util';
 import followRedirects from 'follow-redirects';
 import zlib from 'zlib';
@@ -35,13 +35,6 @@ const brotliOptions = {
   flush: zlib.constants.BROTLI_OPERATION_FLUSH,
   finishFlush: zlib.constants.BROTLI_OPERATION_FLUSH
 }
-
-const {
-  HTTP2_HEADER_SCHEME,
-  HTTP2_HEADER_METHOD,
-  HTTP2_HEADER_PATH,
-  HTTP2_HEADER_STATUS
-} = constants;
 
 const isBrotliSupported = utils.isFunction(zlib.createBrotliDecompress);
 
@@ -85,7 +78,7 @@ class Http2Sessions {
       }
     }
 
-    const session = connect(authority, options);
+    const session = http2.connect(authority, options);
 
     let removed;
 
@@ -275,6 +268,13 @@ const http2Transport = {
       const {http2Options, headers} = options;
 
       const session = http2Sessions.getSession(authority, http2Options);
+
+      const {
+        HTTP2_HEADER_SCHEME,
+        HTTP2_HEADER_METHOD,
+        HTTP2_HEADER_PATH,
+        HTTP2_HEADER_STATUS
+      } = http2.constants;
 
       const http2Headers = {
         [HTTP2_HEADER_SCHEME]: options.protocol.replace(':', ''),


### PR DESCRIPTION
The v1.13.0 release broke Axios in https://github.com/holepunchto/bare, a minimal JavaScript runtime, as Bare only provides an HTTP2 stub implementation and Axios started eagerly dereferencing HTTP2 properties, leading to reference errors.