### PR TITLE
fix(AxiosError): prevent circular reference crash in toJSON

### DIFF
--- a/lib/core/AxiosError.js
+++ b/lib/core/AxiosError.js
@@ -53,6 +53,18 @@ class AxiosError extends Error {
     }
 
   toJSON() {
+    
+    const config = this.config;
+    let cleanConfig = config;
+
+    // Check if config exists and has a cancelToken to avoid the circular loop
+    if (config && config.cancelToken) {
+      
+      // We create a copy of the config without the cancelToken property
+      const { cancelToken, ...rest } = config;
+      cleanConfig = rest;
+    }
+
     return {
       // Standard
       message: this.message,
@@ -65,8 +77,8 @@ class AxiosError extends Error {
       lineNumber: this.lineNumber,
       columnNumber: this.columnNumber,
       stack: this.stack,
-      // Axios
-      config: utils.toJSONObject(this.config),
+      // Axios - Now using the cleanConfig
+      config: utils.toJSONObject(cleanConfig),
       code: this.code,
       status: this.status,
     };


### PR DESCRIPTION
## Summary
This PR fixes a `RangeError: Maximum call stack size exceeded` that occurs when `JSON.stringify()` is called on an `AxiosError` (specifically a `CanceledError`).

## The Problem
When a `cancelToken` is added to the request config and refers back to the error (the "reason"), it creates a circular reference: 
`AxiosError $\rightarrow$ config $\rightarrow$ cancelToken $\rightarrow$ reason (AxiosError)`. 

Because the default `AxiosError.toJSON` attempts to serialize the entire `config` object using `utils.toJSONObject`, it triggers infinite recursion during the stringification process.

## The Fix
I have modified the `toJSON` method in `lib/core/AxiosError.js` to strip the `cancelToken` from the `config` object before serialization. This:
1. Breaks the circular reference chain.
2. Prevents the stack overflow crash.
3. Keeps the rest of the relevant `config` data (url, headers, etc.) available in the logs.

## Linked Issue
Fixes #6815


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash when JSON.stringify is called on AxiosError by omitting config.cancelToken in toJSON to break the circular reference. Synced with v1.x; behavior remains the same. Fixes #6815.

## Description

- Summary of changes
  - Updated AxiosError.toJSON to serialize a shallow copy of config without cancelToken.
  - Still uses utils.toJSONObject, preserving other config fields (url, method, headers).
- Reasoning
  - cancelToken can reference the error (reason), creating a circular loop that triggers a RangeError.
- Additional context
  - Merged latest v1.x into this branch; no API changes.

## Testing

- Verified manually: JSON.stringify(AxiosError) no longer throws; output includes expected config fields.
- No unit tests added. A regression test is recommended to assert serialization succeeds when cancelToken is present in config.

<sup>Written for commit c2aa0ef7b1bbfa5a016bd9dbf307e6d55a7667bd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



