### PR TITLE
fix(fetch): align timeout errors with other adapters

### DIFF
--- a/lib/adapters/fetch.js
+++ b/lib/adapters/fetch.js
@@ -130,6 +130,8 @@ const factory = (env) => {
       signal,
       cancelToken,
       timeout,
+      timeoutErrorMessage,
+      transitional,
       onDownloadProgress,
       onUploadProgress,
       responseType,
@@ -142,7 +144,14 @@ const factory = (env) => {
 
     responseType = responseType ? (responseType + '').toLowerCase() : 'text';
 
-    let composedSignal = composeSignals([signal, cancelToken && cancelToken.toAbortSignal()], timeout);
+    let composedSignal = composeSignals(
+      [signal, cancelToken && cancelToken.toAbortSignal()],
+      timeout,
+      {
+        timeoutErrorMessage,
+        transitional
+      }
+    );
 
     let request = null;
 

--- a/lib/helpers/composeSignals.js
+++ b/lib/helpers/composeSignals.js
@@ -1,8 +1,9 @@
 import CanceledError from "../cancel/CanceledError.js";
 import AxiosError from "../core/AxiosError.js";
 import utils from '../utils.js';
+import transitionalDefaults from "../defaults/transitional.js";
 
-const composeSignals = (signals, timeout) => {
+const composeSignals = (signals, timeout, options = {}) => {
   const {length} = (signals = signals ? signals.filter(Boolean) : []);
 
   if (timeout || length) {
@@ -21,7 +22,18 @@ const composeSignals = (signals, timeout) => {
 
     let timer = timeout && setTimeout(() => {
       timer = null;
-      onabort(new AxiosError(`timeout ${timeout} of ms exceeded`, AxiosError.ETIMEDOUT))
+
+      const {
+        transitional = transitionalDefaults,
+        timeoutErrorMessage
+      } = options || {};
+
+      const message = timeoutErrorMessage || (timeout ? `timeout of ${timeout}ms exceeded` : 'timeout exceeded');
+
+      onabort(new AxiosError(
+        message,
+        transitional && transitional.clarifyTimeoutError ? AxiosError.ETIMEDOUT : AxiosError.ECONNABORTED
+      ))
     }, timeout)
 
     const unsubscribe = () => {

--- a/test/unit/helpers/composeSignals.js
+++ b/test/unit/helpers/composeSignals.js
@@ -32,7 +32,28 @@ describe('helpers::composeSignals', () => {
       signal.addEventListener('abort', resolve);
     });
 
-    assert.match(String(signal.reason), /timeout 100 of ms exceeded/);
+    assert.match(String(signal.reason), /timeout of 100ms exceeded/);
+  });
+
+  it('should respect transitional clarifyTimeoutError flag for timeout errors', async () => {
+    const signals = [
+      composeSignals([], 10),
+      composeSignals([], 10, {transitional: {clarifyTimeoutError: true}})
+    ];
+
+    const reasons = [];
+
+    for (const signal of signals) {
+      await new Promise(resolve => {
+        signal.addEventListener('abort', () => {
+          reasons.push(signal.reason);
+          resolve();
+        });
+      });
+    }
+
+    assert.strictEqual(reasons[0].code, 'ECONNABORTED');
+    assert.strictEqual(reasons[1].code, 'ETIMEDOUT');
   });
 
   it('should return undefined if signals and timeout are not provided', async () => {


### PR DESCRIPTION
## Summary
The fetch adapter ignored `timeoutErrorMessage` and always surfaced `ETIMEDOUT`, which diverged from the xhr/http adapters. As a result, browser/WebWorker callers received inconsistent codes/messages for identical configs.

## Fix
- extend `composeSignals` so timeout paths accept the request’s `timeoutErrorMessage` and transitional flags
- pass those options from the fetch adapter when building the composed signal
- cover the new behavior with mocha specs for both the helper and the fetch adapter

## Reproduction (before fix)
1. `axios.create({adapter: 'fetch'}).get('/', {timeout: 50, timeoutErrorMessage: 'oops'})`
2. Error still read “timeout 50 of ms exceeded” and `err.code` was always `ETIMEDOUT`.

## Tests
- `npm run test:mocha`
- `npm run test:eslint`

## Backward Compatibility
No breaking changes; timeout error reporting now matches the other adapters.

## Checklist
- [x] Follows coding style & CONTRIBUTING
- [x] Conventional commit (`fix(fetch): …`)
- [x] Tests added/updated
- [x] Lint/tests pass locally
- [x] Behavior stays backward compatible