### PR TITLE
feat(abort): propagate abort reason into CanceledError

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -368,9 +368,26 @@ export default isHttpAdapterSupported &&
 
       function abort(reason) {
         try {
+          if (!reason || reason.type) {
+            // AbortSignal listeners receive an Event. Prefer `signal.reason` if available.
+            reason = config.signal && config.signal.aborted ? config.signal.reason : reason;
+          }
+
           abortEmitter.emit(
             'abort',
-            !reason || reason.type ? new CanceledError(null, config, req) : reason
+            reason && reason.__CANCEL__
+              ? reason
+              : (() => {
+                  const canceledError = new CanceledError(
+                    reason instanceof Error ? reason.message : reason,
+                    config,
+                    req
+                  );
+                  if (reason instanceof Error) {
+                    canceledError.cause = reason;
+                  }
+                  return canceledError;
+                })()
           );
         } catch (err) {
           console.warn('emit error', err);

--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -190,7 +190,29 @@ export default isXHRAdapterSupported &&
           if (!request) {
             return;
           }
-          reject(!cancel || cancel.type ? new CanceledError(null, config, request) : cancel);
+
+          // CancelToken subscribers receive a CanceledError instance.
+          // AbortSignal listeners receive an Event (or nothing when already aborted).
+          // Prefer the AbortSignal's `reason` (if present) so callers can differentiate cancel causes.
+          if (!cancel || cancel.type) {
+            const reason = _config.signal && _config.signal.aborted ? _config.signal.reason : null;
+            if (reason && reason.__CANCEL__) {
+              reject(reason);
+            } else {
+              const canceledError = new CanceledError(
+                reason instanceof Error ? reason.message : reason,
+                config,
+                request
+              );
+              if (reason instanceof Error) {
+                canceledError.cause = reason;
+              }
+              reject(canceledError);
+            }
+          } else {
+            reject(cancel);
+          }
+
           request.abort();
           request = null;
         };

--- a/lib/core/dispatchRequest.js
+++ b/lib/core/dispatchRequest.js
@@ -20,6 +20,15 @@ function throwIfCancellationRequested(config) {
   }
 
   if (config.signal && config.signal.aborted) {
+    const reason = config.signal.reason;
+    if (reason != null) {
+      const canceledError = new CanceledError(reason instanceof Error ? reason.message : reason, config);
+      if (reason instanceof Error) {
+        canceledError.cause = reason;
+      }
+      throw canceledError;
+    }
+
     throw new CanceledError(null, config);
   }
 }

--- a/test/specs/cancel.spec.js
+++ b/test/specs/cancel.spec.js
@@ -99,6 +99,7 @@ describe('cancel', function () {
 
   it('it should support cancellation using AbortController signal', function (done) {
     const controller = new envAbortController();
+    const abortReason = 'Operation has been canceled.';
 
     axios
       .get('/foo/bar', {
@@ -110,13 +111,14 @@ describe('cancel', function () {
         },
         function (thrown) {
           expect(thrown).toEqual(jasmine.any(Cancel));
+          expect(thrown.message).toBe(abortReason);
           done();
         }
       );
 
     getAjaxRequest().then(function (request) {
       // call cancel() when the request has been sent, but a response has not been received
-      controller.abort();
+      controller.abort(abortReason);
       setTimeout(function () {
         request.respondWith({
           status: 200,

--- a/test/unit/adapters/http.js
+++ b/test/unit/adapters/http.js
@@ -2466,6 +2466,28 @@ describe('supports http with nodejs', function () {
   describe('request aborting', function () {
     //this.timeout(5000);
 
+    it('should propagate AbortSignal reason to the CanceledError message', async () => {
+      server = await startHTTPServer((req, res) => {
+        setTimeout(() => res.end('OK'), 1000);
+      });
+
+      const controller = new AbortController();
+      const abortReason = 'TimeoutError';
+
+      const reqPromise = axios.get(LOCAL_SERVER_URL, {
+        signal: controller.signal,
+        maxRedirects: 0,
+      });
+
+      setTimeout(() => {
+        controller.abort(abortReason);
+      }, 50);
+
+      await assert.rejects(reqPromise, (err) => {
+        return err && err.code === 'ERR_CANCELED' && err.message === abortReason;
+      });
+    });
+
     it('should be able to abort the response stream', async () => {
       server = await startHTTPServer({
         rate: 100_000,


### PR DESCRIPTION
## Summary

Axios currently does not propagate the abort reason when a request is canceled via `AbortController`; consumers only see a generic `CanceledError` (typically with message "canceled"). 

This change threads `AbortSignal.reason` into the `CanceledError` so applications can differentiate cancellation causes (e.g. intentional request replacement vs. manual timeout) using only AbortController.

[Related issue](https://github.com/axios/axios/issues/7434)

## What changed

Prefer `config.signal.reason` when creating a `CanceledError` for `AbortSignal` cancellations in:
- `dispatchRequest.js`
- `xhr.js`
- `http.js`

If the abort reason is an `Error`:
- `CanceledError.message` is set to `reason.message`
- the original error is attached as `error.cause` (when supported)

If no reason is provided/available, behavior is unchanged (falls back to the default cancel message).

## Behavior examples

- `controller.abort('TimeoutError')` → rejects with `CanceledError` where `message === 'TimeoutError'`
- `controller.abort(new Error('Too slow'))` → rejects with `CanceledError` where `message === 'Too slow'` and `cause` references the original `Error`

## Tests
Updated browser cancellation spec to assert abort reason propagation: `cancel.spec.js`

Added Node HTTP adapter unit test to assert abort reason propagation: `http.js`

## Notes / compatibility

Backwards-compatible: only affects aborts where `AbortSignal.reason` exists.

No changes to `CancelToken` behavior.




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Propagates AbortSignal.reason into Axios CanceledError so callers can tell why a request was canceled. The error message now reflects the reason, and the original Error is preserved via cause when provided.

**Description**
- Use config.signal.reason when creating CanceledError in dispatchRequest, xhr, and http adapters.
- If reason is an Error: set message to reason.message and set error.cause to the original error.
- If no reason: keep existing behavior and default cancel message. CancelToken behavior unchanged. No docs changes needed.

**Testing**
- Browser: updated cancel.spec.js to assert thrown.message equals the AbortController reason.
- Node: added HTTP adapter test asserting ERR_CANCELED with message equal to the abort reason.
- Coverage is sufficient; no additional tests required.

<sup>Written for commit ff84523fe7d2016d132e6a88043dcbaf9573a308. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

