### PR TITLE
fix: fix export for React Native and Browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,11 +149,13 @@
     "typescript": "^4.9.5"
   },
   "browser": {
+    "./dist/node/axios.cjs": "./dist/browser/axios.cjs",
     "./lib/adapters/http.js": "./lib/helpers/null.js",
     "./lib/platform/node/index.js": "./lib/platform/browser/index.js",
     "./lib/platform/node/classes/FormData.js": "./lib/helpers/null.js"
   },
   "react-native": {
+    "./dist/node/axios.cjs": "./dist/browser/axios.cjs",
     "./lib/adapters/http.js": "./lib/helpers/null.js",
     "./lib/platform/node/index.js": "./lib/platform/browser/index.js",
     "./lib/platform/node/classes/FormData.js": "./lib/helpers/null.js"


### PR DESCRIPTION
Browserify and React Native projects (that aren't using `unstable_enablePackageExports`) use the `main` field as the package

entrypoint. A recent PR (#5756) updated `main` to use a CommonJS bundle for Node.js, which caused Browserify and React Native projects to use the Node.js bundle. This led to many reports of broken React Native builds.

This has been fixed by adding an entry to `browser` and `react-native` to re-map the Node.js CommonJS bundle to the browser CommonJS bundle.

Fixes #7357

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remaps the Node.js CJS entry to the browser CJS bundle for Browserify and React Native so they don’t import the Node build. Fixes #7357 and resolves RN build breakage introduced by the updated main field.

**Description**
- Added package.json mappings:
  - browser["./dist/node/axios.cjs"] -> "./dist/browser/axios.cjs"
  - react-native["./dist/node/axios.cjs"] -> "./dist/browser/axios.cjs"
- Keeps existing remaps for http adapter, platform, and FormData.
- Ensures Browserify and RN (without unstable_enablePackageExports) use the browser bundle.

**Testing**
- No tests changed; export maps only.
- Manual checks:
  - Bundle with Browserify and confirm browser CJS is used.
  - Build a React Native app and verify no Node modules are pulled.

<sup>Written for commit c188c0af08f9534775680ba453cc2cd4bb83a157. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

