### PR TITLE
fix: use optional chaining for interceptor options

### DIFF
--- a/lib/core/InterceptorManager.js
+++ b/lib/core/InterceptorManager.js
@@ -20,8 +20,8 @@ class InterceptorManager {
     this.handlers.push({
       fulfilled,
       rejected,
-      synchronous: options ? options.synchronous : false,
-      runWhen: options ? options.runWhen : null,
+      synchronous: options?.synchronous ?? false,
+      runWhen: options?.runWhen ?? null,
     });
     return this.handlers.length - 1;
   }

--- a/lib/core/InterceptorManager.js
+++ b/lib/core/InterceptorManager.js
@@ -17,11 +17,13 @@ class InterceptorManager {
    * @return {Number} An ID used to remove interceptor later
    */
   use(fulfilled, rejected, options) {
+    const interceptorOptions = options || {};
+
     this.handlers.push({
       fulfilled,
       rejected,
-      synchronous: options?.synchronous ?? false,
-      runWhen: options?.runWhen ?? null,
+      synchronous: typeof interceptorOptions.synchronous === 'undefined' ? false : interceptorOptions.synchronous,
+      runWhen: typeof interceptorOptions.runWhen === 'undefined' ? null : interceptorOptions.runWhen,
     });
     return this.handlers.length - 1;
   }

--- a/test/specs/interceptors.spec.js
+++ b/test/specs/interceptors.spec.js
@@ -26,6 +26,20 @@ describe('interceptors', function () {
     });
   });
 
+  it('should default interceptor options when omitted or null', function () {
+    const omittedId = axios.interceptors.request.use(function (config) {
+      return config;
+    });
+    const nullId = axios.interceptors.request.use(function (config) {
+      return config;
+    }, null, null);
+
+    expect(axios.interceptors.request.handlers[omittedId].synchronous).toBe(false);
+    expect(axios.interceptors.request.handlers[omittedId].runWhen).toBe(null);
+    expect(axios.interceptors.request.handlers[nullId].synchronous).toBe(false);
+    expect(axios.interceptors.request.handlers[nullId].runWhen).toBe(null);
+  });
+
   it('should add a request interceptor (explicitly flagged as asynchronous)', function (done) {
     let asyncFlag = false;
     axios.interceptors.request.use(


### PR DESCRIPTION
Noticed options.synchronous and options.runWhen were using ternary checks instead of optional chaining. If someone passes { synchronous: undefined } the old code would use undefined instead of falling back to false. This fixes that by using ?. and ?? which handle both missing and undefined cases.