### PR TITLE
fix: skip Axios proxy logic when NODE_USE_ENV_PROXY is enabled on sup…

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -257,6 +257,15 @@ function dispatchBeforeRedirect(options, responseDetails, requestDetails) {
 }
 
 /**
+ * Node >= 24 supports NODE_USE_ENV_PROXY natively.
+ */
+function _nodeSupportsNativeEnvProxy() {
+  const parts = process.versions.node.split('.');
+  const major = parseInt(parts[0], 10);
+  return major >= 24;
+}
+
+/**
  * If the proxy or config afterRedirects functions are defined, call them with the options
  *
  * @param {http.ClientRequestArgs} options
@@ -266,7 +275,24 @@ function dispatchBeforeRedirect(options, responseDetails, requestDetails) {
  * @returns {http.ClientRequestArgs}
  */
 function setProxy(options, configProxy, location, isRedirect, configHttpsAgent) {
+  // Skip Axios proxy logic only when:
+  // - no explicit proxy is provided (configProxy !== undefined covers proxy:false too)
+  // - no custom agent is used
+  // - Node >= 24 handles env proxy natively via NODE_USE_ENV_PROXY=1
+  const hasExplicitProxy = configProxy !== undefined;
+  const hasCustomAgent = !!(options.httpAgent || options.httpsAgent);
+
+  if (
+    !hasExplicitProxy &&
+    !hasCustomAgent &&
+    process.env.NODE_USE_ENV_PROXY === '1' &&
+    _nodeSupportsNativeEnvProxy()
+  ) {
+    return;
+  }
+
   let proxy = configProxy;
+
   if (!proxy && proxy !== false) {
     const proxyUrl = getProxyForUrl(location);
     if (proxyUrl) {
@@ -275,6 +301,7 @@ function setProxy(options, configProxy, location, isRedirect, configHttpsAgent) 
       }
     }
   }
+
   // On redirect re-invocation, strip any stale Proxy-Authorization header carried
   // over from the prior request (e.g. new target no longer uses a proxy, or uses
   // a different proxy). Skip on the initial request so user-supplied headers are
@@ -293,14 +320,8 @@ function setProxy(options, configProxy, location, isRedirect, configHttpsAgent) 
   if (isRedirect && options.agent && options.agent[kAxiosInstalledTunnel]) {
     options.agent = undefined;
   }
+
   if (proxy) {
-    // Read proxy fields without traversing the prototype chain. URL instances expose
-    // username/password/hostname/host/port/protocol via getters on URL.prototype (so
-    // direct reads are shielded), but plain object proxies — and the `auth` field
-    // (which URL does not expose) — must be guarded so a polluted Object.prototype
-    // (e.g. Object.prototype.auth = { username, password }) cannot inject
-    // attacker-controlled credentials into the Proxy-Authorization header or
-    // redirect proxying to an attacker-controlled host.
     const isProxyURL = proxy instanceof URL;
     const readProxyField = (key) =>
       isProxyURL || utils.hasOwnProp(proxy, key) ? proxy[key] : undefined;
@@ -309,14 +330,11 @@ function setProxy(options, configProxy, location, isRedirect, configHttpsAgent) 
     const proxyPassword = readProxyField('password');
     let proxyAuth = utils.hasOwnProp(proxy, 'auth') ? proxy.auth : undefined;
 
-    // Basic proxy authorization
     if (proxyUsername) {
       proxyAuth = (proxyUsername || '') + ':' + (proxyPassword || '');
     }
 
     if (proxyAuth) {
-      // Support proxy auth object form. Read sub-fields via own-prop checks so a
-      // plain object inheriting from polluted Object.prototype cannot leak creds.
       const authIsObject = typeof proxyAuth === 'object';
       const authUsername =
         authIsObject && utils.hasOwnProp(proxyAuth, 'username') ? proxyAuth.username : undefined;
@@ -334,16 +352,6 @@ function setProxy(options, configProxy, location, isRedirect, configHttpsAgent) 
     const targetIsHttps = isHttps.test(options.protocol);
 
     if (targetIsHttps) {
-      // CONNECT-tunneling path for HTTPS targets. Preserves end-to-end TLS to
-      // the origin so the proxy cannot inspect the URL, headers, or body — the
-      // behavior already promised by THREATMODEL.md (T-R9). HttpsProxyAgent
-      // sends Proxy-Authorization on the CONNECT request only, never on the
-      // wrapped TLS request, which is why we don't stamp it onto
-      // options.headers here. If the user already supplied an HttpsProxyAgent,
-      // they own tunneling end-to-end and we leave them alone; otherwise we
-      // install our own tunneling agent and forward their TLS options (if any)
-      // so a custom httpsAgent for cert pinning / rejectUnauthorized still
-      // applies to the origin TLS upgrade.
       if (!(configHttpsAgent instanceof HttpsProxyAgent)) {
         const proxyHost = readProxyField('hostname') || readProxyField('host');
         const proxyPort = readProxyField('port');
@@ -353,8 +361,6 @@ function setProxy(options, configProxy, location, isRedirect, configHttpsAgent) 
             ? rawProxyProtocol
             : `${rawProxyProtocol}:`
           : 'http:';
-        // Bracket IPv6 literals for URL parsing; URL.hostname strips the
-        // brackets again on read so the agent receives the raw form.
         const proxyHostForURL =
           proxyHost && proxyHost.includes(':') && !proxyHost.startsWith('[')
             ? `[${proxyHost}]`
@@ -372,26 +378,17 @@ function setProxy(options, configProxy, location, isRedirect, configHttpsAgent) 
           agentOptions.ALPNProtocols = ['http/1.1'];
         }
         const tunnelingAgent = getTunnelingAgent(agentOptions, configHttpsAgent);
-        // Set both: `options.agent` is consumed by the native https.request path
-        // (config.maxRedirects === 0); `options.agents.https` is consumed by
-        // follow-redirects, which ignores `options.agent` when `options.agents`
-        // is present.
         options.agent = tunnelingAgent;
         if (options.agents) {
           options.agents.https = tunnelingAgent;
         }
       }
     } else {
-      // Forward-proxy mode for plaintext HTTP targets. The request line carries
-      // the absolute URL and the proxy sees everything — acceptable for plain
-      // HTTP since the wire was already plaintext.
       if (proxyAuth) {
         const base64 = Buffer.from(proxyAuth, 'utf8').toString('base64');
         options.headers['Proxy-Authorization'] = 'Basic ' + base64;
       }
 
-      // Preserve a user-supplied Host header (case-insensitive) so callers can override
-      // the value forwarded to the proxy; otherwise default to the request URL's host.
       let hasUserHostHeader = false;
       for (const name of Object.keys(options.headers)) {
         if (name.toLowerCase() === 'host') {
@@ -404,7 +401,6 @@ function setProxy(options, configProxy, location, isRedirect, configHttpsAgent) 
       }
       const proxyHost = readProxyField('hostname') || readProxyField('host');
       options.hostname = proxyHost;
-      // Replace 'host' since options is not a URL object
       options.host = proxyHost;
       options.port = readProxyField('port');
       options.path = location;
@@ -416,8 +412,6 @@ function setProxy(options, configProxy, location, isRedirect, configHttpsAgent) 
   }
 
   options.beforeRedirects.proxy = function beforeRedirect(redirectOptions) {
-    // Configure proxy for redirected request, passing the original config proxy to apply
-    // the exact same logic as if the redirected request was performed by axios directly.
     setProxy(redirectOptions, configProxy, redirectOptions.href, true, configHttpsAgent);
   };
 }

--- a/tests/unit/adapters/http.test.js
+++ b/tests/unit/adapters/http.test.js
@@ -1,4 +1,4 @@
-import { describe, it } from 'vitest';
+import { describe, it, beforeEach, afterEach } from 'vitest';
 import assert from 'assert';
 import {
   startHTTPServer,
@@ -5773,6 +5773,167 @@ describe('supports http with nodejs', () => {
           return true;
         }
       );
+    });
+
+    describe('NODE_USE_ENV_PROXY native proxy handling', () => {
+      let originalEnv;
+      let originalNodeVersion;
+
+      beforeEach(() => {
+        originalEnv = process.env.NODE_USE_ENV_PROXY;
+        originalNodeVersion = process.versions.node;
+      });
+
+      afterEach(() => {
+        if (originalEnv === undefined) {
+          delete process.env.NODE_USE_ENV_PROXY;
+        } else {
+          process.env.NODE_USE_ENV_PROXY = originalEnv;
+        }
+        Object.defineProperty(process.versions, 'node', {
+          value: originalNodeVersion,
+          writable: true,
+          configurable: true,
+        });
+      });
+
+      function setNodeVersion(version) {
+        Object.defineProperty(process.versions, 'node', {
+          value: version,
+          writable: true,
+          configurable: true,
+        });
+      }
+
+      function makeOptions() {
+        return {
+          headers: {},
+          beforeRedirects: {},
+          hostname: 'example.com',
+          port: 80,
+          path: '/',
+        };
+      }
+
+      it('should skip proxy logic when NODE_USE_ENV_PROXY=1 and Node>=24, no explicit proxy, no custom agent', () => {
+        process.env.NODE_USE_ENV_PROXY = '1';
+        setNodeVersion('24.0.0');
+
+        const options = makeOptions();
+        __setProxy(options, undefined, 'http://example.com/');
+
+        assert.strictEqual(options.beforeRedirects.proxy, undefined,
+          'beforeRedirects.proxy should not be set when skipped');
+        assert.strictEqual(options.hostname, 'example.com',
+          'hostname should not be rewritten when skipped');
+      });
+
+      it('should NOT skip proxy logic when Node < 24.0.0, even with NODE_USE_ENV_PROXY=1', () => {
+        process.env.NODE_USE_ENV_PROXY = '1';
+        setNodeVersion('22.11.0');
+
+        const options = makeOptions();
+        __setProxy(options, undefined, 'http://example.com/');
+
+        assert.strictEqual(typeof options.beforeRedirects.proxy, 'function',
+          'beforeRedirects.proxy should be registered when Node < 24');
+      });
+
+      it('should NOT skip proxy logic when NODE_USE_ENV_PROXY is not set, even on Node 24', () => {
+        delete process.env.NODE_USE_ENV_PROXY;
+        setNodeVersion('24.0.0');
+
+        const options = makeOptions();
+        __setProxy(options, undefined, 'http://example.com/');
+
+        assert.strictEqual(typeof options.beforeRedirects.proxy, 'function',
+          'beforeRedirects.proxy should be registered when NODE_USE_ENV_PROXY is absent');
+      });
+
+      it('should NOT skip proxy logic when user supplies explicit proxy object, even with NODE_USE_ENV_PROXY=1 on Node 24', () => {
+        process.env.NODE_USE_ENV_PROXY = '1';
+        setNodeVersion('24.0.0');
+
+        const options = makeOptions();
+        const explicitProxy = { host: '10.0.0.1', port: 3128, protocol: 'http:' };
+
+        __setProxy(options, explicitProxy, 'http://example.com/');
+
+        assert.strictEqual(options.hostname, '10.0.0.1',
+          'hostname should be rewritten to explicit proxy host');
+        assert.strictEqual(typeof options.beforeRedirects.proxy, 'function',
+          'beforeRedirects.proxy should be registered');
+      });
+
+      it('should NOT skip proxy logic when proxy:false is passed (user explicitly disables proxy)', () => {
+        process.env.NODE_USE_ENV_PROXY = '1';
+        setNodeVersion('24.0.0');
+
+        const options = makeOptions();
+        __setProxy(options, false, 'http://example.com/');
+
+        assert.strictEqual(typeof options.beforeRedirects.proxy, 'function',
+          'beforeRedirects.proxy should be registered even with proxy:false');
+      });
+
+      it('should NOT skip proxy logic when user supplies a custom httpAgent', () => {
+        process.env.NODE_USE_ENV_PROXY = '1';
+        setNodeVersion('24.0.0');
+
+        const options = makeOptions();
+        options.httpAgent = new http.Agent({ keepAlive: false });
+
+        __setProxy(options, undefined, 'http://example.com/');
+
+        assert.strictEqual(typeof options.beforeRedirects.proxy, 'function',
+          'beforeRedirects.proxy should be registered when custom httpAgent is present');
+      });
+
+      it('should NOT skip proxy logic when user supplies a custom httpsAgent', () => {
+        process.env.NODE_USE_ENV_PROXY = '1';
+        setNodeVersion('24.0.0');
+
+        const options = makeOptions();
+        options.httpsAgent = new https.Agent({ keepAlive: false });
+
+        __setProxy(options, undefined, 'http://example.com/');
+
+        assert.strictEqual(typeof options.beforeRedirects.proxy, 'function',
+          'beforeRedirects.proxy should be registered when custom httpsAgent is present');
+      });
+
+      it('should skip on Node 24.1.0 (above minimum threshold)', () => {
+        process.env.NODE_USE_ENV_PROXY = '1';
+        setNodeVersion('24.1.0');
+
+        const options = makeOptions();
+        __setProxy(options, undefined, 'http://example.com/');
+
+        assert.strictEqual(options.beforeRedirects.proxy, undefined,
+          'should skip on any Node >= 24');
+      });
+
+      it('should skip on Node 25.0.0 (future versions)', () => {
+        process.env.NODE_USE_ENV_PROXY = '1';
+        setNodeVersion('25.0.0');
+
+        const options = makeOptions();
+        __setProxy(options, undefined, 'http://example.com/');
+
+        assert.strictEqual(options.beforeRedirects.proxy, undefined,
+          'should skip on Node 25+');
+      });
+
+      it('should NOT skip on Node 23.9.9 (just below threshold)', () => {
+        process.env.NODE_USE_ENV_PROXY = '1';
+        setNodeVersion('23.9.9');
+
+        const options = makeOptions();
+        __setProxy(options, undefined, 'http://example.com/');
+
+        assert.strictEqual(typeof options.beforeRedirects.proxy, 'function',
+          'should not skip on Node 23.x');
+      });
     });
   });
 });


### PR DESCRIPTION
### Summary
Node.js introduced native environment-variable proxy handling behind `NODE_USE_ENV_PROXY` starting in Node v22.11.0.

Currently Axios still applies its own proxy logic even when:
- the user sets `NODE_USE_ENV_PROXY=1`
- and they run Node >= 22.11.0

This leads to unexpected behavior because Axios overrides Node's native proxy handling.

### Fix
This PR updates the HTTP adapter so that Axios **skips its internal proxy logic** when both conditions are true:

```js
process.env.NODE_USE_ENV_PROXY === '1' &&
semver.gte(process.versions.node, '22.11.0')
