### PR TITLE
test: add reproduction case for missing AbortSignal reason

### DIFF
--- a/test/unit/abort-reason.spec.js
+++ b/test/unit/abort-reason.spec.js
@@ -1,0 +1,19 @@
+"use strict";
+
+import axios from '../../lib/axios.js';
+import assert from 'assert';
+
+describe('AbortController abort reason', function () {
+  it('should propagate abort reason to CanceledError', async function () {
+    const controller = new AbortController();
+    setTimeout(() => controller.abort('TimeoutError'), 10);
+
+    try {
+      await axios.get('http://10.255.255.1', { signal: controller.signal });
+      assert.fail('Request should have been aborted');
+    } catch (e) {
+      assert.strictEqual(e.code, 'ERR_CANCELED');
+      assert.strictEqual(e.message, 'TimeoutError');
+    }
+  });
+});


### PR DESCRIPTION
## 🧪 Failing Test Case: Abort Reason Propagation
I have added a unit test that demonstrates how `AxiosError` fails to propagate the specific reason from an `AbortController`.

**The Bug:**
When a request is aborted with a specific reason (e.g., `TimeoutError`), Axios currently defaults the error message to `'canceled'` instead of using the provided reason.

### Test Outcome
- **Test File:** `test/unit/abort-reason.spec.js`
- **Result:** `AssertionError [ERR_ASSERTION]: Expected values to be strictly equal`
- **Actual:** `'canceled'`
- **Expected:** `'TimeoutError'`

## 🔗 Context
This reproduction relates to issue #7434. 

While a reproduction was previously provided in that issue, it did not consistently trigger the failure. This new test case specifically targets the `AbortSignal.reason` propagation, which was identified as the root cause.

---

## 🛠 Next Steps
I am currently working on the fix in `lib/core/dispatchRequest.js` (or relevant adapter) to ensure the `reason` property from the `AbortSignal` is correctly passed to the `CanceledError` constructor.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a failing unit test to reproduce missing AbortSignal.reason propagation in Axios. Confirms CanceledError uses "canceled" instead of the provided reason; branch synced with v1.x (no functional changes).

**Description**
- Added test: test/unit/abort-reason.spec.js to verify CanceledError.message matches AbortSignal.reason.
- Reason: Axios currently overwrites the specific abort reason with "canceled".
- Context: Reproduces issue #7434; deterministic case.
- Synced with v1.x; no changes beyond the test.

**Testing**
- New unit test added; it fails until the fix is implemented.
- Asserts e.code === "ERR_CANCELED" and e.message === "TimeoutError".
- No other tests changed.

<sup>Written for commit 90d2b5fec00047f1c477281cd69e0c002d09f40b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

