### PR TITLE
Fix: Add Falsy Check for authoritySessions to Prevent TypeError

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -88,8 +88,11 @@ class Http2Sessions {
       }
 
       removed = true;
-
-      let entries = authoritySessions, len = entries.length, i = len;
+      let entries = authoritySessions;
+      if (!entries) {
+          return;
+        }
+      let len = entries.length, i = len;
 
       while (i--) {
         if (entries[i][0] === session) {


### PR DESCRIPTION
# **Fix: Prevent TypeError When `authoritySessions` Is Falsy**

This pull request fixes a runtime error in `lib/adapters/http.js` caused by accessing `authoritySessions.length` when `authoritySessions` is `undefined` or `null`.

Previously, the code attempted to read:

```js
let entries = authoritySessions,
    len = entries.length,
    i = len;
```

This resulted in a **TypeError** when `authoritySessions` was not initialized, causing unexpected adapter failures.

---

## **What This PR Changes**

- Assigns `authoritySessions` to a local variable (`entries`)
- Adds an early return when `entries` is falsy
- Safely reads `entries.length` only after validating that `entries` exists

### **Updated implementation:**

```js
let entries = authoritySessions;

if (!entries) {
  return;
}

let len = entries.length, i = len;
```

---

## **Why This Is Important**

- Prevents runtime crashes caused by invalid or missing `authoritySessions`
- Makes the adapter more stable and defensive without altering any API behavior
- Ensures the internal processing logic only runs when valid input is provided
- Avoids TypeErrors that previously occurred during certain edge-case executions

---

## **Impact**

- No changes to production-facing API behavior  
- No breaking changes  
- Safer internal logic with guaranteed null-checking  
- Fully backward compatible  

---

## **Test Summary**

- Existing tests continue to pass  
- No new tests required as this is a defensive guard  
- Fix confirms stability in scenarios where `authoritySessions` may be missing  

---

## **Related Areas**

- `lib/adapters/http.js`
