### PR TITLE
chore: remove TODO comment and dead code from http adapter error handler

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -816,8 +816,6 @@ export default isHttpAdapterSupported && function httpAdapter(config) {
 
     // Handle errors
     req.on('error', function handleRequestError(err) {
-      // @todo remove
-      // if (req.aborted && err.code !== AxiosError.ERR_FR_TOO_MANY_REDIRECTS) return;
       reject(AxiosError.from(err, null, config, req));
     });
 


### PR DESCRIPTION
## Description

This PR removes commented-out code that was marked with `@todo remove` in the HTTP adapter's error handler. The code was already disabled and is no longer needed, so this is a simple cleanup to improve code maintainability.

## Changes

- Removed TODO comment (`@todo remove`) from `lib/adapters/http.js`
- Removed commented-out conditional check in the request error handler
  - The commented code was: `if (req.aborted && err.code !== AxiosError.ERR_FR_TOO_MANY_REDIRECTS) return;`

## Impact

- **No functional changes** - This only removes dead code that was already commented out
- **No breaking changes** - The behavior remains exactly the same
- **Code quality improvement** - Cleaner codebase by addressing an existing TODO

## Testing

- No new tests needed as this is purely a code cleanup
- Existing tests should continue to pass without modification
- The error handler logic remains unchanged (only commented code was removed)

## Type of Change

- [x] Code cleanup / refactoring
- [x] Documentation improvement (removing outdated TODO)