### PR TITLE
fix: status is missing in AxiosError on and after v1.13.3

### DIFF
--- a/lib/adapters/fetch.js
+++ b/lib/adapters/fetch.js
@@ -247,14 +247,14 @@ const factory = (env) => {
 
       if (err && err.name === 'TypeError' && /Load failed|fetch/i.test(err.message)) {
         throw Object.assign(
-          new AxiosError('Network Error', AxiosError.ERR_NETWORK, config, request),
+          new AxiosError('Network Error', AxiosError.ERR_NETWORK, config, err && err.request, err && err.response),
           {
             cause: err.cause || err
           }
         )
       }
 
-      throw AxiosError.from(err, err && err.code, config, request);
+      throw AxiosError.from(err, err && err.code, config, err && err.request, err && err.response);
     }
   }
 }

--- a/lib/adapters/fetch.js
+++ b/lib/adapters/fetch.js
@@ -247,14 +247,14 @@ const factory = (env) => {
 
       if (err && err.name === 'TypeError' && /Load failed|fetch/i.test(err.message)) {
         throw Object.assign(
-          new AxiosError('Network Error', AxiosError.ERR_NETWORK, config, err && err.request, err && err.response),
+          new AxiosError('Network Error', AxiosError.ERR_NETWORK, config, request, err && err.response),
           {
             cause: err.cause || err
           }
         )
       }
 
-      throw AxiosError.from(err, err && err.code, config, (err && err.request) || request, err && err.response);
+      throw AxiosError.from(err, err && err.code, config, request, err && err.response);
     }
   }
 }

--- a/lib/adapters/fetch.js
+++ b/lib/adapters/fetch.js
@@ -254,7 +254,7 @@ const factory = (env) => {
         )
       }
 
-      throw AxiosError.from(err, err && err.code, config, err && err.request, err && err.response);
+      throw AxiosError.from(err, err && err.code, config, (err && err.request) || request, err && err.response);
     }
   }
 }

--- a/test/unit/regression/bugs.js
+++ b/test/unit/regression/bugs.js
@@ -43,6 +43,11 @@ describe('issues', function () {
 
   describe('7364', function () {
     it('fetch: should have status code in axios error', async function () {
+      const isFetchSupported = typeof fetch === 'function';
+      if (!isFetchSupported) {
+        this.skip();
+      }
+
       const server = http.createServer((req, res) => {
         res.statusCode = 400;
         res.end();

--- a/test/unit/regression/bugs.js
+++ b/test/unit/regression/bugs.js
@@ -40,4 +40,51 @@ describe('issues', function () {
       }
     });
   });
+
+  describe('7364', function () {
+    it('fetch: should have status code in axios error', async function () {
+      const server = http.createServer((req, res) => {
+        res.statusCode = 400;
+        res.end();
+      }).listen(0);
+
+      const instance = axios.create({
+        baseURL: `http://localhost:${server.address().port}`,
+        adapter: "fetch",
+      });
+
+      try {
+        await instance.get("/status/400");
+      } catch (error) {
+        assert.equal(error.name, "AxiosError");
+        assert.equal(error.isAxiosError, true);
+        assert.equal(error.status, 400);
+      } finally {
+        server.close();
+      }
+    });
+
+    it('http: should have status code in axios error', async function () {
+      const server = http.createServer((req, res) => {
+        res.statusCode = 400;
+        res.end();
+      }).listen(0);
+
+      const instance = axios.create({
+        baseURL: `http://localhost:${server.address().port}`,
+        adapter: "http",
+      });
+
+      try {
+        await instance.get("/status/400");
+      } catch (error) {
+        assert.equal(error.name, "AxiosError");
+        assert.equal(error.isAxiosError, true);
+        assert.equal(error.status, 400);
+      } finally {
+        server.close();
+      }
+    });
+  });
+
 });


### PR DESCRIPTION
Fixes #7364 

Included request and response in AxiosError when using the fetch adapter.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing status in AxiosError when using the fetch adapter. Failed requests now include error.status.

- **Bug Fixes**
  - Pass request and response to AxiosError in the fetch adapter so status is populated.
  - Add tests for fetch and http adapters to verify error.status is present on 400 responses.

<sup>Written for commit be90c251c3141bec7ca1554dc6f9d23d71eeceaf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

