### PR TITLE
fix: set default responseType to 'json' to match documentationfix: set default responseType to 'json' to match documentation

### DIFF
--- a/lib/defaults/index.js
+++ b/lib/defaults/index.js
@@ -39,6 +39,8 @@ const defaults = {
 
   adapter: ['xhr', 'http', 'fetch'],
 
+  responseType: 'json',
+
   transformRequest: [function transformRequest(data, headers) {
     const contentType = headers.getContentType() || '';
     const hasJSONContentType = contentType.indexOf('application/json') > -1;


### PR DESCRIPTION
## Description

This PR fixes issue #7253 by setting the default `responseType` to `'json'` to align the implementation with the documented behavior.

## Problem

The axios documentation (README.md line 466) states that `responseType` defaults to `'json'`, but in the actual implementation (`lib/defaults/index.js`), `responseType` was not defined in the defaults object, making it `undefined` by default.

This discrepancy caused issues with JSON parsing error handling. Specifically, when a user sets `silentJSONParsing: false` to enable strict JSON parsing errors, the errors were not being thrown as expected because the condition `this.responseType === 'json'` in the `transformResponse` function (line 103) evaluated to `false` when `responseType` was `undefined`.

## Solution

Added `responseType: 'json'` to the defaults object in `lib/defaults/index.js`.

## Changes

- **Modified file**: `lib/defaults/index.js`
- **Lines changed**: Added 1 line (line 42)
- **Change type**: Bug fix
