### PR TITLE
fix(types): align AxiosInterceptorHandler.runWhen type with AxiosInte…

### DIFF
--- a/index.d.cts
+++ b/index.d.cts
@@ -649,7 +649,7 @@ declare namespace axios {
     fulfilled: AxiosInterceptorFulfilled<T>;
     rejected?: AxiosInterceptorRejected;
     synchronous: boolean;
-    runWhen?: (config: AxiosRequestConfig) => boolean;
+    runWhen?: ((config: InternalAxiosRequestConfig) => boolean) | null;
   }
 
   interface AxiosInterceptorManager<V> {

--- a/index.d.ts
+++ b/index.d.ts
@@ -659,7 +659,7 @@ interface AxiosInterceptorHandler<T> {
   fulfilled: AxiosInterceptorFulfilled<T>;
   rejected?: AxiosInterceptorRejected;
   synchronous: boolean;
-  runWhen: (config: AxiosRequestConfig) => boolean | null;
+  runWhen?: ((config: InternalAxiosRequestConfig) => boolean) | null;
 }
 
 export interface AxiosInterceptorManager<V> {


### PR DESCRIPTION
Fix: Align AxiosInterceptorHandler.runWhen type with AxiosInterceptorOptions

Problem

After upgrading from axios 1.13.2 to 1.13.5, TypeScript builds fail with TS2719 when assigning AxiosInstance to AxiosInstance due to incompatible runWhen types.

The input type (AxiosInterceptorOptions) defines:

`runWhen?: (config: InternalAxiosRequestConfig) => boolean;`

But the stored type (AxiosInterceptorHandler) defined:

`runWhen: (config: AxiosRequestConfig) => boolean | null;`

These are incompatible because:

1. runWhen was required in the handler but optional in the options
2. The config parameter type was AxiosRequestConfig instead of InternalAxiosRequestConfig
3. The return type was boolean or null — but it's the property itself that can be null, not the return value

Root Cause
In InterceptorManager.js, the handler stores runWhen as either the user-provided function or null:


`runWhen: options ? options.runWhen : null,`

The type definition did not reflect this runtime behavior.

Fix
Updated AxiosInterceptorHandler.runWhen in both index.d.ts and index.d.cts to:

`runWhen?: ((config: InternalAxiosRequestConfig) => boolean) | null;`

This correctly models the runtime behavior: the property is optional, can be null, and when present uses InternalAxiosRequestConfig consistent with AxiosInterceptorOptions.

Fixes #7404

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns AxiosInterceptorHandler.runWhen type with AxiosInterceptorOptions to fix TS2719 errors introduced in 1.13.5. Restores correct typings by making runWhen optional, accepting InternalAxiosRequestConfig, and allowing null.

**Bug Fixes**
- Updated runWhen to?: ((config: InternalAxiosRequestConfig) => boolean) | null in index.d.ts and index.d.cts.
- Matches runtime behavior (function or null) and prevents TS2719 assignability errors. Fixes #7404.

**Testing**
- Type-only change; no tests updated.
- Optional: add a type test to assert assignability between AxiosInterceptorOptions and AxiosInterceptorHandler.

<sup>Written for commit 88ad170bb901d44872da95f4b66c206a8c8cfd9d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

