### PR TITLE
fix: replace Object.assign with IE11-safe fallback in inherits (#7111)

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -429,8 +429,23 @@ const inherits = (constructor, superConstructor, props, descriptors) => {
   Object.defineProperty(constructor, 'super', {
     value: superConstructor.prototype
   });
-  props && Object.assign(constructor.prototype, props);
-}
+
+  // IE11-safe Object.assign fallback
+  const safeAssign = (target, source) => {
+    if (source) {
+      for (const key in source) {
+        if (Object.prototype.hasOwnProperty.call(source, key)) {
+          target[key] = source[key];
+        }
+      }
+    }
+    return target;
+  };
+
+  // replaces Object.assign to support IE11
+  props && safeAssign(constructor.prototype, props);
+};
+
 
 /**
  * Resolve object with deep prototype chain to a flat object


### PR DESCRIPTION
This PR fixes issue #7111.

Internet Explorer 11 does not support Object.assign, causing Axios 0.30.2 to fail
with the error: "Object doesn't support property or method 'assign'".

Fix:
- Replaced Object.assign() inside inherits() with a safeAssign() fallback function
  that works in older browsers including IE11.

This maintains backward compatibility and fixes the reported runtime error.
