### PR TITLE
docs: fix deprecated Buffer constructor and formatting issues in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1068,7 +1068,7 @@ cancel();
 
 ### URLSearchParams
 
-By default, axios serializes JavaScript objects to `JSON`. To send data in the [`application/x-www-form-urlencoded` format](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/POST) instead, you can use the [`URLSearchParams`](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) API, which is [supported](http://www.caniuse.com/#feat=urlsearchparams) in the vast majority of browsers,and [ Node](https://nodejs.org/api/url.html#url_class_urlsearchparams) starting with v10 (released in 2018).
+By default, axios serializes JavaScript objects to `JSON`. To send data in the [`application/x-www-form-urlencoded`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/POST) format instead, you can use the [`URLSearchParams`](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) API, which is [supported](http://www.caniuse.com/#feat=urlsearchparams) in the vast majority of browsers, and [Node](https://nodejs.org/api/url.html#url_class_urlsearchparams) starting with v10 (released in 2018).
 
 ```js
 const params = new URLSearchParams({ foo: "bar" });
@@ -1187,7 +1187,7 @@ const FormData = require("form-data");
 
 const form = new FormData();
 form.append("my_field", "my value");
-form.append("my_buffer", new Buffer(10));
+form.append("my_buffer", Buffer.alloc(10));
 form.append("my_file", fs.createReadStream("/foo/bar.jpg"));
 
 axios.post("https://example.com", form);
@@ -1228,7 +1228,7 @@ var FormData = require("form-data");
 axios
   .post(
     "https://httpbin.org/post",
-    { x: 1, buf: new Buffer(10) },
+    { x: 1, buf: Buffer.alloc(10) },
     {
       headers: {
         "Content-Type": "multipart/form-data",


### PR DESCRIPTION
This pull request makes minor improvements to the `README.md` documentation. The changes update examples to use modern Node.js APIs and correct a small formatting issue.

* **Node.js API modernization:**
  * Replaced usage of `new Buffer()` with `Buffer.alloc()` in code examples to follow current Node.js best practices and avoid deprecated APIs. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1190-R1190) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1231-R1231)

* **Documentation formatting:**
  * Fixed a typo by adding a missing space after a comma in the URLSearchParams section for improved readability.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Modernize README examples by replacing deprecated new Buffer() with Buffer.alloc() and fix a small URLSearchParams formatting issue. This improves clarity and aligns docs with current Node.js practices.

**Description**
- Changes: replace new Buffer() with Buffer.alloc() in two examples; fix spacing/link formatting in the URLSearchParams paragraph.
- Reason: avoid deprecated APIs and improve readability.
- Context: docs-only; no runtime or API changes.

**Testing**
- No tests added or modified; not needed for a docs-only update.
- Example snippets remain valid in supported Node versions.

<sup>Written for commit 7bf9887421a88b5d4cb8161b098d1573dfc3f6a4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

