### PR TITLE
fix: parse data uris according to rfc 2397

### DIFF
--- a/lib/helpers/fromDataURI.js
+++ b/lib/helpers/fromDataURI.js
@@ -3,8 +3,7 @@
 import AxiosError from '../core/AxiosError.js';
 import parseProtocol from './parseProtocol.js';
 import platform from '../platform/index.js';
-
-const DATA_URL_PATTERN = /^(?:([^;]+);)?(?:[^;]+;)?(base64|),([\s\S]*)$/;
+import dataUriToBuffer from 'data-uri-to-buffer';
 
 /**
  * Parse data uri to a Buffer or Blob
@@ -25,18 +24,14 @@ export default function fromDataURI(uri, asBlob, options) {
   }
 
   if (protocol === 'data') {
-    uri = protocol.length ? uri.slice(protocol.length + 1) : uri;
-
-    const match = DATA_URL_PATTERN.exec(uri);
+    const match = dataUriToBuffer(uri);
 
     if (!match) {
       throw new AxiosError('Invalid URL', AxiosError.ERR_INVALID_URL);
     }
 
-    const mime = match[1];
-    const isBase64 = match[2];
-    const body = match[3];
-    const buffer = Buffer.from(decodeURIComponent(body), isBase64 ? 'base64' : 'utf8');
+    const mime = match.type;
+    const buffer = Buffer.from(match);
 
     if (asBlob) {
       if (!_Blob) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.13.2",
       "license": "MIT",
       "dependencies": {
+        "data-uri-to-buffer": "^3.0.1",
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.4",
         "proxy-from-env": "^1.1.0"
@@ -8274,12 +8275,12 @@
       }
     },
     "node_modules/data-uri-to-buffer": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
-      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
-      "dev": true,
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
+      "integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==",
+      "license": "MIT",
       "engines": {
-        "node": ">= 14"
+        "node": ">= 6"
       }
     },
     "node_modules/date-format": {
@@ -12346,6 +12347,16 @@
         "debug": "^4.3.4",
         "fs-extra": "^11.2.0"
       },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/get-uri/node_modules/data-uri-to-buffer": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 14"
       }
@@ -33189,10 +33200,9 @@
       }
     },
     "data-uri-to-buffer": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
-      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
-      "dev": true
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
+      "integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og=="
     },
     "date-format": {
       "version": "4.0.9",
@@ -36444,6 +36454,12 @@
         "fs-extra": "^11.2.0"
       },
       "dependencies": {
+        "data-uri-to-buffer": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+          "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+          "dev": true
+        },
         "fs-extra": {
           "version": "11.2.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -171,6 +171,7 @@
   "unpkg": "dist/axios.min.js",
   "typings": "./index.d.ts",
   "dependencies": {
+    "data-uri-to-buffer": "^3.0.1",
     "follow-redirects": "^1.15.6",
     "form-data": "^4.0.4",
     "proxy-from-env": "^1.1.0"

--- a/test/unit/helpers/fromDataURI.js
+++ b/test/unit/helpers/fromDataURI.js
@@ -2,11 +2,63 @@ import assert from 'assert';
 import fromDataURI from '../../../lib/helpers/fromDataURI.js';
 
 describe('helpers::fromDataURI', function () {
-  it('should return buffer from data uri', function () {
-    const buffer= Buffer.from('123');
+  for (const isBase64 of [true, false]) {
+    const base64Suffix = isBase64 ? ';base64' : '';
+    const toStringEncoding = isBase64 ? 'base64' : undefined;
 
-    const dataURI = 'data:application/octet-stream;base64,' + buffer.toString('base64');
+    it(`should return buffer from data uri (base64 = ${isBase64})`, function () {
+      const buffer = Buffer.from('123');
 
-    assert.deepStrictEqual(fromDataURI(dataURI, false), buffer);
+      const dataURI = `data:application/octet-stream${base64Suffix},${buffer.toString(toStringEncoding)}`;
+
+      assert.deepStrictEqual(fromDataURI(dataURI, false), buffer);
+    });
+
+    it(`should return buffer from data uri without media type (base64 = ${isBase64})`, function () {
+      const buffer = Buffer.from('123');
+
+      const dataURI = `data:${base64Suffix},${buffer.toString(toStringEncoding)}`;
+
+      assert.deepStrictEqual(fromDataURI(dataURI, false), buffer);
+    });
+
+    it(`should return buffer from data uri with charset (base64 = ${isBase64})`, function () {
+      const buffer = Buffer.from('123');
+
+      const dataURI = `data:text/plain;charset=US-ASCII${base64Suffix},${buffer.toString(toStringEncoding)}`;
+
+      assert.deepStrictEqual(fromDataURI(dataURI, false), buffer);
+    });
+
+    if (typeof Blob !== 'undefined') {
+      it(`should return buffer from data uri as blob (base64 = ${isBase64})`, function () {
+        const buffer = Buffer.from('123');
+
+        const dataURI = `data:application/octet-stream${base64Suffix},${buffer.toString(toStringEncoding)}`;
+
+        assert.deepStrictEqual(fromDataURI(dataURI, true), new Blob([buffer], { type: 'application/octet-stream' }));
+        assert.deepStrictEqual(fromDataURI(dataURI), new Blob([buffer], { type: 'application/octet-stream' }));
+      });
+    }
+  }
+
+  it('should return buffer from data uri with url encoded values', function () {
+    const buffer = Buffer.from('123%20456');
+
+    const dataURI = `data:application/octet-stream,${buffer.toString()}`;
+
+    assert.deepStrictEqual(fromDataURI(dataURI, false), Buffer.from('123 456'));
+  });
+
+  it('should throw for unsupported protocol', function () {
+    assert.throws(function () {
+      fromDataURI('datax:,hi');
+    }, { message: 'Unsupported protocol datax' });
+  });
+
+  it('should throw for invalid data uri', function () {
+    assert.throws(function () {
+      fromDataURI('data:hi');
+    }, 'Invalid URL');
   });
 });


### PR DESCRIPTION
This PR replaces the non-compliant `DATA_URL_PATTERN` regular expression in `fromDataURI` with the `data-uri-to-buffer` library, which is compliant with RFC 2397.

Before this change, the following valid Data URIs resulted in `Invalid URL`:
* `data:;base64,MTIz`
* `data:application/octet-stream,123`
* `data:text/plain;charset=US-ASCII,123`

It uses `data-uri-to-buffer@3`, which supports Node.js 6+.