### PR TITLE
fix(types): align runWhen types

### DIFF
--- a/index.d.cts
+++ b/index.d.cts
@@ -649,7 +649,7 @@ declare namespace axios {
     fulfilled: AxiosInterceptorFulfilled<T>;
     rejected?: AxiosInterceptorRejected;
     synchronous: boolean;
-    runWhen?: (config: AxiosRequestConfig) => boolean;
+    runWhen?: ((config: AxiosRequestConfig) => boolean) | null;
   }
 
   interface AxiosInterceptorManager<V> {

--- a/index.d.ts
+++ b/index.d.ts
@@ -659,7 +659,7 @@ interface AxiosInterceptorHandler<T> {
   fulfilled: AxiosInterceptorFulfilled<T>;
   rejected?: AxiosInterceptorRejected;
   synchronous: boolean;
-  runWhen: (config: AxiosRequestConfig) => boolean | null;
+  runWhen?: ((config: AxiosRequestConfig) => boolean) | null;
 }
 
 export interface AxiosInterceptorManager<V> {


### PR DESCRIPTION
fixing the issue described in issue [7404](https://github.com/axios/axios/issues/7404)

Fixes #7404 



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns runWhen types for Axios interceptors across index.d.ts and index.d.cts. Makes runWhen optional and allows null on the property while requiring the callback to return a boolean, matching runtime and preventing TS errors when runWhen is omitted or set to null.

## Description

- Summary of changes
  - index.d.ts (AxiosInterceptorHandler): runWhen?: ((config: AxiosRequestConfig) => boolean) | null
  - index.d.cts (AxiosInterceptorOptions): runWhen?: ((config: AxiosRequestConfig) => boolean) | null
- Reasoning
  - Runtime allows interceptors without runWhen.
  - The callback should return a boolean; null is expressed via the property value.
  - Resolves the mismatch reported in issue 7404.
- Additional context
  - Code returning null from runWhen will now error; return a boolean or set runWhen to null.

## Docs

- No docs changes needed.

## Testing

- No tests updated; types-only change.
- Suggested follow-up tsd/dtslint cases:
  - handler without runWhen
  - runWhen set to null
  - runWhen returning boolean (valid)
  - runWhen returning null (invalid)

<sup>Written for commit 084e5bcc624b44fdfb2fb40461e8d8913c111576. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





