### PR TITLE
docs: add simple axios.get example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,8 +266,23 @@ Promise.all([getUserAccount(), getUserPermissions()])
     const acct = results[0];
     const perm = results[1];
   });
+  
 ```
 
+### Simple GET example
+
+```js
+// GET request for JSON data
+import axios from 'axios';
+
+axios.get('https://api.github.com/repos/axios/axios')
+  .then(response => {
+    console.log(response.data);
+  })
+  .catch(error => {
+    console.error('Request failed:', error);
+  });
+```
 ## axios API
 
 Requests can be made by passing the relevant config to `axios`.


### PR DESCRIPTION
This is a small documentation-only change that adds a simple `axios.get` example to the README to help new users see a basic usage pattern.

- Adds: a basic GET example showing axios.get usage and simple error handling.

No code changes. This should be safe to merge; CI and maintainer review welcome.
