### PR TITLE
fix(xhr): clamp upload progress loaded value to total

### DIFF
--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -163,7 +163,17 @@ export default isXHRAdapterSupported && function (config) {
     if (onUploadProgress && request.upload) {
       ([uploadThrottled, flushUpload] = progressEventReducer(onUploadProgress));
 
-      request.upload.addEventListener('progress', uploadThrottled);
+      request.upload.addEventListener('progress', function handleProgress(e){
+        if (e && e.lengthComputable && e.loaded > e.total){
+          e.loaded = e.total
+
+        }
+        uploadThrottled(e)
+        
+
+      })
+      
+
 
       request.upload.addEventListener('loadend', flushUpload);
     }

--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -166,15 +166,9 @@ export default isXHRAdapterSupported && function (config) {
       request.upload.addEventListener('progress', function handleProgress(e){
         if (e && e.lengthComputable && e.loaded > e.total){
           e.loaded = e.total
-
         }
         uploadThrottled(e)
-        
-
       })
-      
-
-
       request.upload.addEventListener('loadend', flushUpload);
     }
 


### PR DESCRIPTION


Fixes an issue where XHR implementations (like in React Native) can report a `loaded` value greater than `total`, causing progress calculations to exceed 100%.

This change adds a check to clamp `e.loaded` to `e.total` if it exceeds the total, ensuring the progress event remains valid.

Fixes #7232
