### PR TITLE
docs: add async/await timeout handling example

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,7 +522,27 @@ These are the available config options for making requests. Only the `url` is re
   }
 }
 ```
+**Handling request timeouts with async/await**
 
+```js
+import axios from 'axios';
+
+async function fetchData() {
+  try {
+    const response = await axios.get('https://example.com/api', {
+      timeout: 1000,
+    });
+
+    console.log(response.data);
+  } catch (error) {
+    if (error.code === 'ECONNABORTED') {
+      console.error('Request timed out');
+    } else {
+      console.error(error.message);
+    }
+  }
+}
+```
 ## Response Schema
 
 The response for a request contains the following information.


### PR DESCRIPTION
### Summary

This pull request adds a missing async/await example for handling request timeouts in Axios.

### Details

While Axios documents the `timeout` request configuration option, there was no clear example demonstrating how to handle timeout errors using async/await syntax. This caused confusion for developers using modern JavaScript patterns.

This change adds a concise example that shows:
- How to configure a request timeout
- How to handle timeout errors using `try/catch`
- How to detect timeout failures via `error.code === 'ECONNABORTED'`

### Scope

- Documentation-only change
- Updates `README.md` only
- No changes to source code, tests, or configuration

### Related Issue

Fixes #7225
