### PR TITLE
test: add reproduction case for missing AbortSignal reason

### DIFF
--- a/test/unit/abort-reason.spec.js
+++ b/test/unit/abort-reason.spec.js
@@ -4,7 +4,7 @@ import assert from 'assert';
 describe('AbortController abort reason', function () {
   it('should propagate abort reason to CanceledError', async function () {
     const controller = new AbortController();
-    setTimeout(() => controller.abort('TimeoutError'), 10);
+    setTimeout(() => controller.abort('TimeoutError'), 100);
 
     try {
       await axios.get('http://10.255.255.1', { signal: controller.signal });

--- a/test/unit/abort-reason.spec.js
+++ b/test/unit/abort-reason.spec.js
@@ -1,0 +1,17 @@
+import axios from '../../lib/axios.js';
+import assert from 'assert';
+
+describe('AbortController abort reason', function () {
+  it('should propagate abort reason to CanceledError', async function () {
+    const controller = new AbortController();
+    setTimeout(() => controller.abort('TimeoutError'), 10);
+
+    try {
+      await axios.get('http://10.255.255.1', { signal: controller.signal });
+      assert.fail('Request should have been aborted');
+    } catch (e) {
+      assert.strictEqual(e.code, 'ERR_CANCELED');
+      assert.strictEqual(e.message, 'TimeoutError');
+    }
+  });
+});


### PR DESCRIPTION
## 🧪 Failing Test Case: Abort Reason Propagation
I have added a unit test that demonstrates how `AxiosError` fails to propagate the specific reason from an `AbortController`.

**The Bug:**
When a request is aborted with a specific reason (e.g., `TimeoutError`), Axios currently defaults the error message to `'canceled'` instead of using the provided reason.

### Test Outcome
- **Test File:** `test/unit/abort-reason.spec.js`
- **Result:** `AssertionError [ERR_ASSERTION]: Expected values to be strictly equal`
- **Actual:** `'canceled'`
- **Expected:** `'TimeoutError'`

---

## 🛠 Next Steps
I am currently working on the fix in `lib/core/dispatchRequest.js` (or relevant adapter) to ensure the `reason` property from the `AbortSignal` is correctly passed to the `CanceledError` constructor.




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a failing unit test to reproduce missing AbortSignal.reason propagation in Axios. It shows CanceledError uses "canceled" instead of the provided reason.

## Description

- Summary of changes
  - Added test: test/unit/abort-reason.spec.js to assert CanceledError.message equals the AbortSignal reason.
  - Aborts after 100ms with reason "TimeoutError" to reduce flakiness.
- Reasoning
  - Reproduces the bug to guide the fix (relates to issue #7434).
- Additional context
  - Test will pass once adapters propagate AbortSignal.reason to CanceledError.

## Docs

- No docs changes. Will update error handling docs after the fix if needed.

## Testing

- Added one failing unit test; no other tests changed.
- Asserts e.code === "ERR_CANCELED" and e.message === "TimeoutError".

<sup>Written for commit 96bf5e3255c3f7c411adfecacf9f7e5b9d1dab00. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



