### PR TITLE
chore: fix issues with yml

### DIFF
--- a/.github/workflows/update-sponsor-block.yml
+++ b/.github/workflows/update-sponsor-block.yml
@@ -33,7 +33,7 @@ jobs:
         run: npm ci
       - name: Check if sponsors require updates
         id: sponsors-requires-update
-        run: node ../../bin/update-sponsors.js
+        run: node ./bin/update-sponsors.js
       - name: Read sponsors.md file content
         run: |
           echo 'CONTENT<<EOF' >> $GITHUB_ENV

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "preversion": "gulp version",
     "version": "npm run build && git add package.json",
     "prepublishOnly": "npm run test:build:version",
-    "postpublish": "git push && git push --tags",
     "build": "gulp clear && cross-env NODE_ENV=production rollup -c -m",
     "examples": "node ./examples/server.js",
     "coveralls": "cat coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",


### PR DESCRIPTION
## Description

Removed the postpublish npm script that auto-pushed commits and tags after publishing to prevent unintended pushes and fix YML workflow issues. Publishing now no longer triggers any git pushes.

