### PR TITLE
docs(http): fix typos and improve clarity in timeout logic

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -889,12 +889,13 @@ export default isHttpAdapterSupported &&
 
           return;
         }
+        
+        // Sometimes, the response is very slow and does not respond, so the connect event is blocked by the event loop.
+        // The timer callback fires and abort() is called before the connection, causing a "socket hang up" and ECONNRESET.
+        // At this time, if there are a large number of requests, Node.js will hang up sockets in the background.
+        // These hung sockets will then slowly devour CPU resources.
+        // ClientRequest.setTimeout triggers after the specified milliseconds to ensure abort() only fires after connecting.
 
-        // Sometime, the response will be very slow, and does not respond, the connect event will be block by event loop system.
-        // And timer callback will be fired, and abort() will be invoked before connection, then get "socket hang up" and code ECONNRESET.
-        // At this time, if we have a large number of request, nodejs will hang up some socket on background. and the number will up and up.
-        // And then these socket which be hang up will devouring CPU little by little.
-        // ClientRequest.setTimeout will be fired on the specify milliseconds, and can make sure that abort() will be fired after connect.
         req.setTimeout(timeout, function handleRequestTimeout() {
           if (isDone) return;
           let timeoutErrorMessage = config.timeout


### PR DESCRIPTION
- Fix grammar: "Sometimes", "blocked", "requests", "sockets", "devour"
- Improve readability of the event loop and hanging sockets explanation
- Clarify ClientRequest.setTimeout behavior

<!-- Instructions

If you would like to add a PR description you may do so or let our AI agent create one, after the creation
you may then edit the file if the AI agent got it wrong.

Please read and follow the instructions before creating and submitting a pull request:

- Create an issue explaining the feature. It could save you some effort in case we don't consider it should be included in axios.
- If you're fixing a bug, try to commit the failing test/s and the code fixing it in different commits.
- Ensure you're following our [contributing guide](https://github.com/axios/axios/blob/main/CONTRIBUTING.md).

**⚠️👆 Delete the instructions before submitting the pull request 👆⚠️**

Describe your pull request here. -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies HTTP adapter timeout comments to better explain slow responses, event-loop blocking, socket hang-ups, and ClientRequest.setTimeout behavior. Documentation-only change; no runtime behavior is modified.

**Description**
- Fixes grammar and typos in inline comments.
- Rewrites the explanation of pre-connect aborts causing ECONNRESET and “socket hang up”.
- Clarifies that ClientRequest.setTimeout triggers after the specified milliseconds to prevent abort() firing before connect.

**Testing**
- No tests added or changed.
- Not needed since this is a comments-only/docs update with no functional impact.

<sup>Written for commit f3c702e4a02671a0405a8856a4bc3d79ba379540. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

