### PR TITLE
fix: make content-type value comparison case-insensitive in transform…

### DIFF
--- a/lib/defaults/index.js
+++ b/lib/defaults/index.js
@@ -40,7 +40,7 @@ const defaults = {
 
   transformRequest: [
     function transformRequest(data, headers) {
-      const contentType = headers.getContentType() || '';
+      const contentType = (headers.getContentType() || '').toLowerCase();
       const hasJSONContentType = contentType.indexOf('application/json') > -1;
       const isObjectPayload = utils.isObject(data);
 

--- a/test/specs/transform.spec.js
+++ b/test/specs/transform.spec.js
@@ -185,6 +185,21 @@ describe('transform', function () {
     });
   });
 
+  it('should auto-serialize to url-encoded form with Pascal-case Content-Type header', function (done) {
+    const data = {
+      foo: 'bar',
+    };
+
+    axios.post('/foo', data, {
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    });
+
+    getAjaxRequest().then(function (request) {
+      expect(request.params).toEqual('foo=bar');
+      done();
+    });
+  });
+
   it("should normalize 'content-type' header when using a custom transformRequest", function (done) {
     const data = {
       foo: 'bar',

--- a/test/unit/adapters/http.js
+++ b/test/unit/adapters/http.js
@@ -2115,6 +2115,40 @@ describe('supports http with nodejs', function () {
           .catch(done);
       });
     });
+
+    it('should post object data as url-encoded form with Pascal-case Content-Type header', function (done) {
+      var app = express();
+
+      var obj = {
+        arr1: ['1', '2', '3'],
+        arr2: ['1', ['2'], '3'],
+        obj: { x: '1', y: { z: '1' } },
+        users: [
+          { name: 'Peter', surname: 'griffin' },
+          { name: 'Thomas', surname: 'Anderson' },
+        ],
+      };
+
+      app.use(bodyParser.urlencoded({ extended: true }));
+
+      app.post('/', function (req, res, next) {
+        res.send(JSON.stringify(req.body));
+      });
+
+      server = app.listen(3001, function () {
+        return axios
+          .post('http://localhost:3001/', obj, {
+            headers: {
+              'Content-Type': 'application/x-www-form-urlencoded',
+            },
+          })
+          .then(function (res) {
+            assert.deepStrictEqual(res.data, obj);
+            done();
+          })
+          .catch(done);
+      });
+    });
   });
 
   it('should respect formSerializer config', function (done) {


### PR DESCRIPTION
## Summary                                                                                                                                                           
                                                                                                                                                                       
  Fixes #7393                                                                                                                                                          
                                                                                                                                                                       
  When users specify `'Content-Type': 'application/x-www-form-urlencoded'` (Pascal-case header name), the automatic URL-encoded serialization can fail on certain
  environments (e.g. Node 24). This is because the content-type **value** returned by `getContentType()` was compared case-sensitively using `indexOf`, which violates
  RFC 2045 (MIME types are case-insensitive).

  ### Changes

  - **`lib/defaults/index.js`**: Normalize the content-type value to lowercase before comparing against MIME type literals in `transformRequest`
  - **`test/unit/adapters/http.js`**: Added Node.js test for Pascal-case `Content-Type` with URL-encoded serialization
  - **`test/specs/transform.spec.js`**: Added browser test for Pascal-case `Content-Type` with URL-encoded serialization

  ### Test plan

  - [x] Existing tests pass (`npm test`)
  - [x] New test: `{ 'Content-Type': 'application/x-www-form-urlencoded' }` triggers URL-encoded serialization
  - [x] Regression: `{ 'content-type': 'application/x-www-form-urlencoded' }` still works

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Content-Type value checks case-insensitive in transformRequest so application/x-www-form-urlencoded auto-serialization works regardless of header casing. Fixes #7393 and aligns with RFC 2045 across Node 24 and browsers.

**Bug Fixes**
- Normalize headers.getContentType() to lowercase before comparing against MIME literals in lib/defaults/index.js.

**Testing**
- Added Node and browser tests to verify URL-encoded auto-serialization with Pascal-case "Content-Type"; all existing tests still pass.

<sup>Written for commit 76bb4a0c995c79782eaca8d28c9070f8a36c73e6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

