### PR TITLE
fix: prevent nested arrays in formDataToJSON for duplicate keys

### DIFF
--- a/lib/helpers/formDataToJSON.js
+++ b/lib/helpers/formDataToJSON.js
@@ -58,7 +58,7 @@ function formDataToJSON(formData) {
 
     if (isLast) {
       if (utils.hasOwnProp(target, name)) {
-        target[name] = [target[name], value];
+        target[name] = utils.isArray(target[name]) ? target[name].concat(value) : [target[name], value];
       } else {
         target[name] = value;
       }

--- a/test/specs/helpers/formDataToJSON.spec.js
+++ b/test/specs/helpers/formDataToJSON.spec.js
@@ -26,6 +26,18 @@ describe('formDataToJSON', function () {
     });
   });
 
+  it('should convert 3+ repeatable values as a flat array', function () {
+    const formData = new FormData();
+
+    formData.append('select3', '301');
+    formData.append('select3', '302');
+    formData.append('select3', '303');
+
+    expect(formDataToJSON(formData)).toEqual({
+      select3: ['301', '302', '303'],
+    });
+  });
+
   it('should convert props with empty brackets to arrays', function () {
     const formData = new FormData();
 


### PR DESCRIPTION
## Summary

Fixes #7365

When posting an HTML form with `Content-Type: application/json` containing a
`<select multiple>` element with 3 or more selected options, `formDataToJSON`
produced nested arrays instead of a flat array.

**Example:** `select3=301&select3=302&select3=303`
- Expected: `{ select3: ['301', '302', '303'] }`
- Actual:   `{ select3: [['301', '302'], '303'] }`

## Root Cause

In `lib/helpers/formDataToJSON.js`, `buildPath()` always wrapped duplicate keys
with `[target[name], value]`. This works for the 2nd value but wraps the
already-created array on the 3rd+ value.

## Fix

Check whether `target[name]` is already an array before wrapping:

```js
target[name] = utils.isArray(target[name])
  ? target[name].concat(value)
  : [target[name], value];

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix nested arrays in formDataToJSON when a key appears 3+ times (e.g., multi-select). Duplicate values now produce a flat array.

- **Bug Fixes**
  - Root cause: buildPath wrapped the existing array on the 3rd+ value, creating nested arrays.
  - Change: if target[name] is already an array, append the new value; otherwise create [existing, value].

- **Testing**
  - Added a test to ensure 3+ repeated keys return a flat array (e.g., ['301', '302', '303']).
  - No other tests changed.

<sup>Written for commit cebc6d1a75410ec23a7b9659f11cbbd6c324b9f4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

