### PR TITLE
ci: fix run condition

### DIFF
--- a/.github/workflows/run-ci.yml
+++ b/.github/workflows/run-ci.yml
@@ -2,9 +2,7 @@ name: Continuous integration
 
 on:
   pull_request:
-    branches:
-      - "**"
-      - "!sponsors"
+    types: [opened, synchronize, reopened]
 
 permissions:
   contents: read

--- a/.github/workflows/run-ci.yml
+++ b/.github/workflows/run-ci.yml
@@ -5,10 +5,6 @@ on:
     branches:
       - "**"
       - "!sponsors"
-  push:
-    branches:
-      - "**"
-      - "!sponsors"
 
 permissions:
   contents: read

--- a/.github/workflows/run-ci.yml
+++ b/.github/workflows/run-ci.yml
@@ -2,8 +2,7 @@ name: Continuous integration
 
 on:
   pull_request:
-    branches:
-      - "!sponsors"
+    types: [opened, synchronize, reopened]
   push:
     branches:
       - "!sponsors"

--- a/.github/workflows/run-ci.yml
+++ b/.github/workflows/run-ci.yml
@@ -2,9 +2,12 @@ name: Continuous integration
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    branches:
+      - "**"
+      - "!sponsors"
   push:
     branches:
+      - "**"
       - "!sponsors"
 
 permissions:


### PR DESCRIPTION
<!-- Instructions

If you would like to add a PR description you may do so or let our AI agent create one, after the creation
you may then edit the file if the AI agent got it wrong.

Please read and follow the instructions before creating and submitting a pull request:

- Create an issue explaining the feature. It could save you some effort in case we don't consider it should be included in axios.
- If you're fixing a bug, try to commit the failing test/s and the code fixing it in different commits.
- Ensure you're following our [contributing guide](https://github.com/axios/axios/blob/main/CONTRIBUTING.md).

**⚠️👆 Delete the instructions before submitting the pull request 👆⚠️**

Describe your pull request here. -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run CI only on pull_request events when a PR is opened, synchronized, or reopened, so PR updates always build. Removed the push trigger and branch filters (no sponsors exclusion).

- **Description**
  - Trigger on pull_request types: opened, synchronize, reopened.
  - Removed push event trigger.
  - Removed branch filters, including "!sponsors".
  - Context: .github/workflows/run-ci.yml only.

- **Testing**
  - No tests added or modified.
  - Validate by opening or updating a PR; CI should run on open, synchronize, or reopen. Direct pushes without a PR will not run.

<sup>Written for commit 04205d45e3aceaf81c5e42060942d6be687d79f6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

