### PR TITLE
fix: automatically configure httpsAgent for HTTPS requests through HT…

### DIFF
--- a/index.d.cts
+++ b/index.d.cts
@@ -261,6 +261,8 @@ declare namespace axios {
     port: number;
     auth?: AxiosBasicCredentials;
     protocol?: string;
+    hostname?: string;
+    rejectUnauthorized?: boolean;
   }
 
   type Method =

--- a/index.d.ts
+++ b/index.d.ts
@@ -125,6 +125,8 @@ export interface AxiosProxyConfig {
   port: number;
   auth?: AxiosBasicCredentials;
   protocol?: string;
+  hostname?: string;
+  rejectUnauthorized?: boolean;
 }
 
 export enum HttpStatusCode {

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -174,10 +174,11 @@ function dispatchBeforeRedirect(options, responseDetails) {
  * @param {http.ClientRequestArgs} options
  * @param {AxiosProxyConfig} configProxy configuration from Axios options object
  * @param {string} location
+ * @param {string} originalProtocol the original request protocol (before proxy modification)
  *
  * @returns {http.ClientRequestArgs}
  */
-function setProxy(options, configProxy, location) {
+function setProxy(options, configProxy, location, originalProtocol) {
   let proxy = configProxy;
   if (!proxy && proxy !== false) {
     const proxyUrl = proxyFromEnv.getProxyForUrl(location);
@@ -209,15 +210,20 @@ function setProxy(options, configProxy, location) {
     options.host = proxyHost;
     options.port = proxy.port;
     options.path = location;
-    if (proxy.protocol) {
-      options.protocol = proxy.protocol.includes(':') ? proxy.protocol : `${proxy.protocol}:`;
-    }
+    
+    // Store original protocol and proxy protocol for HTTPS through HTTP proxy detection
+    const proxyProtocol = proxy.protocol ? (proxy.protocol.includes(':') ? proxy.protocol : `${proxy.protocol}:`) : 'http:';
+    options._originalProtocol = originalProtocol || options.protocol;
+    options._proxyProtocol = proxyProtocol;
+    
+    // Set protocol to proxy protocol (defaults to http: if not specified)
+    options.protocol = proxyProtocol;
   }
 
   options.beforeRedirects.proxy = function beforeRedirect(redirectOptions) {
     // Configure proxy for redirected request, passing the original config proxy to apply
     // the exact same logic as if the redirected request was performed by axios directly.
-    setProxy(redirectOptions, configProxy, redirectOptions.href);
+    setProxy(redirectOptions, configProxy, redirectOptions.href, redirectOptions._originalProtocol);
   };
 }
 
@@ -621,12 +627,36 @@ export default isHttpAdapterSupported && function httpAdapter(config) {
     } else {
       options.hostname = parsed.hostname.startsWith("[") ? parsed.hostname.slice(1, -1) : parsed.hostname;
       options.port = parsed.port;
-      setProxy(options, config.proxy, protocol + '//' + parsed.hostname + (parsed.port ? ':' + parsed.port : '') + options.path);
+      setProxy(options, config.proxy, protocol + '//' + parsed.hostname + (parsed.port ? ':' + parsed.port : '') + options.path, protocol);
     }
 
     let transport;
     const isHttpsRequest = isHttps.test(options.protocol);
-    options.agent = isHttpsRequest ? config.httpsAgent : config.httpAgent;
+    
+    // Detect HTTPS request through HTTP proxy scenario
+    // Corporate proxies often do SSL inspection/interception, which requires
+    // configuring the httpsAgent to accept proxy certificates
+    const isHttpsThroughHttpProxy = isHttps.test(options._originalProtocol || protocol) && 
+                                    options._proxyProtocol && 
+                                    !isHttps.test(options._proxyProtocol);
+    
+    // If making HTTPS request through HTTP proxy and no custom httpsAgent provided,
+    // create one that can handle proxy certificates (corporate proxy SSL inspection)
+    let httpsAgent = config.httpsAgent;
+    if (isHttpsThroughHttpProxy && !httpsAgent) {
+      // Check if proxy has rejectUnauthorized option, otherwise default to false for corporate proxies
+      const rejectUnauthorized = config.proxy && config.proxy.rejectUnauthorized !== undefined 
+        ? config.proxy.rejectUnauthorized 
+        : false;
+      httpsAgent = new https.Agent({
+        rejectUnauthorized: rejectUnauthorized,
+        keepAlive: true
+      });
+      // Update agents object for follow-redirects library
+      options.agents.https = httpsAgent;
+    }
+    
+    options.agent = isHttpsRequest ? (httpsAgent || config.httpsAgent) : config.httpAgent;
 
     if (isHttp2) {
        transport = http2Transport;


### PR DESCRIPTION

Fixes #7213

When making HTTPS requests through an HTTP proxy, corporate proxies often perform SSL inspection/interception, presenting their own certificates instead of the target server's certificates. This causes SSL handshake failures.

This fix:
- Automatically detects HTTPS requests through HTTP proxy scenarios
- Creates an httpsAgent with rejectUnauthorized: false when no custom httpsAgent is provided
- Allows users to control certificate validation via proxy.rejectUnauthorized
- Updates TypeScript definitions to include rejectUnauthorized option

The fix ensures that corporate proxy SSL inspection works out of the box without requiring manual httpsAgent configuration.
