### PR TITLE
ci: update ymls

### DIFF
--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -7,11 +7,10 @@ on:
         type: choice
         description: Choose release type
         options:
-          - auto
           - patch
           - minor
           - major
-        default: auto
+        default: patch
       beta:
         type: boolean
         description: Prerelease

--- a/.github/workflows/run-ci.yml
+++ b/.github/workflows/run-ci.yml
@@ -3,9 +3,7 @@ name: Continuous integration
 on:
   pull_request:
     branches:
-      - "*"
-      - "*/*"
-      - "**"
+      - "!sponsors"
 
 permissions:
   contents: read

--- a/.github/workflows/run-ci.yml
+++ b/.github/workflows/run-ci.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
       - "!sponsors"
+  push:
+    branches:
+      - "!sponsors"
 
 permissions:
   contents: read

--- a/.github/workflows/run-ci.yml
+++ b/.github/workflows/run-ci.yml
@@ -6,7 +6,6 @@ on:
       - "*"
       - "*/*"
       - "**"
-      - "!sponsors"
 
 permissions:
   contents: read

--- a/.github/workflows/update-sponsor-block.yml
+++ b/.github/workflows/update-sponsor-block.yml
@@ -51,7 +51,7 @@ jobs:
           branch: sponsors
           delete-branch: true
           commit-message: "chore(sponsor): update sponsor block"
-          title: "[Chore] Update sponsor block"
+          title: "chore(docs): update sponsor block"
           body: |
             **New sponsor block update:**
             ${{ env.CONTENT }}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Cleaned up CI workflows: simplified branch filters, added push runs, set release default to patch, and standardized the sponsor block PR title.

- **Description**
  - Simplified run-ci triggers: run on push and pull_request; exclude "sponsors".
  - Updated release-branch to remove "auto" and default to "patch".
  - Standardized sponsor block PR title to "chore(docs): update sponsor block".
  - Only GitHub workflow YAML files changed.

- **Testing**
  - No tests changed; none needed.
  - Validate by pushing and opening PRs (ensuring "sponsors" is excluded), confirming the release workflow defaults to patch, and checking the generated sponsor block PR title.

<sup>Written for commit c51f0a8c76e39068ed339616251c0eedd853ee93. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

