### PR TITLE
feat: add debug option for request logging to help debug 403 errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,6 +507,19 @@ These are the available config options for making requests. Only the `url` is re
     return status >= 200 && status < 300; // default
   },
 
+  // `debug` enables request debugging/logging. When set to `true`, logs detailed request
+  // information including method, URL, headers, and data to the console. When set to a
+  // function, uses that function as a custom logger. This is particularly useful for
+  // debugging 403 errors and comparing requests with curl commands.
+  // The debug output includes an equivalent curl command for easy testing.
+  debug: false, // default
+  // Example with default console logging:
+  // axios.get('/api/data', { debug: true });
+  // Example with custom logger:
+  // axios.get('/api/data', { 
+  //   debug: (message) => myLogger.log(message) 
+  // });
+
   // `maxRedirects` defines the maximum number of redirects to follow in node.js.
   // If set to 0, no redirects will be followed.
   maxRedirects: 21, // default

--- a/index.d.ts
+++ b/index.d.ts
@@ -375,6 +375,21 @@ export interface AxiosRequestConfig<D = any> {
   http2Options?: Record<string, any> & {
     sessionTimeout?: number;
   };
+  /**
+   * Enable request debugging/logging. When set to `true`, logs request details to console.
+   * When set to a function, uses that function as a custom logger.
+   * Useful for debugging 403 errors and comparing with curl commands.
+   * 
+   * @example
+   * // Enable default console logging
+   * axios.get('/api/data', { debug: true });
+   * 
+   * // Use custom logger
+   * axios.get('/api/data', { 
+   *   debug: (info) => console.log('Custom:', info) 
+   * });
+   */
+  debug?: boolean | ((message: string) => void);
 }
 
 // Alias

--- a/lib/core/dispatchRequest.js
+++ b/lib/core/dispatchRequest.js
@@ -6,6 +6,7 @@ import defaults from '../defaults/index.js';
 import CanceledError from '../cancel/CanceledError.js';
 import AxiosHeaders from '../core/AxiosHeaders.js';
 import adapters from "../adapters/adapters.js";
+import logRequest from '../helpers/logRequest.js';
 
 /**
  * Throws a `CanceledError` if cancellation has been requested.
@@ -44,6 +45,11 @@ export default function dispatchRequest(config) {
 
   if (['post', 'put', 'patch'].indexOf(config.method) !== -1) {
     config.headers.setContentType('application/x-www-form-urlencoded', false);
+  }
+
+  // Log request details if debug is enabled
+  if (config.debug !== undefined) {
+    logRequest(config, config.debug);
   }
 
   const adapter = adapters.getAdapter(config.adapter || defaults.adapter, config);

--- a/lib/helpers/logRequest.js
+++ b/lib/helpers/logRequest.js
@@ -1,0 +1,118 @@
+'use strict';
+
+import utils from '../utils.js';
+import buildURL from './buildURL.js';
+import buildFullPath from '../core/buildFullPath.js';
+
+/**
+ * Formats request data for logging, handling different data types
+ * 
+ * @param {any} data - The request data to format
+ * @param {number} maxLength - Maximum length of data string (default: 1000)
+ * @returns {string} Formatted data string
+ */
+function formatRequestData(data, maxLength = 1000) {
+  if (data === undefined || data === null) {
+    return '(no data)';
+  }
+
+  if (utils.isString(data)) {
+    return data.length > maxLength ? data.substring(0, maxLength) + '... (truncated)' : data;
+  }
+
+  if (utils.isFormData(data)) {
+    return '[FormData]';
+  }
+
+  if (utils.isArrayBuffer(data) || utils.isBuffer(data)) {
+    return `[${data.constructor.name}] (${data.byteLength || data.length} bytes)`;
+  }
+
+  if (utils.isStream(data) || utils.isReadableStream(data)) {
+    return '[Stream]';
+  }
+
+  if (utils.isFile(data) || utils.isBlob(data)) {
+    return `[${data.constructor.name}] (${data.size || 'unknown size'} bytes)`;
+  }
+
+  try {
+    const stringified = JSON.stringify(data);
+    return stringified.length > maxLength 
+      ? stringified.substring(0, maxLength) + '... (truncated)' 
+      : stringified;
+  } catch (e) {
+    return `[${data.constructor?.name || 'Object'}] (unable to stringify)`;
+  }
+}
+
+/**
+ * Logs request details for debugging purposes
+ * 
+ * @param {Object} config - The axios request config
+ * @param {boolean|Function} debug - Debug option: true for console.log, or a custom logger function
+ */
+export default function logRequest(config, debug) {
+  if (!debug) {
+    return;
+  }
+
+  const logger = typeof debug === 'function' ? debug : console.log;
+  
+  const fullPath = buildFullPath(config.baseURL, config.url, config.allowAbsoluteUrls);
+  const finalURL = buildURL(fullPath, config.params, config.paramsSerializer);
+  
+  const headers = config.headers.toJSON ? config.headers.toJSON() : config.headers;
+  
+  const requestInfo = {
+    method: (config.method || 'GET').toUpperCase(),
+    url: finalURL,
+    headers: headers,
+    data: formatRequestData(config.data)
+  };
+
+  // Format as curl-like command for easy debugging
+  const curlCommand = formatAsCurlCommand(requestInfo);
+  
+  logger('=== Axios Request Debug ===');
+  logger(`Method: ${requestInfo.method}`);
+  logger(`URL: ${requestInfo.url}`);
+  logger('Headers:');
+  Object.entries(requestInfo.headers).forEach(([key, value]) => {
+    if (value !== null && value !== false && value !== undefined) {
+      logger(`  ${key}: ${value}`);
+    }
+  });
+  logger(`Data: ${requestInfo.data}`);
+  logger('\nEquivalent curl command:');
+  logger(curlCommand);
+  logger('=== End Request Debug ===\n');
+}
+
+/**
+ * Formats request info as a curl command for easy debugging
+ * 
+ * @param {Object} requestInfo - The request information object
+ * @returns {string} Formatted curl command
+ */
+function formatAsCurlCommand(requestInfo) {
+  let curl = `curl -X ${requestInfo.method} '${requestInfo.url}'`;
+  
+  Object.entries(requestInfo.headers).forEach(([key, value]) => {
+    if (value !== null && value !== false && value !== undefined) {
+      const headerValue = Array.isArray(value) ? value.join(', ') : String(value);
+      curl += ` \\\n  -H '${key}: ${headerValue}'`;
+    }
+  });
+  
+  if (requestInfo.data && requestInfo.data !== '(no data)') {
+    const dataStr = String(requestInfo.data);
+    // Only add data if it's not a binary/stream indicator
+    if (!dataStr.startsWith('[') || dataStr.includes('FormData')) {
+      curl += ` \\\n  -d '${dataStr.replace(/'/g, "'\\''")}'`;
+    }
+  }
+  
+  return curl;
+}
+

--- a/test/specs/debug.spec.js
+++ b/test/specs/debug.spec.js
@@ -1,0 +1,207 @@
+describe('debug option', function () {
+  let originalConsoleLog;
+  let logOutput;
+
+  beforeEach(function () {
+    jasmine.Ajax.install();
+    originalConsoleLog = console.log;
+    logOutput = [];
+    console.log = function (...args) {
+      logOutput.push(args.join(' '));
+    };
+  });
+
+  afterEach(function () {
+    jasmine.Ajax.uninstall();
+    console.log = originalConsoleLog;
+    logOutput = [];
+  });
+
+  it('should not log when debug is not set', function (done) {
+    axios('/foo');
+
+    getAjaxRequest().then(function (request) {
+      expect(logOutput.length).toBe(0);
+      request.respondWith({
+        status: 200
+      });
+      done();
+    });
+  });
+
+  it('should not log when debug is false', function (done) {
+    axios('/foo', { debug: false });
+
+    getAjaxRequest().then(function (request) {
+      expect(logOutput.length).toBe(0);
+      request.respondWith({
+        status: 200
+      });
+      done();
+    });
+  });
+
+  it('should log request details when debug is true', function (done) {
+    axios('/foo', { debug: true });
+
+    getAjaxRequest().then(function (request) {
+      const logText = logOutput.join('\n');
+      expect(logText).toContain('=== Axios Request Debug ===');
+      expect(logText).toContain('Method: GET');
+      expect(logText).toContain('URL: /foo');
+      expect(logText).toContain('Headers:');
+      expect(logText).toContain('Equivalent curl command:');
+      expect(logText).toContain('=== End Request Debug ===');
+      request.respondWith({
+        status: 200
+      });
+      done();
+    });
+  });
+
+  it('should log POST request with data when debug is true', function (done) {
+    axios.post('/foo', { name: 'test' }, { debug: true });
+
+    getAjaxRequest().then(function (request) {
+      const logText = logOutput.join('\n');
+      expect(logText).toContain('Method: POST');
+      expect(logText).toContain('URL: /foo');
+      expect(logText).toContain('Data:');
+      expect(logText).toContain('name');
+      expect(logText).toContain('test');
+      request.respondWith({
+        status: 200
+      });
+      done();
+    });
+  });
+
+  it('should log custom headers when debug is true', function (done) {
+    axios('/foo', {
+      debug: true,
+      headers: {
+        'Custom-Header': 'custom-value',
+        'User-Agent': 'Mozilla/5.0'
+      }
+    });
+
+    getAjaxRequest().then(function (request) {
+      const logText = logOutput.join('\n');
+      expect(logText).toContain('Custom-Header: custom-value');
+      expect(logText).toContain('User-Agent: Mozilla/5.0');
+      request.respondWith({
+        status: 200
+      });
+      done();
+    });
+  });
+
+  it('should use custom logger function when provided', function (done) {
+    const customLogger = jasmine.createSpy('customLogger');
+    
+    axios('/foo', { debug: customLogger });
+
+    getAjaxRequest().then(function (request) {
+      expect(customLogger).toHaveBeenCalled();
+      const calls = customLogger.calls.all();
+      expect(calls.length).toBeGreaterThan(0);
+      const logText = calls.map(call => call.args[0]).join('\n');
+      expect(logText).toContain('=== Axios Request Debug ===');
+      request.respondWith({
+        status: 200
+      });
+      done();
+    });
+  });
+
+  it('should log full URL with baseURL when debug is true', function (done) {
+    axios('/bar', {
+      baseURL: 'https://api.example.com',
+      debug: true
+    });
+
+    getAjaxRequest().then(function (request) {
+      const logText = logOutput.join('\n');
+      expect(logText).toContain('URL: https://api.example.com/bar');
+      request.respondWith({
+        status: 200
+      });
+      done();
+    });
+  });
+
+  it('should log URL with query parameters when debug is true', function (done) {
+    axios('/foo', {
+      params: { id: 123, name: 'test' },
+      debug: true
+    });
+
+    getAjaxRequest().then(function (request) {
+      const logText = logOutput.join('\n');
+      expect(logText).toContain('URL: /foo');
+      expect(logText).toContain('id');
+      expect(logText).toContain('123');
+      request.respondWith({
+        status: 200
+      });
+      done();
+    });
+  });
+
+  it('should format FormData correctly when debug is true', function (done) {
+    const formData = new FormData();
+    formData.append('field', 'value');
+
+    axios.post('/foo', formData, { debug: true });
+
+    getAjaxRequest().then(function (request) {
+      const logText = logOutput.join('\n');
+      expect(logText).toContain('[FormData]');
+      request.respondWith({
+        status: 200
+      });
+      done();
+    });
+  });
+
+  it('should format different HTTP methods correctly', function (done) {
+    const methods = ['get', 'post', 'put', 'patch', 'delete'];
+    let completed = 0;
+
+    methods.forEach(function (method) {
+      axios[method]('/foo', { debug: true }).catch(function () {});
+
+      getAjaxRequest().then(function (request) {
+        const logText = logOutput.join('\n');
+        expect(logText).toContain(`Method: ${method.toUpperCase()}`);
+        request.respondWith({
+          status: 200
+        });
+        completed++;
+        if (completed === methods.length) {
+          done();
+        }
+      });
+    });
+  });
+
+  it('should include curl command in debug output', function (done) {
+    axios('/foo', {
+      debug: true,
+      headers: {
+        'Authorization': 'Bearer token123'
+      }
+    });
+
+    getAjaxRequest().then(function (request) {
+      const logText = logOutput.join('\n');
+      expect(logText).toContain('curl -X GET');
+      expect(logText).toContain("'Authorization: Bearer token123'");
+      request.respondWith({
+        status: 200
+      });
+      done();
+    });
+  });
+});
+


### PR DESCRIPTION
This commit adds a new `debug` config option that allows users to log detailed request information including method, URL, headers, and data. This is particularly useful for debugging 403 errors and comparing requests with curl commands.

Features:
- Enable debug logging with `debug: true` or custom logger function
- Logs method, URL, headers, and data in a readable format
- Includes equivalent curl command for easy testing
- Supports custom logger functions for integration with logging libraries
- Comprehensive test coverage

Fixes #7233