### PR TITLE
fix: prevent nested arrays when converting multiple select FormData to JSON

### DIFF
--- a/lib/helpers/formDataToJSON.js
+++ b/lib/helpers/formDataToJSON.js
@@ -58,7 +58,11 @@ function formDataToJSON(formData) {
 
     if (isLast) {
       if (utils.hasOwnProp(target, name)) {
-        target[name] = [target[name], value];
+        // If the key already exists, check if it's an array
+        // If so, append to it; otherwise create a new array
+        target[name] = utils.isArray(target[name]) 
+          ? target[name].concat(value)
+          : [target[name], value];
       } else {
         target[name] = value;
       }

--- a/test/specs/helpers/formDataToJSON.spec.js
+++ b/test/specs/helpers/formDataToJSON.spec.js
@@ -26,6 +26,18 @@ describe('formDataToJSON', function () {
     });
   });
 
+  it('should convert multiple (3+) repeatable values as a flat array without nesting', function () {
+    const formData = new FormData();
+
+    formData.append('select3', '301');
+    formData.append('select3', '302');
+    formData.append('select3', '303');
+
+    expect(formDataToJSON(formData)).toEqual({
+      select3: ['301', '302', '303'],
+    });
+  });
+
   it('should convert props with empty brackets to arrays', function () {
     const formData = new FormData();
 


### PR DESCRIPTION
## Problem

Fixes #7365

When submitting an HTML form with `Content-Type: application/json` containing a `<select multiple>` element with **3 or more** selected values, Axios creates nested arrays instead of a flat array.

**Example HTML:**
```html
<form method="POST" enctype="application/json">
  <select multiple name="select3">
    <option value="301" selected>Option 1</option>
    <option value="302" selected>Option 2</option>
    <option value="303" selected>Option 3</option>
  </select>
</form>
```

**Browser submits:** `select3=301&select3=302&select3=303`

**Expected:** `{select3: ['301', '302', '303']}` ✅  
**Actual:**    `{select3: [['301', '302'], '303']}` ❌

The bug creates a nested array on the 3rd value, making the data structure inconsistent and breaking downstream code expecting a flat array.

## Root Cause

In `lib/helpers/formDataToJSON.js` line 59, when processing duplicate keys:

```javascript
if (utils.hasOwnProp(target, name)) {
  target[name] = [target[name], value];  // ❌ Wraps on every call
}
```

**What happens:**
1. **1st value (301):** Stores as `'301'`
2. **2nd value (302):** Creates array `['301', '302']` ✅
3. **3rd value (303):** Wraps existing array → `[['301', '302'], '303']` ❌

The code doesn't check if `target[name]` is already an array before wrapping it.

## Solution

Check if `target[name]` is already an array and append instead of wrapping:

```javascript
if (utils.hasOwnProp(target, name)) {
  // If already an array, append; otherwise create new array
  target[name] = utils.isArray(target[name]) 
    ? target[name].concat(value)
    : [target[name], value];
}
```

**Now:**
1. **1st value:** Stores as `'301'`
2. **2nd value:** Creates array `['301', '302']` ✅
3. **3rd value:** Appends to array `['301', '302', '303']` ✅
4. **4th+ values:** Continue appending `['301', '302', '303', '304', ...]` ✅

## Testing

**Added regression test** in `test/specs/helpers/formDataToJSON.spec.js`:
```javascript
it('should convert multiple (3+) repeatable values as a flat array without nesting', function () {
  const formData = new FormData();

  formData.append('select3', '301');
  formData.append('select3', '302');
  formData.append('select3', '303');

  expect(formDataToJSON(formData)).toEqual({
    select3: ['301', '302', '303'],  // ✅ Flat array
  });
});
```

The existing test only covered 2 values, which is why this bug wasn't caught earlier.

## Impact

- ✅ Fixes HTML `<select multiple>` form submissions with 3+ values
- ✅ Fixes checkbox groups with 3+ checked items
- ✅ No breaking changes - existing 2-value case still works
- ✅ Backward compatible - only affects buggy behavior

## Files Changed

- `lib/helpers/formDataToJSON.js` - Fixed array nesting logic (+4, -1 lines)
- `test/specs/helpers/formDataToJSON.spec.js` - Added 3-value regression test (+12 lines)

---

Generated-by: Claude Sonnet 4.5

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes nested arrays when converting FormData with duplicate keys (e.g., <select multiple>) to JSON. Values now stay as a flat array for 3+ items. Fixes #7365.

- Bug Fixes
  - Root cause: duplicate keys were always wrapped, nesting arrays on the 3rd value.
  - Change: if the existing value is an array, append; otherwise create an array.
  - Impact: correct flat arrays for multi-selects and checkbox groups; no breaking changes.

- Testing
  - Added regression test for 3+ repeatable values to ensure flat arrays.
  - Existing tests (2-value case) still pass.

<sup>Written for commit ade8643b2bb178662671e82c2b94f7ec9929f9d4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

