### PR TITLE
fix(fetch): defer global access to avoid module-load TypeError

### DIFF
--- a/lib/adapters/fetch.js
+++ b/lib/adapters/fetch.js
@@ -18,13 +18,6 @@ const DEFAULT_CHUNK_SIZE = 64 * 1024;
 
 const { isFunction } = utils;
 
-const globalFetchAPI = (({ Request, Response }) => ({
-  Request,
-  Response,
-}))(utils.global);
-
-const { ReadableStream, TextEncoder } = utils.global;
-
 const test = (fn, ...args) => {
   try {
     return !!fn(...args);
@@ -34,11 +27,17 @@ const test = (fn, ...args) => {
 };
 
 const factory = (env) => {
+  const globalObject = utils.global ?? globalThis;
+  const { ReadableStream, TextEncoder } = globalObject;
+
   env = utils.merge.call(
     {
       skipUndefined: true,
     },
-    globalFetchAPI,
+    {
+      Request: globalObject.Request,
+      Response: globalObject.Response,
+    },
     env
   );
 

--- a/tests/unit/adapters/fetch.test.js
+++ b/tests/unit/adapters/fetch.test.js
@@ -9,6 +9,7 @@ import {
   makeEchoStream,
 } from '../../setup/server.js';
 import axios from '../../../index.js';
+import utils from '../../../lib/utils.js';
 import { getFetch } from '../../../lib/adapters/fetch.js';
 import stream from 'stream';
 import { AbortController } from 'abortcontroller-polyfill/dist/cjs-ponyfill.js';
@@ -814,6 +815,24 @@ describe.runIf(typeof fetch === 'function')('supports fetch with nodejs', () => 
   });
 
   describe('env config', () => {
+    it('should fallback to globalThis when utils.global is temporarily undefined', () => {
+      const originalGlobal = utils.global;
+
+      try {
+        utils.global = undefined;
+
+        assert.doesNotThrow(() =>
+          getFetch({
+            env: {
+              fetch() {},
+            },
+          })
+        );
+      } finally {
+        utils.global = originalGlobal;
+      }
+    });
+
     it('should respect env fetch API configuration', async () => {
       const { data, headers } = await fetchAxios.get('/', {
         env: {


### PR DESCRIPTION
## Description

Fixes #7259

Similar to #7153 which fixed unsafe destructuring in `config.env`, this PR fixes another unsafe destructuring pattern in the fetch adapter that causes `TypeError` when `utils.global` is `undefined` during module loading.

## Problem

The current code (lines 15-17 in `lib/adapters/fetch.js`) directly destructures `utils.global` without checking if it's defined:

```javascript
const globalFetchAPI = (({Request, Response}) => ({
  Request, Response
}))(utils.global);
```

This throws `TypeError: Cannot destructure property 'Request' of 'undefined'` in certain build environments (Vite, webpack) where module initialization timing can cause `utils.global` to be temporarily undefined.

## Summary
Defer `utils.global` access to `factory()` and guard it with a fallback object to prevent module-
load crashes when globals are not ready.

## Fix
- Move `Request/Response/ReadableStream/TextEncoder` access into `factory()`
- Use a fallback object to avoid destructuring from `undefined`

## Reproduction
Minimal repro repo:
https://github.com/Jye10032/axios-repo

Steps:
1. `npm install`
2. `npm run build`
3. `npm run preview`
4. Open the preview URL → console shows:

TypeError: Cannot destructure property 'Request' of 'undefined'

## Related

- Similar fix in #7155 for `config.env` destructuring
- Reported by users experiencing build failures in production deployments