### PR TITLE
fix: cap onUploadProgress at 100% when loaded exceeds total

### DIFF
--- a/lib/helpers/progressEventReducer.js
+++ b/lib/helpers/progressEventReducer.js
@@ -18,7 +18,7 @@ export const progressEventReducer = (listener, isDownloadStream, freq = 3) => {
     const data = {
       loaded,
       total,
-      progress: total ? (loaded / total) : undefined,
+      progress: total ? Math.min(loaded / total, 1) : undefined,
       bytes: progressBytes,
       rate: rate ? rate : undefined,
       estimated: rate && total && inRange ? (total - loaded) / rate : undefined,

--- a/test/specs/progress.spec.js
+++ b/test/specs/progress.spec.js
@@ -108,4 +108,20 @@ describe('progress events', function () {
       done();
     });
   });
+
+  it('should cap progress at 100% when loaded exceeds total', function () {
+    const { progressEventReducer } = require('../../lib/helpers/progressEventReducer.js');
+    let capturedProgress;
+    
+    const mockListener = (data) => {
+      capturedProgress = data.progress;
+    };
+
+    const [reducer] = progressEventReducer(mockListener, false, 1);
+
+    // Simulate scenario where loaded exceeds total (React Native bug)
+    reducer({ loaded: 712704, total: 400155, lengthComputable: true });
+
+    expect(capturedProgress).toBe(1); // Should be capped at 1 (100%)
+  });
 });


### PR DESCRIPTION
##  Overview of the Changes

- Corrects the progress calculation in `progressEventReducer` to ensure the computed percentage never exceeds 100%.
- Adds a `Math.min()` clamp so the normalized progress value is always capped at `1.0`.
- Introduces a regression test to cover the overflow scenario and prevent similar issues in future updates.
- Handles a React Native 0.81.4 edge case where `loaded` bytes can temporarily exceed `total`, resulting in inflated progress values.

---

##  Why This Matters

In some environments — most notably React Native 0.81.4 — progress events can report `loaded > total` due to momentary inconsistencies in native upload tracking.  
Without a safety check, Axios ends up emitting progress values like:



