### PR TITLE
fix: backport DOS via `__proto__` key in merge config fix to v0.x

### DIFF
--- a/lib/core/mergeConfig.js
+++ b/lib/core/mergeConfig.js
@@ -94,7 +94,10 @@ module.exports = function mergeConfig(config1, config2) {
   };
 
   utils.forEach(Object.keys(config1).concat(Object.keys(config2)), function computeConfigValue(prop) {
-    var merge = mergeMap[prop] || mergeDeepProperties;
+    if (prop === '__proto__' || prop === 'constructor' || prop === 'prototype') {
+      return;
+    }
+    var merge = utils.hasOwnProperty(mergeMap, prop) ? mergeMap[prop] : mergeDeepProperties;
     var configValue = merge(prop);
     (utils.isUndefined(configValue) && merge !== mergeDirectKeys) || (config[prop] = configValue);
   });

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -310,6 +310,10 @@ function forEach(obj, fn) {
 function merge(/* obj1, obj2, obj3, ... */) {
   var result = {};
   function assignValue(val, key) {
+    if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+      return;
+    }
+
     if (isPlainObject(result[key]) && isPlainObject(val)) {
       result[key] = merge(result[key], val);
     } else if (isPlainObject(val)) {

--- a/test/unit/core/prototypePollution.js
+++ b/test/unit/core/prototypePollution.js
@@ -1,0 +1,226 @@
+"use strict";
+
+import assert from "assert";
+import utils from "../../../lib/utils.js";
+import mergeConfig from "../../../lib/core/mergeConfig.js";
+
+describe("Prototype Pollution Protection", function () {
+  afterEach(function () {
+    // Clean up any pollution that might have occurred
+    delete Object.prototype.polluted;
+  });
+
+  describe("utils.merge", function () {
+    it("should filter __proto__ key at top level", function () {
+      const result = utils.merge(
+        {},
+        { __proto__: { polluted: "yes" }, safe: "value" },
+      );
+
+      assert.strictEqual(Object.prototype.polluted, undefined);
+      assert.strictEqual(result.safe, "value");
+      assert.strictEqual(result.hasOwnProperty("__proto__"), false);
+    });
+
+    it("should filter constructor key at top level", function () {
+      const result = utils.merge(
+        {},
+        { constructor: { polluted: "yes" }, safe: "value" },
+      );
+
+      assert.strictEqual(result.safe, "value");
+      assert.strictEqual(result.hasOwnProperty("constructor"), false);
+    });
+
+    it("should filter prototype key at top level", function () {
+      const result = utils.merge(
+        {},
+        { prototype: { polluted: "yes" }, safe: "value" },
+      );
+
+      assert.strictEqual(result.safe, "value");
+      assert.strictEqual(result.hasOwnProperty("prototype"), false);
+    });
+
+    it("should filter __proto__ key in nested objects", function () {
+      const result = utils.merge(
+        {},
+        {
+          headers: {
+            __proto__: { polluted: "nested" },
+            "Content-Type": "application/json",
+          },
+        },
+      );
+
+      assert.strictEqual(Object.prototype.polluted, undefined);
+      assert.strictEqual(result.headers["Content-Type"], "application/json");
+      assert.strictEqual(result.headers.hasOwnProperty("__proto__"), false);
+    });
+
+    it("should filter constructor key in nested objects", function () {
+      const result = utils.merge(
+        {},
+        {
+          headers: {
+            constructor: { prototype: { polluted: "nested" } },
+            "Content-Type": "application/json",
+          },
+        },
+      );
+
+      assert.strictEqual(Object.prototype.polluted, undefined);
+      assert.strictEqual(result.headers["Content-Type"], "application/json");
+      assert.strictEqual(result.headers.hasOwnProperty("constructor"), false);
+    });
+
+    it("should filter prototype key in nested objects", function () {
+      const result = utils.merge(
+        {},
+        {
+          headers: {
+            prototype: { polluted: "nested" },
+            "Content-Type": "application/json",
+          },
+        },
+      );
+
+      assert.strictEqual(result.headers["Content-Type"], "application/json");
+      assert.strictEqual(result.headers.hasOwnProperty("prototype"), false);
+    });
+
+    it("should filter dangerous keys in deeply nested objects", function () {
+      const result = utils.merge(
+        {},
+        {
+          level1: {
+            level2: {
+              __proto__: { polluted: "deep" },
+              prototype: { polluted: "deep" },
+              safe: "value",
+            },
+          },
+        },
+      );
+
+      assert.strictEqual(Object.prototype.polluted, undefined);
+      assert.strictEqual(result.level1.level2.safe, "value");
+      assert.strictEqual(
+        result.level1.level2.hasOwnProperty("__proto__"),
+        false,
+      );
+    });
+
+    it("should still merge regular properties correctly", function () {
+      const result = utils.merge({ a: 1, b: { c: 2 } }, { b: { d: 3 }, e: 4 });
+
+      assert.strictEqual(result.a, 1);
+      assert.strictEqual(result.b.c, 2);
+      assert.strictEqual(result.b.d, 3);
+      assert.strictEqual(result.e, 4);
+    });
+
+    it("should handle JSON.parse payloads safely", function () {
+      const malicious = JSON.parse('{"__proto__": {"polluted": "yes"}}');
+      const result = utils.merge({}, malicious);
+
+      assert.strictEqual(Object.prototype.polluted, undefined);
+      assert.strictEqual(result.hasOwnProperty("__proto__"), false);
+    });
+
+    it("should handle nested JSON.parse payloads safely", function () {
+      const malicious = JSON.parse(
+        '{"headers": {"constructor": {"prototype": {"polluted": "yes"}}}}',
+      );
+      const result = utils.merge({}, malicious);
+
+      assert.strictEqual(Object.prototype.polluted, undefined);
+      assert.strictEqual(result.headers.hasOwnProperty("constructor"), false);
+    });
+  });
+
+  describe("mergeConfig", function () {
+    it("should filter dangerous keys at top level", function () {
+      const result = mergeConfig(
+        {},
+        {
+          __proto__: { polluted: "yes" },
+          constructor: { polluted: "yes" },
+          prototype: { polluted: "yes" },
+          url: "/api/test",
+        },
+      );
+
+      assert.strictEqual(Object.prototype.polluted, undefined);
+      assert.strictEqual(result.url, "/api/test");
+      assert.strictEqual(result.hasOwnProperty("__proto__"), false);
+      assert.strictEqual(result.hasOwnProperty("constructor"), false);
+      assert.strictEqual(result.hasOwnProperty("prototype"), false);
+    });
+
+    it("should filter dangerous keys in headers", function () {
+      const result = mergeConfig(
+        {},
+        {
+          headers: {
+            __proto__: { polluted: "yes" },
+            "Content-Type": "application/json",
+          },
+        },
+      );
+
+      assert.strictEqual(Object.prototype.polluted, undefined);
+      assert.strictEqual(result.headers["Content-Type"], "application/json");
+      assert.strictEqual(result.headers.hasOwnProperty("__proto__"), false);
+    });
+
+    it("should filter dangerous keys in custom config properties", function () {
+      const result = mergeConfig(
+        {},
+        {
+          customProp: {
+            __proto__: { polluted: "yes" },
+            safe: "value",
+          },
+        },
+      );
+
+      assert.strictEqual(Object.prototype.polluted, undefined);
+      assert.strictEqual(result.customProp.safe, "value");
+      assert.strictEqual(result.customProp.hasOwnProperty("__proto__"), false);
+    });
+
+    it("should still merge configs correctly", function () {
+      const config1 = {
+        baseURL: "https://api.example.com",
+        timeout: 1000,
+        headers: {
+          common: {
+            Accept: "application/json",
+          },
+        },
+      };
+
+      const config2 = {
+        url: "/users",
+        timeout: 5000,
+        headers: {
+          common: {
+            "Content-Type": "application/json",
+          },
+        },
+      };
+
+      const result = mergeConfig(config1, config2);
+
+      assert.strictEqual(result.baseURL, "https://api.example.com");
+      assert.strictEqual(result.url, "/users");
+      assert.strictEqual(result.timeout, 5000);
+      assert.strictEqual(result.headers.common.Accept, "application/json");
+      assert.strictEqual(
+        result.headers.common["Content-Type"],
+        "application/json",
+      );
+    });
+  });
+});

--- a/test/unit/core/prototypePollution.js
+++ b/test/unit/core/prototypePollution.js
@@ -1,8 +1,8 @@
 "use strict";
 
-import assert from "assert";
-import utils from "../../../lib/utils.js";
-import mergeConfig from "../../../lib/core/mergeConfig.js";
+var assert = require('assert');
+var utils = require('../../../lib/utils');
+var mergeConfig = require('../../../lib/core/mergeConfig');
 
 describe("Prototype Pollution Protection", function () {
   afterEach(function () {


### PR DESCRIPTION
Backports fix for https://github.com/advisories/GHSA-43fc-jf86-j433 on v1.x (https://github.com/axios/axios/pull/7369) to v0.x.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Backports the GHSA-43fc-jf86-j433 prototype pollution fix to v0.x by filtering dangerous keys during config merging. Prevents DoS via __proto__/constructor/prototype and aligns v0.x with the v1.x behavior.

**Description**
- Filter "__proto__", "constructor", and "prototype" in utils.merge and core/mergeConfig.
- In mergeConfig, use utils.hasOwnProperty(mergeMap, prop) when choosing the merge strategy to avoid prototype-chain lookups.
- No breaking changes for valid configs.

**Testing**
- Added test/unit/core/prototypePollution.js covering top-level and nested dangerous keys, deeply nested objects, JSON.parse payloads, headers, custom props, and normal merge behavior.
- Tests use require() (CommonJS) to match v0.x.
- No changes to existing tests.

<sup>Written for commit a615fe52b61e538517939e7c63a2125cb8ad1644. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

