### PR TITLE
fix: make runWhen optional in AxiosInterceptorHandler type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -659,7 +659,7 @@ interface AxiosInterceptorHandler<T> {
   fulfilled: AxiosInterceptorFulfilled<T>;
   rejected?: AxiosInterceptorRejected;
   synchronous: boolean;
-  runWhen: (config: AxiosRequestConfig) => boolean | null;
+  runWhen?: (config: AxiosRequestConfig) => boolean | null;
 }
 
 export interface AxiosInterceptorManager<V> {


### PR DESCRIPTION
## Problem

Fixes #7404

Type mismatch between `AxiosInterceptorOptions` and `AxiosInterceptorHandler` causes TypeScript compilation errors when upgrading from axios 1.13.2 to 1.13.5.

**Error reported:**
```
Type 'import("node_modules/axios/index").AxiosInterceptorHandler<...>[]' 
is not assignable to type 'AxiosInterceptorHandler<...>[]'.
Types of property 'runWhen' are incompatible.
Type '((config: AxiosRequestConfig) => boolean) | undefined' 
is not assignable to type '(config: AxiosRequestConfig) => boolean | null'.
Type 'undefined' is not assignable to type '(config: AxiosRequestConfig) => boolean | null'.
```

## Root Cause

There's a type inconsistency between the two interfaces:

**AxiosInterceptorOptions (line 641):**
```typescript
export interface AxiosInterceptorOptions {
  synchronous?: boolean;
  runWhen?: (config: InternalAxiosRequestConfig) => boolean;  // ✅ Optional
}
```

**AxiosInterceptorHandler (line 662):**
```typescript
interface AxiosInterceptorHandler<T> {
  fulfilled: AxiosInterceptorFulfilled<T>;
  rejected?: AxiosInterceptorRejected;
  synchronous: boolean;
  runWhen: (config: AxiosRequestConfig) => boolean | null;  // ❌ Required
}
```

When `interceptors.request.handlers` is typed as `AxiosInterceptorHandler[]`, TypeScript expects `runWhen` to always be present, but it's optional in `AxiosInterceptorOptions`. This creates a type incompatibility.

## Solution

Make `runWhen` optional in `AxiosInterceptorHandler` to match `AxiosInterceptorOptions`:

```diff
interface AxiosInterceptorHandler<T> {
  fulfilled: AxiosInterceptorFulfilled<T>;
  rejected?: AxiosInterceptorRejected;
  synchronous: boolean;
-  runWhen: (config: AxiosRequestConfig) => boolean | null;
+  runWhen?: (config: AxiosRequestConfig) => boolean | null;
}
```

This is a one-character fix (adding `?`) that aligns both type definitions.

## Testing

- ✅ Verified type compatibility between `AxiosInterceptorOptions` and `AxiosInterceptorHandler`
- ✅ Confirmed existing interceptor code continues to work with both optional and required `runWhen`
- ✅ No runtime behavior changes - purely a TypeScript type fix

## Impact

- Fixes TypeScript compilation errors for users upgrading to 1.13.5
- No breaking changes - makes the type more permissive (optional vs required)
- Aligns with the actual runtime behavior where `runWhen` is optional

---

Generated-by: Claude Sonnet 4.5

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make runWhen optional in AxiosInterceptorHandler to align with AxiosInterceptorOptions and fix TypeScript type errors seen in 1.13.5. No runtime changes; resolves compilation failures when runWhen isn’t provided.

## Description

- Summary of changes
  - index.d.ts: runWhen in AxiosInterceptorHandler is now optional.
- Reasoning
  - AxiosInterceptorOptions defines runWhen as optional, but AxiosInterceptorHandler required it, causing a mismatch and TS compile errors during upgrade from 1.13.2 to 1.13.5.
- Additional context
  - Purely a type fix; behavior unchanged.
  - Unblocks projects that don’t set runWhen on request interceptors.

## Docs

- No docs changes needed; types now match existing runtime behavior where runWhen is optional.

## Testing

- No new tests added. Change is type-only.
- Verified via local TypeScript compilation with and without runWhen on interceptors.
- Consider adding a lightweight type test to ensure handler and options remain compatible.

<sup>Written for commit 47b516b9e5dfb1d1c92d21e37ea51ef3a55fa23c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

