### PR TITLE
fix(composeSignals): handle already-aborted signals

### DIFF
--- a/lib/helpers/composeSignals.js
+++ b/lib/helpers/composeSignals.js
@@ -45,6 +45,12 @@ const composeSignals = (signals, timeout) => {
 
     signals.forEach((signal) => signal.addEventListener('abort', onabort));
 
+    const abortedSignal = signals.find((signal) => signal.aborted);
+
+    if (abortedSignal) {
+      onabort.call(abortedSignal, abortedSignal.reason);
+    }
+
     const { signal } = controller;
 
     signal.unsubscribe = () => utils.asap(unsubscribe);

--- a/test/unit/helpers/composeSignals.js
+++ b/test/unit/helpers/composeSignals.js
@@ -35,6 +35,16 @@ describe('helpers::composeSignals', () => {
     assert.match(String(signal.reason), /timeout of 100ms exceeded/);
   });
 
+  it('should abort immediately if a signal is already aborted', () => {
+    const controller = new AbortController();
+    controller.abort(new Error('already aborted'));
+
+    const signal = composeSignals([controller.signal]);
+
+    assert.ok(signal.aborted);
+    assert.match(String(signal.reason), /already aborted/);
+  });
+
   it('should return undefined if signals and timeout are not provided', async () => {
     const signal = composeSignals([]);
 


### PR DESCRIPTION
## Summary
- Abort composed signals immediately when any input signal is already aborted.
- Add a unit test to cover the pre-aborted signal case.

## Motivation
If a caller passes an `AbortSignal` that is already aborted, the composed signal previously did not abort immediately. This could allow a request to proceed even though it should be cancelled.

## Testing
- `npm run test:node`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Abort composed signals immediately when any input AbortSignal is already aborted to prevent work from continuing. Adds a unit test for the pre-aborted case.

**Description**
- Abort early when a passed signal is already aborted, invoking the composeSignals abort handler with its reason.
- Prevents requests/actions from proceeding when cancellation was already requested.
- No API changes; existing unsubscribe behavior remains the same.

**Testing**
- Added unit test to assert immediate abort when a pre-aborted signal is passed.
- All existing tests pass via npm run test:node.

<sup>Written for commit 5ff63fcf213f0c3914c1299b7b2f45364946744f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

