### PR TITLE
fix: remove CreateAxiosDefaults['lookup'] in favor of Agent['lookup']…

### DIFF
--- a/index.d.cts
+++ b/index.d.cts
@@ -4,23 +4,23 @@ interface RawAxiosHeaders {
 
 type MethodsHeaders = Partial<{
   [Key in axios.Method as Lowercase<Key>]: AxiosHeaders;
-} & {common: AxiosHeaders}>;
+} & { common: AxiosHeaders }>;
 
 type AxiosHeaderMatcher = string | RegExp | ((this: AxiosHeaders, value: string, name: string) => boolean);
 
 type AxiosHeaderParser = (this: AxiosHeaders, value: axios.AxiosHeaderValue, header: string) => any;
 
-type CommonRequestHeadersList = 'Accept' | 'Content-Length' | 'User-Agent'| 'Content-Encoding' | 'Authorization';
+type CommonRequestHeadersList = 'Accept' | 'Content-Length' | 'User-Agent' | 'Content-Encoding' | 'Authorization';
 
 type ContentType = axios.AxiosHeaderValue | 'text/html' | 'text/plain' | 'multipart/form-data' | 'application/json' | 'application/x-www-form-urlencoded' | 'application/octet-stream';
 
-type CommonResponseHeadersList = 'Server' | 'Content-Type' | 'Content-Length' | 'Cache-Control'| 'Content-Encoding';
+type CommonResponseHeadersList = 'Server' | 'Content-Type' | 'Content-Length' | 'Cache-Control' | 'Content-Encoding';
 
 type BrowserProgressEvent = any;
 
 declare class AxiosHeaders {
   constructor(
-      headers?: RawAxiosHeaders | AxiosHeaders | string
+    headers?: RawAxiosHeaders | AxiosHeaders | string
   );
 
   [key: string]: any;
@@ -86,11 +86,11 @@ declare class AxiosHeaders {
 
 declare class AxiosError<T = unknown, D = any> extends Error {
   constructor(
-      message?: string,
-      code?: string,
-      config?: axios.InternalAxiosRequestConfig<D>,
-      request?: any,
-      response?: axios.AxiosResponse<T, D>
+    message?: string,
+    code?: string,
+    config?: axios.InternalAxiosRequestConfig<D>,
+    request?: any,
+    response?: axios.AxiosResponse<T, D>
   );
 
   config?: axios.InternalAxiosRequestConfig<D>;
@@ -109,7 +109,7 @@ declare class AxiosError<T = unknown, D = any> extends Error {
     request?: any,
     response?: axios.AxiosResponse<T, D>,
     customProps?: object,
-): AxiosError<T, D>;
+  ): AxiosError<T, D>;
   static readonly ERR_FR_TOO_MANY_REDIRECTS = "ERR_FR_TOO_MANY_REDIRECTS";
   static readonly ERR_BAD_OPTION_VALUE = "ERR_BAD_OPTION_VALUE";
   static readonly ERR_BAD_OPTION = "ERR_BAD_OPTION";
@@ -319,11 +319,11 @@ declare namespace axios {
 
   interface SerializerVisitor {
     (
-        this: GenericFormData,
-        value: any,
-        key: string | number,
-        path: null | Array<string | number>,
-        helpers: FormDataVisitorHelpers
+      this: GenericFormData,
+      value: any,
+      key: string | number,
+      path: null | Array<string | number>,
+      helpers: FormDataVisitorHelpers
     ): boolean;
   }
 
@@ -410,7 +410,7 @@ declare namespace axios {
     maxBodyLength?: number;
     maxRedirects?: number;
     maxRate?: number | [MaxUploadRate, MaxDownloadRate];
-    beforeRedirect?: (options: Record<string, any>, responseDetails: {headers: Record<string, string>, statusCode: HttpStatusCode}) => void;
+    beforeRedirect?: (options: Record<string, any>, responseDetails: { headers: Record<string, string>, statusCode: HttpStatusCode }) => void;
     socketPath?: string | null;
     transport?: any;
     httpAgent?: any;
@@ -426,14 +426,13 @@ declare namespace axios {
       fetch?: (input: URL | Request | string, init?: RequestInit) => Promise<Response>;
       Request?: new (input: URL | Request | string, init?: RequestInit) => Request;
       Response?: new (
-          body?: ArrayBuffer | ArrayBufferView | Blob | FormData | URLSearchParams | string | null,
-          init?: ResponseInit
+        body?: ArrayBuffer | ArrayBufferView | Blob | FormData | URLSearchParams | string | null,
+        init?: ResponseInit
       ) => Response;
     };
     formSerializer?: FormSerializerOptions;
     family?: AddressFamily;
-    lookup?: ((hostname: string, options: object, cb: (err: Error | null, address: LookupAddress | LookupAddress[], family?: AddressFamily) => void) => void) |
-        ((hostname: string, options: object) => Promise<[address: LookupAddressEntry | LookupAddressEntry[], family?: AddressFamily] | LookupAddress>);
+
     withXSRFToken?: boolean | ((config: InternalAxiosRequestConfig) => boolean | undefined);
     fetchOptions?: Omit<RequestInit, 'body' | 'headers' | 'method' | 'signal'> | Record<string, any>;
     httpVersion?: 1 | 2;
@@ -471,7 +470,7 @@ declare namespace axios {
     headers?: RawAxiosRequestHeaders | AxiosHeaders | Partial<HeadersDefaults>;
   }
 
-  interface AxiosResponse<T = any, D = any, H = {}>  {
+  interface AxiosResponse<T = any, D = any, H = {}> {
     data: T;
     status: number;
     statusText: string;
@@ -483,7 +482,7 @@ declare namespace axios {
   type AxiosPromise<T = any> = Promise<AxiosResponse<T>>;
 
   interface CancelStatic {
-    new (message?: string): Cancel;
+    new(message?: string): Cancel;
   }
 
   interface Cancel {
@@ -495,7 +494,7 @@ declare namespace axios {
   }
 
   interface CancelTokenStatic {
-    new (executor: (cancel: Canceler) => void): CancelToken;
+    new(executor: (cancel: Canceler) => void): CancelToken;
     source(): CancelTokenSource;
   }
 
@@ -560,7 +559,7 @@ declare namespace axios {
     spread<T, R>(callback: (...args: T[]) => R): (array: T[]) => R;
     isAxiosError<T = any, D = any>(payload: any): payload is AxiosError<T, D>;
     toFormData(sourceObj: object, targetFormData?: GenericFormData, options?: FormSerializerOptions): GenericFormData;
-    formToJSON(form: GenericFormData|GenericHTMLFormElement): object;
+    formToJSON(form: GenericFormData | GenericHTMLFormElement): object;
     getAdapter(adapters: AxiosAdapterConfig | AxiosAdapterConfig[] | undefined): AxiosAdapter;
     AxiosHeaders: typeof AxiosHeaders;
     mergeConfig<D = any>(config1: AxiosRequestConfig<D>, config2: AxiosRequestConfig<D>): AxiosRequestConfig<D>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -9,7 +9,7 @@ interface RawAxiosHeaders {
 
 type MethodsHeaders = Partial<{
   [Key in Method as Lowercase<Key>]: AxiosHeaders;
-} & {common: AxiosHeaders}>;
+} & { common: AxiosHeaders }>;
 
 type AxiosHeaderMatcher = string | RegExp | ((this: AxiosHeaders, value: string, name: string) => boolean);
 
@@ -17,7 +17,7 @@ type AxiosHeaderParser = (this: AxiosHeaders, value: AxiosHeaderValue, header: s
 
 export class AxiosHeaders {
   constructor(
-      headers?: RawAxiosHeaders | AxiosHeaders | string
+    headers?: RawAxiosHeaders | AxiosHeaders | string
   );
 
   [key: string]: any;
@@ -93,7 +93,7 @@ export type RawAxiosRequestHeaders = Partial<RawAxiosHeaders & {
 
 export type AxiosRequestHeaders = RawAxiosRequestHeaders & AxiosHeaders;
 
-type CommonResponseHeadersList = 'Server' | 'Content-Type' | 'Content-Length' | 'Cache-Control'| 'Content-Encoding';
+type CommonResponseHeadersList = 'Server' | 'Content-Type' | 'Content-Length' | 'Cache-Control' | 'Content-Encoding';
 
 type RawCommonResponseHeaders = {
   [Key in CommonResponseHeadersList]: AxiosHeaderValue;
@@ -196,39 +196,39 @@ export enum HttpStatusCode {
 }
 
 export type Method =
-    | 'get' | 'GET'
-    | 'delete' | 'DELETE'
-    | 'head' | 'HEAD'
-    | 'options' | 'OPTIONS'
-    | 'post' | 'POST'
-    | 'put' | 'PUT'
-    | 'patch' | 'PATCH'
-    | 'purge' | 'PURGE'
-    | 'link' | 'LINK'
-    | 'unlink' | 'UNLINK';
+  | 'get' | 'GET'
+  | 'delete' | 'DELETE'
+  | 'head' | 'HEAD'
+  | 'options' | 'OPTIONS'
+  | 'post' | 'POST'
+  | 'put' | 'PUT'
+  | 'patch' | 'PATCH'
+  | 'purge' | 'PURGE'
+  | 'link' | 'LINK'
+  | 'unlink' | 'UNLINK';
 
 export type ResponseType =
-    | 'arraybuffer'
-    | 'blob'
-    | 'document'
-    | 'json'
-    | 'text'
-    | 'stream'
-    | 'formdata';
+  | 'arraybuffer'
+  | 'blob'
+  | 'document'
+  | 'json'
+  | 'text'
+  | 'stream'
+  | 'formdata';
 
 export type responseEncoding =
-    | 'ascii' | 'ASCII'
-    | 'ansi' | 'ANSI'
-    | 'binary' | 'BINARY'
-    | 'base64' | 'BASE64'
-    | 'base64url' | 'BASE64URL'
-    | 'hex' | 'HEX'
-    | 'latin1' | 'LATIN1'
-    | 'ucs-2' | 'UCS-2'
-    | 'ucs2' | 'UCS2'
-    | 'utf-8' | 'UTF-8'
-    | 'utf8' | 'UTF8'
-    | 'utf16le' | 'UTF16LE';
+  | 'ascii' | 'ASCII'
+  | 'ansi' | 'ANSI'
+  | 'binary' | 'BINARY'
+  | 'base64' | 'BASE64'
+  | 'base64url' | 'BASE64URL'
+  | 'hex' | 'HEX'
+  | 'latin1' | 'LATIN1'
+  | 'ucs-2' | 'UCS-2'
+  | 'ucs2' | 'UCS2'
+  | 'utf-8' | 'UTF-8'
+  | 'utf8' | 'UTF8'
+  | 'utf16le' | 'UTF16LE';
 
 export interface TransitionalOptions {
   silentJSONParsing?: boolean;
@@ -251,11 +251,11 @@ export interface FormDataVisitorHelpers {
 
 export interface SerializerVisitor {
   (
-      this: GenericFormData,
-      value: any,
-      key: string | number,
-      path: null | Array<string | number>,
-      helpers: FormDataVisitorHelpers
+    this: GenericFormData,
+    value: any,
+    key: string | number,
+    path: null | Array<string | number>,
+    helpers: FormDataVisitorHelpers
   ): boolean;
 }
 
@@ -344,7 +344,7 @@ export interface AxiosRequestConfig<D = any> {
   maxBodyLength?: number;
   maxRedirects?: number;
   maxRate?: number | [MaxUploadRate, MaxDownloadRate];
-  beforeRedirect?: (options: Record<string, any>, responseDetails: {headers: Record<string, string>, statusCode: HttpStatusCode}) => void;
+  beforeRedirect?: (options: Record<string, any>, responseDetails: { headers: Record<string, string>, statusCode: HttpStatusCode }) => void;
   socketPath?: string | null;
   transport?: any;
   httpAgent?: any;
@@ -360,14 +360,13 @@ export interface AxiosRequestConfig<D = any> {
     fetch?: (input: URL | Request | string, init?: RequestInit) => Promise<Response>;
     Request?: new (input: URL | Request | string, init?: RequestInit) => Request;
     Response?: new (
-        body?: ArrayBuffer | ArrayBufferView | Blob | FormData | URLSearchParams | string | null,
-        init?: ResponseInit
+      body?: ArrayBuffer | ArrayBufferView | Blob | FormData | URLSearchParams | string | null,
+      init?: ResponseInit
     ) => Response;
   };
   formSerializer?: FormSerializerOptions;
   family?: AddressFamily;
-  lookup?: ((hostname: string, options: object, cb: (err: Error | null, address: LookupAddress | LookupAddress[], family?: AddressFamily) => void) => void) |
-      ((hostname: string, options: object) => Promise<[address: LookupAddressEntry | LookupAddressEntry[], family?: AddressFamily] | LookupAddress>);
+
   withXSRFToken?: boolean | ((config: InternalAxiosRequestConfig) => boolean | undefined);
   parseReviver?: (this: any, key: string, value: any) => any;
   fetchOptions?: Omit<RequestInit, 'body' | 'headers' | 'method' | 'signal'> | Record<string, any>;
@@ -417,11 +416,11 @@ export interface AxiosResponse<T = any, D = any, H = {}> {
 
 export class AxiosError<T = unknown, D = any> extends Error {
   constructor(
-      message?: string,
-      code?: string,
-      config?: InternalAxiosRequestConfig<D>,
-      request?: any,
-      response?: AxiosResponse<T, D>
+    message?: string,
+    code?: string,
+    config?: InternalAxiosRequestConfig<D>,
+    request?: any,
+    response?: AxiosResponse<T, D>
   );
 
   config?: InternalAxiosRequestConfig<D>;
@@ -440,7 +439,7 @@ export class AxiosError<T = unknown, D = any> extends Error {
     request?: any,
     response?: AxiosResponse<T, D>,
     customProps?: object,
-): AxiosError<T, D>;
+  ): AxiosError<T, D>;
   static readonly ERR_FR_TOO_MANY_REDIRECTS = "ERR_FR_TOO_MANY_REDIRECTS";
   static readonly ERR_BAD_OPTION_VALUE = "ERR_BAD_OPTION_VALUE";
   static readonly ERR_BAD_OPTION = "ERR_BAD_OPTION";
@@ -462,7 +461,7 @@ export class CanceledError<T> extends AxiosError<T> {
 export type AxiosPromise<T = any> = Promise<AxiosResponse<T>>;
 
 export interface CancelStatic {
-  new (message?: string): Cancel;
+  new(message?: string): Cancel;
 }
 
 export interface Cancel {
@@ -474,7 +473,7 @@ export interface Canceler {
 }
 
 export interface CancelTokenStatic {
-  new (executor: (cancel: Canceler) => void): CancelToken;
+  new(executor: (cancel: Canceler) => void): CancelToken;
   source(): CancelTokenSource;
 }
 
@@ -551,7 +550,7 @@ export function getAdapter(adapters: AxiosAdapterConfig | AxiosAdapterConfig[] |
 
 export function toFormData(sourceObj: object, targetFormData?: GenericFormData, options?: FormSerializerOptions): GenericFormData;
 
-export function formToJSON(form: GenericFormData|GenericHTMLFormElement): object;
+export function formToJSON(form: GenericFormData | GenericHTMLFormElement): object;
 
 export function isAxiosError<T = any, D = any>(payload: any): payload is AxiosError<T, D>;
 

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -9,7 +9,7 @@ import http2 from 'http2';
 import util from 'util';
 import followRedirects from 'follow-redirects';
 import zlib from 'zlib';
-import {VERSION} from '../env/data.js';
+import { VERSION } from '../env/data.js';
 import transitionalDefaults from '../defaults/transitional.js';
 import AxiosError from '../core/AxiosError.js';
 import CanceledError from '../cancel/CanceledError.js';
@@ -18,12 +18,12 @@ import fromDataURI from '../helpers/fromDataURI.js';
 import stream from 'stream';
 import AxiosHeaders from '../core/AxiosHeaders.js';
 import AxiosTransformStream from '../helpers/AxiosTransformStream.js';
-import {EventEmitter} from 'events';
+import { EventEmitter } from 'events';
 import formDataToStream from "../helpers/formDataToStream.js";
 import readBlob from "../helpers/readBlob.js";
 import ZlibHeaderTransformStream from '../helpers/ZlibHeaderTransformStream.js';
 import callbackify from "../helpers/callbackify.js";
-import {progressEventReducer, progressEventDecorator, asyncDecorator} from "../helpers/progressEventReducer.js";
+import { progressEventReducer, progressEventDecorator, asyncDecorator } from "../helpers/progressEventReducer.js";
 import estimateDataURLDecodedBytes from '../helpers/estimateDataURLDecodedBytes.js';
 
 const zlibOptions = {
@@ -38,7 +38,7 @@ const brotliOptions = {
 
 const isBrotliSupported = utils.isFunction(zlib.createBrotliDecompress);
 
-const {http: httpFollow, https: httpsFollow} = followRedirects;
+const { http: httpFollow, https: httpsFollow } = followRedirects;
 
 const isHttps = /https:?/;
 
@@ -105,9 +105,9 @@ class Http2Sessions {
 
     const originalRequestFn = session.request;
 
-    const {sessionTimeout} = options;
+    const { sessionTimeout } = options;
 
-    if(sessionTimeout != null) {
+    if (sessionTimeout != null) {
 
       let timer;
       let streamsCount = 0;
@@ -138,11 +138,11 @@ class Http2Sessions {
     session.once('close', removeSession);
 
     let entry = [
-        session,
-        options
-      ];
+      session,
+      options
+    ];
 
-    authoritySessions ? authoritySessions.push(entry) : authoritySessions =  this.sessions[authority] = [entry];
+    authoritySessions ? authoritySessions.push(entry) : authoritySessions = this.sessions[authority] = [entry];
 
     return session;
   }
@@ -254,7 +254,7 @@ const wrapAsync = (asyncExecutor) => {
   })
 };
 
-const resolveFamily = ({address, family}) => {
+const resolveFamily = ({ address, family }) => {
   if (!utils.isString(address)) {
     throw TypeError('address must be a string');
   }
@@ -264,60 +264,60 @@ const resolveFamily = ({address, family}) => {
   });
 }
 
-const buildAddressEntry = (address, family) => resolveFamily(utils.isObject(address) ? address : {address, family});
+const buildAddressEntry = (address, family) => resolveFamily(utils.isObject(address) ? address : { address, family });
 
 const http2Transport = {
   request(options, cb) {
-      const authority = options.protocol + '//' + options.hostname + ':' + (options.port || 80);
+    const authority = options.protocol + '//' + options.hostname + ':' + (options.port || 80);
 
-      const {http2Options, headers} = options;
+    const { http2Options, headers } = options;
 
-      const session = http2Sessions.getSession(authority, http2Options);
+    const session = http2Sessions.getSession(authority, http2Options);
 
-      const {
-        HTTP2_HEADER_SCHEME,
-        HTTP2_HEADER_METHOD,
-        HTTP2_HEADER_PATH,
-        HTTP2_HEADER_STATUS
-      } = http2.constants;
+    const {
+      HTTP2_HEADER_SCHEME,
+      HTTP2_HEADER_METHOD,
+      HTTP2_HEADER_PATH,
+      HTTP2_HEADER_STATUS
+    } = http2.constants;
 
-      const http2Headers = {
-        [HTTP2_HEADER_SCHEME]: options.protocol.replace(':', ''),
-        [HTTP2_HEADER_METHOD]: options.method,
-        [HTTP2_HEADER_PATH]: options.path,
-      }
+    const http2Headers = {
+      [HTTP2_HEADER_SCHEME]: options.protocol.replace(':', ''),
+      [HTTP2_HEADER_METHOD]: options.method,
+      [HTTP2_HEADER_PATH]: options.path,
+    }
 
-      utils.forEach(headers, (header, name) => {
-        name.charAt(0) !== ':' && (http2Headers[name] = header);
-      });
+    utils.forEach(headers, (header, name) => {
+      name.charAt(0) !== ':' && (http2Headers[name] = header);
+    });
 
-      const req = session.request(http2Headers);
+    const req = session.request(http2Headers);
 
-      req.once('response', (responseHeaders) => {
-        const response = req; //duplex
+    req.once('response', (responseHeaders) => {
+      const response = req; //duplex
 
-        responseHeaders = Object.assign({}, responseHeaders);
+      responseHeaders = Object.assign({}, responseHeaders);
 
-        const status = responseHeaders[HTTP2_HEADER_STATUS];
+      const status = responseHeaders[HTTP2_HEADER_STATUS];
 
-        delete responseHeaders[HTTP2_HEADER_STATUS];
+      delete responseHeaders[HTTP2_HEADER_STATUS];
 
-        response.headers = responseHeaders;
+      response.headers = responseHeaders;
 
-        response.statusCode = +status;
+      response.statusCode = +status;
 
-        cb(response);
-      })
+      cb(response);
+    })
 
-      return req;
+    return req;
   }
 }
 
 /*eslint consistent-return:0*/
 export default isHttpAdapterSupported && function httpAdapter(config) {
   return wrapAsync(async function dispatchHttpRequest(resolve, reject, onDone) {
-    let {data, lookup, family, httpVersion = 1, http2Options} = config;
-    const {responseType, responseEncoding} = config;
+    let { data, family, httpVersion = 1, http2Options } = config;
+    const { responseType, responseEncoding } = config;
     const method = config.method.toUpperCase();
     let isDone;
     let rejected = false;
@@ -335,28 +335,14 @@ export default isHttpAdapterSupported && function httpAdapter(config) {
 
     const isHttp2 = httpVersion === 2;
 
-    if (lookup) {
-      const _lookup = callbackify(lookup, (value) => utils.isArray(value) ? value : [value]);
-      // hotfix to support opt.all option which is required for node 20.x
-      lookup = (hostname, opt, cb) => {
-        _lookup(hostname, opt, (err, arg0, arg1) => {
-          if (err) {
-            return cb(err);
-          }
 
-          const addresses = utils.isArray(arg0) ? arg0.map(addr => buildAddressEntry(addr)) : [buildAddressEntry(arg0, arg1)];
-
-          opt.all ? cb(err, addresses) : cb(err, addresses[0].address, addresses[0].family);
-        });
-      }
-    }
 
     const abortEmitter = new EventEmitter();
 
     function abort(reason) {
       try {
         abortEmitter.emit('abort', !reason || reason.type ? new CanceledError(null, config, req) : reason);
-      } catch(err) {
+      } catch (err) {
         console.warn('emit error', err);
       }
     }
@@ -391,7 +377,7 @@ export default isHttpAdapterSupported && function httpAdapter(config) {
         return;
       }
 
-      const {data} = response;
+      const { data } = response;
 
       if (data instanceof stream.Readable || data instanceof stream.Duplex) {
         const offListeners = stream.finished(data, () => {
@@ -482,7 +468,7 @@ export default isHttpAdapterSupported && function httpAdapter(config) {
     // Only set header if it hasn't been set in config
     headers.set('User-Agent', 'axios/' + VERSION, false);
 
-    const {onUploadProgress, onDownloadProgress} = config;
+    const { onUploadProgress, onDownloadProgress } = config;
     const maxRate = config.maxRate;
     let maxUploadRate = undefined;
     let maxDownloadRate = undefined;
@@ -551,7 +537,7 @@ export default isHttpAdapterSupported && function httpAdapter(config) {
 
     if (data && (onUploadProgress || maxUploadRate)) {
       if (!utils.isStream(data)) {
-        data = stream.Readable.from(data, {objectMode: false});
+        data = stream.Readable.from(data, { objectMode: false });
       }
 
       data = stream.pipeline([data, new AxiosTransformStream({
@@ -602,7 +588,7 @@ export default isHttpAdapterSupported && function httpAdapter(config) {
     headers.set(
       'Accept-Encoding',
       'gzip, compress, deflate' + (isBrotliSupported ? ', br' : ''), false
-      );
+    );
 
     const options = {
       path,
@@ -618,7 +604,7 @@ export default isHttpAdapterSupported && function httpAdapter(config) {
     };
 
     // cacheable-lookup integration hotfix
-    !utils.isUndefined(lookup) && (options.lookup = lookup);
+
 
     if (config.socketPath) {
       options.socketPath = config.socketPath;
@@ -633,7 +619,7 @@ export default isHttpAdapterSupported && function httpAdapter(config) {
     options.agent = isHttpsRequest ? config.httpsAgent : config.httpAgent;
 
     if (isHttp2) {
-       transport = http2Transport;
+      transport = http2Transport;
     } else {
       if (config.transport) {
         transport = config.transport;
@@ -700,31 +686,31 @@ export default isHttpAdapterSupported && function httpAdapter(config) {
         }
 
         switch ((res.headers['content-encoding'] || '').toLowerCase()) {
-        /*eslint default-case:0*/
-        case 'gzip':
-        case 'x-gzip':
-        case 'compress':
-        case 'x-compress':
-          // add the unzipper to the body stream processing pipeline
-          streams.push(zlib.createUnzip(zlibOptions));
+          /*eslint default-case:0*/
+          case 'gzip':
+          case 'x-gzip':
+          case 'compress':
+          case 'x-compress':
+            // add the unzipper to the body stream processing pipeline
+            streams.push(zlib.createUnzip(zlibOptions));
 
-          // remove the content-encoding in order to not confuse downstream operations
-          delete res.headers['content-encoding'];
-          break;
-        case 'deflate':
-          streams.push(new ZlibHeaderTransformStream());
-
-          // add the unzipper to the body stream processing pipeline
-          streams.push(zlib.createUnzip(zlibOptions));
-
-          // remove the content-encoding in order to not confuse downstream operations
-          delete res.headers['content-encoding'];
-          break;
-        case 'br':
-          if (isBrotliSupported) {
-            streams.push(zlib.createBrotliDecompress(brotliOptions));
+            // remove the content-encoding in order to not confuse downstream operations
             delete res.headers['content-encoding'];
-          }
+            break;
+          case 'deflate':
+            streams.push(new ZlibHeaderTransformStream());
+
+            // add the unzipper to the body stream processing pipeline
+            streams.push(zlib.createUnzip(zlibOptions));
+
+            // remove the content-encoding in order to not confuse downstream operations
+            delete res.headers['content-encoding'];
+            break;
+          case 'br':
+            if (isBrotliSupported) {
+              streams.push(zlib.createBrotliDecompress(brotliOptions));
+              delete res.headers['content-encoding'];
+            }
         }
       }
 

--- a/test/unit/adapters/http.js
+++ b/test/unit/adapters/http.js
@@ -9,7 +9,6 @@ import util from 'util';
 import assert from 'assert';
 import fs from 'fs';
 import path from 'path';
-import {lookup} from 'dns';
 let server, server2, proxy;
 import AxiosError from '../../../lib/core/AxiosError.js';
 import FormDataLegacy from 'form-data';
@@ -19,9 +18,9 @@ import multer from 'multer';
 import bodyParser from 'body-parser';
 const isBlobSupported = typeof Blob !== 'undefined';
 import devNull from 'dev-null';
-import {AbortController} from 'abortcontroller-polyfill/dist/cjs-ponyfill.js';
-import {__setProxy} from "../../../lib/adapters/http.js";
-import {FormData as FormDataPolyfill, Blob as BlobPolyfill, File as FilePolyfill} from 'formdata-node';
+import { AbortController } from 'abortcontroller-polyfill/dist/cjs-ponyfill.js';
+import { __setProxy } from "../../../lib/adapters/http.js";
+import { FormData as FormDataPolyfill, Blob as BlobPolyfill, File as FilePolyfill } from 'formdata-node';
 import getStream from "get-stream";
 import {
   startHTTPServer,
@@ -44,7 +43,7 @@ const __filename = url.fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 function setTimeoutAsync(ms) {
-  return new Promise(resolve=> setTimeout(resolve, ms));
+  return new Promise(resolve => setTimeout(resolve, ms));
 }
 
 const pipelineAsync = util.promisify(stream.pipeline);
@@ -66,7 +65,7 @@ function toleranceRange(positive, negative) {
 const nodeVersion = process.versions.node.split('.').map(v => parseInt(v, 10));
 const nodeMajorVersion = nodeVersion[0];
 
-var noop = () => {};
+var noop = () => { };
 
 describe('supports http with nodejs', function () {
   afterEach(async function () {
@@ -366,7 +365,7 @@ describe('supports http with nodejs', function () {
         res.writeHead(302);
       }
       res.end();
-    }, {port: 4444});
+    }, { port: 4444 });
 
     let proxyUseCount = 0;
     proxy = await startHTTPServer(function (req, res) {
@@ -381,7 +380,7 @@ describe('supports http with nodejs', function () {
 
       const request = http.get(opts, function (response) {
         res.writeHead(response.statusCode, response.headers);
-        stream.pipeline(response, res, () => {});
+        stream.pipeline(response, res, () => { });
       });
 
       request.on('error', (err) => {
@@ -390,7 +389,7 @@ describe('supports http with nodejs', function () {
         res.end();
       })
 
-    }, {port: 4000});
+    }, { port: 4000 });
 
     let configBeforeRedirectCount = 0;
 
@@ -520,20 +519,20 @@ describe('supports http with nodejs', function () {
       })
     });
 
-    it('should support disabling automatic decompression of response data', function(done) {
+    it('should support disabling automatic decompression of response data', function (done) {
       var data = 'Test data';
 
-      zlib.gzip(data, function(err, zipped) {
-        server = http.createServer(function(req, res) {
+      zlib.gzip(data, function (err, zipped) {
+        server = http.createServer(function (req, res) {
           res.setHeader('Content-Type', 'text/html;charset=utf-8');
           res.setHeader('Content-Encoding', 'gzip');
           res.end(zipped);
-        }).listen(4444, function() {
+        }).listen(4444, function () {
           axios.get('http://localhost:4444/', {
             decompress: false,
             responseType: 'arraybuffer'
 
-          }).then(function(res) {
+          }).then(function (res) {
             assert.equal(res.data.toString('base64'), zipped.toString('base64'));
             done();
           }).catch(done);
@@ -542,7 +541,7 @@ describe('supports http with nodejs', function () {
     });
 
     describe('algorithms', () => {
-      const responseBody ='str';
+      const responseBody = 'str';
 
       for (const [typeName, zipped] of Object.entries({
         gzip: gzip(responseBody),
@@ -561,7 +560,7 @@ describe('supports http with nodejs', function () {
               res.end(await zipped);
             });
 
-            const {data} = await axios.get(LOCAL_SERVER_URL);
+            const { data } = await axios.get(LOCAL_SERVER_URL);
 
             assert.strictEqual(data, responseBody);
           });
@@ -573,7 +572,7 @@ describe('supports http with nodejs', function () {
               res.end(await zipped);
             });
 
-            const {data} = await axios.get(LOCAL_SERVER_URL);
+            const { data } = await axios.get(LOCAL_SERVER_URL);
 
             assert.strictEqual(data, responseBody);
           });
@@ -587,7 +586,7 @@ describe('supports http with nodejs', function () {
               res.end();
             });
 
-            const {data} = await axios.get(LOCAL_SERVER_URL);
+            const { data } = await axios.get(LOCAL_SERVER_URL);
 
             assert.strictEqual(data, responseBody);
           });
@@ -599,7 +598,7 @@ describe('supports http with nodejs', function () {
               res.end();
             });
 
-            const {data} = await axios.get(LOCAL_SERVER_URL);
+            const { data } = await axios.get(LOCAL_SERVER_URL);
 
             assert.strictEqual(data, '');
           });
@@ -699,14 +698,14 @@ describe('supports http with nodejs', function () {
     server = await startHTTPServer(function (req, res) {
       res.setHeader('Content-Type', 'text/html; charset=UTF-8');
       res.end(Array(5000).join('#'));
-    }, {port: 4444});
+    }, { port: 4444 });
 
     await assert.rejects(() => {
       return axios.get('http://localhost:4444/', {
         maxContentLength: 2000,
         maxRedirects: 0
       })
-    },/maxContentLength size of 2000 exceeded/);
+    }, /maxContentLength size of 2000 exceeded/);
   });
 
   it('should support max content length for redirected', function (done) {
@@ -776,7 +775,7 @@ describe('supports http with nodejs', function () {
 
   it('should properly support default max body length (follow-redirects as well)', function (done) {
     // taken from https://github.com/follow-redirects/follow-redirects/blob/22e81fc37132941fb83939d1dc4c2282b5c69521/index.js#L461
-    var followRedirectsMaxBodyDefaults = 10 * 1024 *1024;
+    var followRedirectsMaxBodyDefaults = 10 * 1024 * 1024;
     var data = Array(2 * followRedirectsMaxBodyDefaults).join('ж');
 
     server = http.createServer(function (req, res) {
@@ -840,15 +839,15 @@ describe('supports http with nodejs', function () {
     });
   });
 
-  describe('streams', function(){
+  describe('streams', function () {
     it('should support streams', function (done) {
       server = http.createServer(function (req, res) {
         req.pipe(res);
       }).listen(4444, function () {
         axios.post('http://localhost:4444/',
           fs.createReadStream(__filename), {
-            responseType: 'stream'
-          }).then(function (res) {
+          responseType: 'stream'
+        }).then(function (res) {
           var stream = res.data;
           var string = '';
           stream.on('data', function (chunk) {
@@ -886,18 +885,18 @@ describe('supports http with nodejs', function () {
         stream.destroy();
       }, 1000);
 
-      const {data} = await axios.post(LOCAL_SERVER_URL, stream, {responseType: 'stream'});
+      const { data } = await axios.post(LOCAL_SERVER_URL, stream, { responseType: 'stream' });
 
       let streamError;
 
-      data.on('error', function(err) {
+      data.on('error', function (err) {
         streamError = err;
       });
 
       try {
         await pipelineAsync(data, devNull());
         assert.fail('stream was not aborted');
-      } catch(e) {
+      } catch (e) {
         console.log(`pipeline error: ${e}`);
       } finally {
         assert.strictEqual(streamError && streamError.code, 'ERR_CANCELED');
@@ -913,18 +912,18 @@ describe('supports http with nodejs', function () {
     }).listen(4444, function () {
       axios.post('http://localhost:4444/',
         buf, {
-          responseType: 'stream'
-        }).then(function (res) {
-          var stream = res.data;
-          var string = '';
-          stream.on('data', function (chunk) {
-            string += chunk.toString('utf8');
-          });
-          stream.on('end', function () {
-            assert.equal(string, buf.toString());
-            done();
-          });
-        }).catch(done);
+        responseType: 'stream'
+      }).then(function (res) {
+        var stream = res.data;
+        var string = '';
+        stream.on('data', function (chunk) {
+          string += chunk.toString('utf8');
+        });
+        stream.on('end', function () {
+          assert.equal(string, buf.toString());
+          done();
+        });
+      }).catch(done);
     });
   });
 
@@ -1153,7 +1152,7 @@ describe('supports http with nodejs', function () {
           });
         });
       }).listen(4000, function () {
-        axios.get('http://localhost:4444/').then(function(res) {
+        axios.get('http://localhost:4444/').then(function (res) {
           assert.equal(res.status, 200);
           assert.equal(proxyUseCount, 1);
           done();
@@ -1373,8 +1372,8 @@ describe('supports http with nodejs', function () {
         }
       };
 
-      return axios.get('https://test-domain.abc', {proxy})
-        .then(function(){
+      return axios.get('https://test-domain.abc', { proxy })
+        .then(function () {
           assert.fail('Does not throw');
         }, function (error) {
           assert.strictEqual(error.message, 'Invalid proxy authorization');
@@ -1569,7 +1568,7 @@ describe('supports http with nodejs', function () {
       setTimeout(function () {
         res.write('chunk 2');
       }, 100);
-      setTimeout(function() {
+      setTimeout(function () {
         res.destroy();
       }, 200);
     }).listen(4444, function () {
@@ -1593,7 +1592,7 @@ describe('supports http with nodejs', function () {
     });
   });
 
-  it('should able to cancel multiple requests with CancelToken', function(done){
+  it('should able to cancel multiple requests with CancelToken', function (done) {
     server = http.createServer(function (req, res) {
       res.end('ok');
     }).listen(4444, function () {
@@ -1601,7 +1600,7 @@ describe('supports http with nodejs', function () {
       var source = CancelToken.source();
       var canceledStack = [];
 
-      var requests = [1, 2, 3, 4, 5].map(function(id){
+      var requests = [1, 2, 3, 4, 5].map(function (id) {
         return axios
           .get('/foo/bar', { cancelToken: source.token })
           .catch(function (e) {
@@ -1661,7 +1660,7 @@ describe('supports http with nodejs', function () {
               'Content-Type': 'multipart/form-data'
             }
           }).then(function (res) {
-            assert.deepStrictEqual(res.data.fields, {foo: 'bar'});
+            assert.deepStrictEqual(res.data.fields, { foo: 'bar' });
 
             assert.strictEqual(res.data.files.file1.mimetype, 'image/jpeg');
             assert.strictEqual(res.data.files.file1.originalFilename, 'temp/bar.jpg');
@@ -1680,7 +1679,7 @@ describe('supports http with nodejs', function () {
     describe('SpecCompliant FormData', (done) => {
       it('should allow passing FormData', async function () {
         server = await startHTTPServer(async (req, res) => {
-          const {fields, files} = await handleFormData(req);
+          const { fields, files } = await handleFormData(req);
 
           res.end(JSON.stringify({
             fields,
@@ -1692,26 +1691,26 @@ describe('supports http with nodejs', function () {
 
         const blobContent = 'blob-content';
 
-        const blob = new BlobSpecCompliant([blobContent], {type: 'image/jpeg'})
+        const blob = new BlobSpecCompliant([blobContent], { type: 'image/jpeg' })
 
         form.append('foo1', 'bar1');
         form.append('foo2', 'bar2');
 
         form.append('file1', blob);
 
-        const {data} = await axios.post(LOCAL_SERVER_URL, form, {
+        const { data } = await axios.post(LOCAL_SERVER_URL, form, {
           maxRedirects: 0
         });
 
-        assert.deepStrictEqual(data.fields, {foo1: 'bar1' ,'foo2': 'bar2'});
+        assert.deepStrictEqual(data.fields, { foo1: 'bar1', 'foo2': 'bar2' });
 
         assert.deepStrictEqual(typeof data.files.file1, 'object');
 
-        const {size, mimetype, originalFilename} = data.files.file1;
+        const { size, mimetype, originalFilename } = data.files.file1;
 
         assert.deepStrictEqual(
-          {size, mimetype, originalFilename},
-          {mimetype: 'image/jpeg', originalFilename: 'blob', size: Buffer.from(blobContent).byteLength}
+          { size, mimetype, originalFilename },
+          { mimetype: 'image/jpeg', originalFilename: 'blob', size: Buffer.from(blobContent).byteLength }
         );
       });
     });
@@ -1723,8 +1722,8 @@ describe('supports http with nodejs', function () {
         var obj = {
           arr1: ['1', '2', '3'],
           arr2: ['1', ['2'], '3'],
-          obj: {x: '1', y: {z: '1'}},
-          users: [{name: 'Peter', surname: 'griffin'}, {name: 'Thomas', surname: 'Anderson'}]
+          obj: { x: '1', y: { z: '1' } },
+          users: [{ name: 'Peter', surname: 'griffin' }, { name: 'Thomas', surname: 'Anderson' }]
         };
 
         app.post('/', multer().none(), function (req, res, next) {
@@ -1743,11 +1742,11 @@ describe('supports http with nodejs', function () {
           // arr[1]: '2'
           // -------------
           Promise.all([null, false, true].map(function (mode) {
-            return axios.postForm('http://localhost:3001/', obj, {formSerializer: {indexes: mode}})
+            return axios.postForm('http://localhost:3001/', obj, { formSerializer: { indexes: mode } })
               .then(function (res) {
                 assert.deepStrictEqual(res.data, obj, 'Index mode ' + mode);
               });
-          })).then(function (){
+          })).then(function () {
             done();
           }, done)
         });
@@ -1763,9 +1762,9 @@ describe('supports http with nodejs', function () {
 
       const blobContent = 'blob-content';
 
-      const blob = new BlobSpecCompliant([blobContent], {type: 'image/jpeg'})
+      const blob = new BlobSpecCompliant([blobContent], { type: 'image/jpeg' })
 
-      const {data} = await axios.post(LOCAL_SERVER_URL, blob, {
+      const { data } = await axios.post(LOCAL_SERVER_URL, blob, {
         maxRedirects: 0
       });
 
@@ -1780,8 +1779,8 @@ describe('supports http with nodejs', function () {
       var obj = {
         arr1: ['1', '2', '3'],
         arr2: ['1', ['2'], '3'],
-        obj: {x: '1', y: {z: '1'}},
-        users: [{name: 'Peter', surname: 'griffin'}, {name: 'Thomas', surname: 'Anderson'}]
+        obj: { x: '1', y: { z: '1' } },
+        users: [{ name: 'Peter', surname: 'griffin' }, { name: 'Thomas', surname: 'Anderson' }]
       };
 
       app.use(bodyParser.urlencoded({ extended: true }));
@@ -1844,7 +1843,7 @@ describe('supports http with nodejs', function () {
 
       const dataURI = 'data:application/octet-stream;base64,' + buffer.toString('base64');
 
-      axios.get(dataURI).then(({data}) => {
+      axios.get(dataURI).then(({ data }) => {
         assert.deepStrictEqual(data, buffer);
         done();
       }).catch(done);
@@ -1861,7 +1860,7 @@ describe('supports http with nodejs', function () {
 
       const dataURI = 'data:application/octet-stream;base64,' + buffer.toString('base64');
 
-      axios.get(dataURI, {responseType: 'blob'}).then(async ({data}) => {
+      axios.get(dataURI, { responseType: 'blob' }).then(async ({ data }) => {
         assert.strictEqual(data.type, 'application/octet-stream');
         assert.deepStrictEqual(await data.text(), '123');
         done();
@@ -1873,7 +1872,7 @@ describe('supports http with nodejs', function () {
 
       const dataURI = 'data:application/octet-stream;base64,' + buffer.toString('base64');
 
-      axios.get(dataURI, {responseType: "text"}).then(({data}) => {
+      axios.get(dataURI, { responseType: "text" }).then(({ data }) => {
         assert.deepStrictEqual(data, '123');
         done();
       }).catch(done);
@@ -1884,14 +1883,14 @@ describe('supports http with nodejs', function () {
 
       const dataURI = 'data:application/octet-stream;base64,' + buffer.toString('base64');
 
-      axios.get(dataURI, {responseType: "stream"}).then(({data}) => {
+      axios.get(dataURI, { responseType: "stream" }).then(({ data }) => {
         var str = '';
 
-        data.on('data', function(response){
+        data.on('data', function (response) {
           str += response.toString();
         });
 
-        data.on('end', function(){
+        data.on('end', function () {
           assert.strictEqual(str, '123');
           done();
         });
@@ -1925,8 +1924,8 @@ describe('supports http with nodejs', function () {
 
         const samples = [];
 
-        const {data} = await axios.post(LOCAL_SERVER_URL, readable, {
-          onUploadProgress: ({loaded, total, progress, bytes, upload}) => {
+        const { data } = await axios.post(LOCAL_SERVER_URL, readable, {
+          onUploadProgress: ({ loaded, total, progress, bytes, upload }) => {
             console.log('onUploadProgress', loaded, '/', total);
             samples.push({
               loaded,
@@ -1984,8 +1983,8 @@ describe('supports http with nodejs', function () {
 
         const samples = [];
 
-        const {data} = await axios.post(LOCAL_SERVER_URL, readable, {
-          onDownloadProgress: ({loaded, total, progress, bytes, download}) => {
+        const { data } = await axios.post(LOCAL_SERVER_URL, readable, {
+          onDownloadProgress: ({ loaded, total, progress, bytes, download }) => {
             console.log('onDownloadProgress', loaded, '/', total);
             samples.push({
               loaded,
@@ -2034,8 +2033,8 @@ describe('supports http with nodejs', function () {
       const skip = 4;
       const compareValues = toleranceRange(50, 50);
 
-      const {data} = await axios.post(LOCAL_SERVER_URL, buf, {
-        onUploadProgress: ({loaded, total, progress, bytes, rate}) => {
+      const { data } = await axios.post(LOCAL_SERVER_URL, buf, {
+        onUploadProgress: ({ loaded, total, progress, bytes, rate }) => {
           samples.push({
             loaded,
             total,
@@ -2049,10 +2048,9 @@ describe('supports http with nodejs', function () {
         maxRedirects: 0
       });
 
-      samples.slice(skip).forEach(({rate, progress}, i, _samples) => {
+      samples.slice(skip).forEach(({ rate, progress }, i, _samples) => {
         assert.ok(compareValues(rate, configRate),
-          `Rate sample at index ${i} is out of the expected range (${rate} / ${configRate}) [${
-            _samples.map(({rate}) => rate).join(', ')
+          `Rate sample at index ${i} is out of the expected range (${rate} / ${configRate}) [${_samples.map(({ rate }) => rate).join(', ')
           }]`
         );
 
@@ -2061,8 +2059,7 @@ describe('supports http with nodejs', function () {
 
         assert.ok(
           Math.abs(expectedProgress - progress) < 0.25,
-          `Progress sample at index ${i} is out of the expected range (${progress} / ${expectedProgress}) [${
-            _samples.map(({progress}) => progress).join(', ')
+          `Progress sample at index ${i} is out of the expected range (${progress} / ${expectedProgress}) [${_samples.map(({ progress }) => progress).join(', ')
           }]`
         );
       });
@@ -2082,8 +2079,8 @@ describe('supports http with nodejs', function () {
       const skip = 4;
       const compareValues = toleranceRange(50, 50);
 
-      const {data} = await axios.post(LOCAL_SERVER_URL, buf, {
-        onDownloadProgress: ({loaded, total, progress, bytes, rate}) => {
+      const { data } = await axios.post(LOCAL_SERVER_URL, buf, {
+        onDownloadProgress: ({ loaded, total, progress, bytes, rate }) => {
           samples.push({
             loaded,
             total,
@@ -2097,10 +2094,9 @@ describe('supports http with nodejs', function () {
         maxRedirects: 0
       });
 
-      samples.slice(skip).forEach(({rate, progress}, i, _samples) => {
+      samples.slice(skip).forEach(({ rate, progress }, i, _samples) => {
         assert.ok(compareValues(rate, configRate),
-          `Rate sample at index ${i} is out of the expected range (${rate} / ${configRate}) [${
-            _samples.map(({rate}) => rate).join(', ')
+          `Rate sample at index ${i} is out of the expected range (${rate} / ${configRate}) [${_samples.map(({ rate }) => rate).join(', ')
           }]`
         );
 
@@ -2109,8 +2105,7 @@ describe('supports http with nodejs', function () {
 
         assert.ok(
           Math.abs(expectedProgress - progress) < 0.25,
-          `Progress sample at index ${i} is out of the expected range (${progress} / ${expectedProgress}) [${
-            _samples.map(({progress}) => progress).join(', ')
+          `Progress sample at index ${i} is out of the expected range (${progress} / ${expectedProgress}) [${_samples.map(({ progress }) => progress).join(', ')
           }]`
         );
       });
@@ -2119,7 +2114,7 @@ describe('supports http with nodejs', function () {
     });
   });
 
-  describe('request aborting', function() {
+  describe('request aborting', function () {
     //this.timeout(5000);
 
     it('should be able to abort the response stream', async () => {
@@ -2132,7 +2127,7 @@ describe('supports http with nodejs', function () {
 
       const controller = new AbortController();
 
-      const {data} = await axios.post(LOCAL_SERVER_URL, buf, {
+      const { data } = await axios.post(LOCAL_SERVER_URL, buf, {
         responseType: 'stream',
         signal: controller.signal,
         maxRedirects: 0
@@ -2144,7 +2139,7 @@ describe('supports http with nodejs', function () {
 
       let streamError;
 
-      data.on('error', function(err) {
+      data.on('error', function (err) {
         streamError = err;
       });
 
@@ -2161,7 +2156,7 @@ describe('supports http with nodejs', function () {
   it('should support function as paramsSerializer value', async () => {
     server = await startHTTPServer((req, res) => res.end(req.url));
 
-    const {data} = await axios.post(LOCAL_SERVER_URL, 'test', {
+    const { data } = await axios.post(LOCAL_SERVER_URL, 'test', {
       params: {
         x: 1
       },
@@ -2172,112 +2167,9 @@ describe('supports http with nodejs', function () {
     assert.strictEqual(data, '/?foo');
   });
 
-  describe('DNS', function() {
-    it('should support a custom DNS lookup function', async function () {
-      server = await startHTTPServer(SERVER_HANDLER_STREAM_ECHO);
 
-      const payload = 'test';
 
-      let isCalled = false;
-
-      const {data} = await axios.post(`http://fake-name.axios:4444`, payload,{
-        lookup: (hostname, opt, cb) =>  {
-          isCalled = true;
-          cb(null, '127.0.0.1', 4);
-        }
-      });
-
-      assert.ok(isCalled);
-
-      assert.strictEqual(data, payload);
-    });
-
-    it('should support a custom DNS lookup function with address entry passing', async function () {
-      server = await startHTTPServer(SERVER_HANDLER_STREAM_ECHO);
-
-      const payload = 'test';
-
-      let isCalled = false;
-
-      const {data} = await axios.post(`http://fake-name.axios:4444`, payload,{
-        lookup: (hostname, opt, cb) =>  {
-          isCalled = true;
-          cb(null, {address: '127.0.0.1', family: 4});
-        }
-      });
-
-      assert.ok(isCalled);
-
-      assert.strictEqual(data, payload);
-    });
-
-    it('should support a custom DNS lookup function (async)', async function () {
-      server = await startHTTPServer(SERVER_HANDLER_STREAM_ECHO);
-
-      const payload = 'test';
-
-      let isCalled = false;
-
-      const {data} = await axios.post(`http://fake-name.axios:4444`, payload,{
-        lookup: async (hostname, opt) =>  {
-          isCalled = true;
-          return ['127.0.0.1', 4];
-        }
-      });
-
-      assert.ok(isCalled);
-
-      assert.strictEqual(data, payload);
-    });
-
-    it('should support a custom DNS lookup function with address entry (async)', async function () {
-      server = await startHTTPServer(SERVER_HANDLER_STREAM_ECHO);
-
-      const payload = 'test';
-
-      let isCalled = false;
-
-      const {data} = await axios.post(`http://fake-name.axios:4444`, payload,{
-        lookup: async (hostname, opt) =>  {
-          isCalled = true;
-          return {address: '127.0.0.1', family: 4};
-        }
-      });
-
-      assert.ok(isCalled);
-
-      assert.strictEqual(data, payload);
-    });
-
-    it('should support a custom DNS lookup function that returns only IP address (async)', async function () {
-      server = await startHTTPServer(SERVER_HANDLER_STREAM_ECHO);
-
-      const payload = 'test';
-
-      let isCalled = false;
-
-      const {data} = await axios.post(`http://fake-name.axios:4444`, payload,{
-        lookup: async (hostname, opt) =>  {
-          isCalled = true;
-          return '127.0.0.1';
-        }
-      });
-
-      assert.ok(isCalled);
-
-      assert.strictEqual(data, payload);
-    });
-
-    it('should handle errors', () => {
-      return assert.rejects(async () => {
-        await axios.get('https://no-such-domain-987654.com', {
-          lookup
-        });
-      }, /ENOTFOUND/);
-    });
-  });
-
-  describe('JSON', function() {
+  describe('JSON', function () {
     it('should support reviver on JSON.parse', async function () {
       server = await startHTTPServer(async (_, res) => {
         res.end(JSON.stringify({
@@ -2285,13 +2177,13 @@ describe('supports http with nodejs', function () {
         }));
       });
 
-      const {data} = await axios.get(LOCAL_SERVER_URL, {
+      const { data } = await axios.get(LOCAL_SERVER_URL, {
         parseReviver: (key, value) => {
           return key === 'foo' ? 'success' : value;
         },
       });
 
-      assert.deepStrictEqual(data, {foo: 'success'});
+      assert.deepStrictEqual(data, { foo: 'success' });
     });
   });
 
@@ -2307,9 +2199,9 @@ describe('supports http with nodejs', function () {
     });
 
     it('should merge request http2Options with its instance config', async () => {
-      const {data} = await http2Axios.get('/', {
+      const { data } = await http2Axios.get('/', {
         http2Options: {
-          foo : 'test'
+          foo: 'test'
         },
         adapter: async (config) => {
           return {
@@ -2320,7 +2212,7 @@ describe('supports http with nodejs', function () {
 
       assert.deepStrictEqual(data, {
         rejectUnauthorized: false,
-        foo : 'test'
+        foo: 'test'
       });
     });
 
@@ -2331,7 +2223,7 @@ describe('supports http with nodejs', function () {
         useHTTP2: true
       });
 
-      const {data} = await http2Axios.get(LOCAL_SERVER_URL);
+      const { data } = await http2Axios.get(LOCAL_SERVER_URL);
 
       assert.deepStrictEqual(data, 'OK');
 
@@ -2344,7 +2236,7 @@ describe('supports http with nodejs', function () {
 
       const payload = 'DATA';
 
-      const {data} = await http2Axios.post(LOCAL_SERVER_URL, payload);
+      const { data } = await http2Axios.post(LOCAL_SERVER_URL, payload);
 
       assert.deepStrictEqual(data, payload);
 
@@ -2357,7 +2249,7 @@ describe('supports http with nodejs', function () {
 
 
       server = await startHTTPServer(async (req, res) => {
-        const {fields, files} = await handleFormData(req);
+        const { fields, files } = await handleFormData(req);
 
         res.end(JSON.stringify({
           fields,
@@ -2372,7 +2264,7 @@ describe('supports http with nodejs', function () {
       form.append('x', 'foo');
       form.append('y', 'bar');
 
-      const {data} = await http2Axios.post(LOCAL_SERVER_URL, form);
+      const { data } = await http2Axios.post(LOCAL_SERVER_URL, form);
 
       assert.deepStrictEqual(data, {
         fields: {
@@ -2388,13 +2280,13 @@ describe('supports http with nodejs', function () {
       const originalData = '{"test": "OK"}';
 
       const fixtures = {
-        'text' : (v) => assert.strictEqual(v, originalData),
-        'arraybuffer' : (v) => assert.deepStrictEqual(v, Buffer.from(originalData)),
+        'text': (v) => assert.strictEqual(v, originalData),
+        'arraybuffer': (v) => assert.deepStrictEqual(v, Buffer.from(originalData)),
         'stream': async (v) => assert.deepStrictEqual(await getStream(v), originalData),
         'json': async (v) => assert.deepStrictEqual(v, JSON.parse(originalData))
       };
 
-      for(let [responseType, assertValue] of Object.entries(fixtures)) {
+      for (let [responseType, assertValue] of Object.entries(fixtures)) {
         it(`should support ${responseType} response type`, async () => {
           server = await startHTTPServer((req, res) => {
             res.end(originalData);
@@ -2402,7 +2294,7 @@ describe('supports http with nodejs', function () {
             useHTTP2: true
           });
 
-          const {data} = await http2Axios.get(LOCAL_SERVER_URL, {
+          const { data } = await http2Axios.get(LOCAL_SERVER_URL, {
             responseType
           });
 
@@ -2414,7 +2306,7 @@ describe('supports http with nodejs', function () {
 
 
     it('should support request timeout', async () => {
-      let isAborted= false;
+      let isAborted = false;
 
       let aborted;
       const promise = new Promise(resolve => aborted = resolve);
@@ -2445,12 +2337,12 @@ describe('supports http with nodejs', function () {
       assert.ok(isAborted);
     });
 
-    it('should support request cancellation', async function (){
+    it('should support request cancellation', async function () {
       if (typeof AbortSignal !== 'function' || !AbortSignal.timeout) {
         this.skip();
       }
 
-      let isAborted= false;
+      let isAborted = false;
 
       let aborted;
       const promise = new Promise(resolve => aborted = resolve);
@@ -2482,7 +2374,7 @@ describe('supports http with nodejs', function () {
     });
 
     it('should support stream response cancellation', async () => {
-      let isAborted= false;
+      let isAborted = false;
       var source = axios.CancelToken.source();
 
       let aborted;
@@ -2501,7 +2393,7 @@ describe('supports http with nodejs', function () {
         });
       });
 
-      const {data} = await http2Axios.get(LOCAL_SERVER_URL, {
+      const { data } = await http2Axios.get(LOCAL_SERVER_URL, {
         cancelToken: source.token,
         responseType: 'stream'
       });
@@ -2519,7 +2411,7 @@ describe('supports http with nodejs', function () {
     });
 
     describe("session", () => {
-      it("should reuse session for the target authority", async() => {
+      it("should reuse session for the target authority", async () => {
         server = await startHTTPServer((req, res) => {
           setTimeout(() => res.end('OK'), 1000);
         }, {
@@ -2546,7 +2438,7 @@ describe('supports http with nodejs', function () {
         );
       });
 
-      it("should use different sessions for different authorities", async() => {
+      it("should use different sessions for different authorities", async () => {
         server = await startHTTPServer((req, res) => {
           setTimeout(() => {
             res.end('OK');
@@ -2584,7 +2476,7 @@ describe('supports http with nodejs', function () {
         );
       });
 
-      it("should use different sessions for requests with different http2Options set", async() => {
+      it("should use different sessions for requests with different http2Options set", async () => {
         server = await startHTTPServer((req, res) => {
           setTimeout(() => {
             res.end('OK')
@@ -2619,7 +2511,7 @@ describe('supports http with nodejs', function () {
         );
       });
 
-      it("should use the same session for request with the same resolved http2Options set", async() => {
+      it("should use the same session for request with the same resolved http2Options set", async () => {
         server = await startHTTPServer((req, res) => {
           setTimeout(() => res.end('OK'), 1000);
         }, {
@@ -2649,12 +2541,12 @@ describe('supports http with nodejs', function () {
 
 
         assert.deepStrictEqual(
-          await Promise.all(responses.map(({data}) => getStream(data))),
+          await Promise.all(responses.map(({ data }) => getStream(data))),
           ['OK', 'OK', 'OK']
         );
       });
 
-      it("should use different sessions after previous session timeout", async() => {
+      it("should use different sessions after previous session timeout", async () => {
         server = await startHTTPServer((req, res) => {
           setTimeout(() => res.end('OK'), 100);
         }, {
@@ -2701,7 +2593,7 @@ describe('supports http with nodejs', function () {
       });
 
       assert.fail('should be rejected');
-    } catch(err) {
+    } catch (err) {
       assert.strictEqual(await getStream(err.response.data), 'OK');
     }
   });
@@ -2716,8 +2608,8 @@ describe('supports http with nodejs', function () {
       })
 
       const baseURL = LOCAL_SERVER_URL;
-      await axios.get('/1', {baseURL, timeout: 1000});
-      await axios.get(`/wait`, {baseURL, timeout: 0});
+      await axios.get('/1', { baseURL, timeout: 1000 });
+      await axios.get(`/wait`, { baseURL, timeout: 0 });
     }, 15000);
   });
 });


### PR DESCRIPTION
Fixed Issue #7271 

**Description**

This PR removes CreateAxiosDefaults["lookup"] in favor of using only Agent["lookup"] for custom hostname resolution in Node.js. Axios already prioritizes Agent.lookup, and the Axios-level lookup option is redundant and poorly typed, leading to unnecessary duplication and complex validation logic.

**Problem**

1. Poor typing & unnecessary complexity.
2. There is also a major fix that CreateAxiosDefaults.lookup has loosely defined types.
3. Custom DNS lookup is only supported in Node.js.
4. Axios prefers Agent.lookup; CreateAxiosDefaults.lookup is only used if the agent does not define one.

**Solution**

1. Remove CreateAxiosDefaults["lookup"]
2. Now , Axios already prioritizes Agent["lookup"] according to Node.js standards.

### I also want to show the demonstrated example code for clarification for the review by maintainers

Code Snippet 1

```
const httpsAgent = new Agent({ lookup: dnsLookup });

axios.create({
  httpsAgent,
  lookup: customWrappedLookup
});
```

Now , in the above code, problem is that there exists a duplicate logic as we are defining two lookup functions(dnsLookup and customWrappedLookup) so , it waill cause more bugs and consequently more confusion.

Code Snippet 2:


```
const httpsAgent = new Agent({ lookup: dnsLookup });

axios.create({
  httpsAgent
});

```

Now , in this code there is only one lookup function that is the Node.js provided us(Agent.lookup), so it, resulted in to more cleaner API, no more wrapping .

**Please review and let me know if you'd like any modifications. I'm ready to update the PR.**

