### PR TITLE
fix(core): copy status from source error in AxiosError.from

### DIFF
--- a/lib/core/AxiosError.js
+++ b/lib/core/AxiosError.js
@@ -7,6 +7,12 @@ class AxiosError extends Error {
     const axiosError = new AxiosError(error.message, code || error.code, config, request, response);
     axiosError.cause = error;
     axiosError.name = error.name;
+
+    // Preserve status from the original error if not already set from response
+    if (error.status != null && axiosError.status == null) {
+      axiosError.status = error.status;
+    }
+
     customProps && Object.assign(axiosError, customProps);
     return axiosError;
   }

--- a/test/specs/core/AxiosError.spec.js
+++ b/test/specs/core/AxiosError.spec.js
@@ -49,6 +49,23 @@ describe('core::AxiosError', function () {
         AxiosError.from(error, 'ESOMETHING', { foo: 'bar' }) instanceof AxiosError
       ).toBeTruthy();
     });
+
+    it('should preserve status property from original error when response is not provided', function () {
+      const error = new Error('Network Error');
+      error.status = 404;
+
+      const axiosError = AxiosError.from(error, 'ERR_NETWORK', { foo: 'bar' });
+      expect(axiosError.status).toBe(404);
+    });
+
+    it('should use response.status over error.status when response is provided', function () {
+      const error = new Error('Error');
+      error.status = 500;
+      const response = { status: 404 };
+
+      const axiosError = AxiosError.from(error, 'ERR_BAD_REQUEST', {}, null, response);
+      expect(axiosError.status).toBe(404);
+    });
   });
 
   it('should be a native error as checked by the NodeJS `isNativeError` function', function () {


### PR DESCRIPTION
This pull request enhances the handling of the `status` property in `AxiosError` instances, ensuring that error status codes are preserved or correctly overridden depending on the context. Unit tests have been added to verify these behaviors.

Improvements to error handling:

* Updated `AxiosError.from` to preserve the `status` property from the original error if no response is provided, and to use `response.status` when a response is present. (`lib/core/AxiosError.js`)

Testing enhancements:

* Added unit tests to verify that `AxiosError` correctly preserves the original error's `status` when no response is provided, and prefers `response.status` when a response is present. (`test/specs/core/AxiosError.spec.js`)

#7364