### PR TITLE
docs: refresh CDN URLs and example JSON headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,13 +188,13 @@ const axios = require('axios/dist/browser/axios.cjs'); // browser commonJS bundl
 Using jsDelivr CDN (ES5 UMD browser module):
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/axios@1.6.7/dist/axios.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/axios@1.13.2/dist/axios.min.js"></script>
 ```
 
 Using unpkg CDN:
 
 ```html
-<script src="https://unpkg.com/axios@1.6.7/dist/axios.min.js"></script>
+<script src="https://unpkg.com/axios@1.13.2/dist/axios.min.js"></script>
 ```
 
 ## Example

--- a/examples/get/server.js
+++ b/examples/get/server.js
@@ -27,7 +27,7 @@ const people = [
 
 export default function (req, res) {
   res.writeHead(200, {
-    'Content-Type': 'text/json'
+    'Content-Type': 'application/json'
   });
   res.write(JSON.stringify(people));
   res.end();

--- a/examples/post/server.js
+++ b/examples/post/server.js
@@ -8,7 +8,7 @@ export default function (req, res) {
   req.on('end', function () {
     console.log('POST data received');
     res.writeHead(200, {
-      'Content-Type': 'text/json'
+    'Content-Type': 'application/json'
     });
     res.write(JSON.stringify(data));
     res.end();

--- a/examples/postMultipartFormData/server.js
+++ b/examples/postMultipartFormData/server.js
@@ -6,7 +6,7 @@ export default function (req, res) {
   req.on('end', function () {
     console.log('POST  received');
     res.writeHead(200, {
-      'Content-Type': 'text/json'
+    'Content-Type': 'application/json'
     });
     res.end();
   });

--- a/lib/helpers/composeSignals.js
+++ b/lib/helpers/composeSignals.js
@@ -21,7 +21,7 @@ const composeSignals = (signals, timeout) => {
 
     let timer = timeout && setTimeout(() => {
       timer = null;
-      onabort(new AxiosError(`timeout ${timeout} of ms exceeded`, AxiosError.ETIMEDOUT))
+      onabort(new AxiosError(`timeout of ${timeout}ms exceeded`, AxiosError.ETIMEDOUT))
     }, timeout)
 
     const unsubscribe = () => {

--- a/test/unit/helpers/composeSignals.js
+++ b/test/unit/helpers/composeSignals.js
@@ -32,7 +32,7 @@ describe('helpers::composeSignals', () => {
       signal.addEventListener('abort', resolve);
     });
 
-    assert.match(String(signal.reason), /timeout 100 of ms exceeded/);
+    assert.match(String(signal.reason), /timeout of 100ms exceeded/);
   });
 
   it('should return undefined if signals and timeout are not provided', async () => {


### PR DESCRIPTION
## Summary

- **Consistent timeout messaging:** The composed AbortController used by the fetch adapter now throws the same `"timeout of Nms exceeded"` text as the HTTP/XHR adapters. The helper’s unit test was updated accordingly so the behavior stays locked.
- **Current CDN snippets:** The README’s jsDelivr and unpkg examples now reference `axios@1.13.2`, matching the version declared in `package.json` and preventing newcomers from copy/pasting an outdated build.
- **Standards-compliant examples:** All example servers that return JSON now emit `Content-Type: application/json` instead of the non-standard `text/json`, so readers following the samples mirror best practices.

Together these tweaks keep the developer experience polished: users get predictable error strings regardless of adapter, documentation reflects the latest release, and sample code won’t propagate incorrect headers.

## Testing

- `node bin/ssl_hotfix.js mocha test/unit/helpers/composeSignals.js`
  - *(Local run is blocked until dependencies such as `cross-env` are installed; please re-run after installing dev deps.)*
