### PR TITLE
fix(AxiosError): prevent circular reference crash in toJSON

### DIFF
--- a/lib/core/AxiosError.js
+++ b/lib/core/AxiosError.js
@@ -53,6 +53,18 @@ class AxiosError extends Error {
     }
 
   toJSON() {
+    
+    const config = this.config;
+    let cleanConfig = config;
+
+    // Check if config exists and has a cancelToken to avoid the circular loop
+    if (config && config.cancelToken) {
+      
+      // We create a copy of the config without the cancelToken property
+      const { cancelToken, ...rest } = config;
+      cleanConfig = rest;
+    }
+
     return {
       // Standard
       message: this.message,
@@ -65,8 +77,8 @@ class AxiosError extends Error {
       lineNumber: this.lineNumber,
       columnNumber: this.columnNumber,
       stack: this.stack,
-      // Axios
-      config: utils.toJSONObject(this.config),
+      // Axios - Now using the cleanConfig
+      config: utils.toJSONObject(cleanConfig),
       code: this.code,
       status: this.status,
     };


### PR DESCRIPTION
## Summary
This PR fixes a `RangeError: Maximum call stack size exceeded` that occurs when `JSON.stringify()` is called on an `AxiosError` (specifically a `CanceledError`).

## The Problem
When a `cancelToken` is added to the request config and refers back to the error (the "reason"), it creates a circular reference: 
`AxiosError $\rightarrow$ config $\rightarrow$ cancelToken $\rightarrow$ reason (AxiosError)`. 

Because the default `AxiosError.toJSON` attempts to serialize the entire `config` object using `utils.toJSONObject`, it triggers infinite recursion during the stringification process.

## The Fix
I have modified the `toJSON` method in `lib/core/AxiosError.js` to strip the `cancelToken` from the `config` object before serialization. This:
1. Breaks the circular reference chain.
2. Prevents the stack overflow crash.
3. Keeps the rest of the relevant `config` data (url, headers, etc.) available in the logs.

## Linked Issue
Fixes #6815

<!-- This is an auto-generated description by cubic. -->
---

## Description

Prevents a crash when JSON.stringify is called on AxiosError by removing cancelToken from config in toJSON. Breaks the circular reference and preserves other config fields. Fixes #6815.

- **The Issue:** `cancelToken` can hold a reference back to the error itself (the `reason`), creating a circular dependency. When serialized, this triggers a `RangeError: Maximum call stack size exceeded`.
- **The Fix:** Updated `toJSON` to serialize a shallow copy of the `config` object with the `cancelToken` property explicitly removed.
- **The Impact:** `CanceledError` can now be safely logged or sent to error-tracking services (like Sentry) without crashing the process.

## Testing & Verification
- [x] Verified manually with a reproduction script.
- [x] Confirmed `JSON.stringify(error)` no longer throws a RangeError.
- [x] Validated that other config fields (`url`, `method`, `headers`) remain present in the output.

### Scenario 1: Before Fix (Crash)
When calling `JSON.stringify(error)`, the circular reference in the `cancelToken` caused the following stack overflow:

```RangeError: Maximum call stack size exceeded```

### Scenario 2: After Fix (Success)
After stripping the cancelToken, the AxiosError serializes successfully into a valid JSON object:

<details>
<summary><b>🔍 Click to view successful JSON output</b></summary>
<br>

```json
{
   "message":"Request timed out",
   "name":"CanceledError",
   "stack":"CanceledError: Request timed out\n    at cancel (file:///C:/Users/HP/Documents/Projects/OS_Projects/axios/lib/cancel/CancelToken.js:60:22)\n    at Timeout._onTimeout (file:///C:/Users/HP/Documents/Projects/OS_Projects/axios/debug.js:7:24)\n    at listOnTimeout (node:internal/timers:581:17)\n    at process.processTimers (node:internal/timers:519:7)\n    at Axios.request (file:///C:/Users/HP/Documents/Projects/OS_Projects/axios/lib/core/Axios.js:46:41)\n    at runNextTicks (node:internal/process/task_queues:60:5)\n    at listOnTimeout (node:internal/timers:545:9)\n    at process.processTimers (node:internal/timers:519:7)",
   "config":{
      "transitional":{
         "silentJSONParsing":true,
         "forcedJSONParsing":true,
         "clarifyTimeoutError":false,
         "legacyInterceptorReqResOrdering":true
      },
      "adapter":[
         "xhr",
         "http",
         "fetch"
      ],
      "transformRequest":[
         null
      ],
      "transformResponse":[
         null
      ],
      "timeout":1,
      "xsrfCookieName":"XSRF-TOKEN",
      "xsrfHeaderName":"X-XSRF-TOKEN",
      "maxContentLength":-1,
      "maxBodyLength":-1,
      "env":{
         
      },
      "headers":{
         "Accept":"application/json, text/plain, */*",
         "User-Agent":"axios/1.13.5",
         "Accept-Encoding":"gzip, compress, deflate, br"
      },
      "method":"get",
      "url":"http://10.255.255.1",
      "allowAbsoluteUrls":true
   },
   "code":"ERR_CANCELED"
}
```
</details>

<sup>Written for commit 1c197de05d78c02f5e1bc10531965df6fb3dec45. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

