### PR TITLE
fix(headers): trim trailing CRLF in normalized header values

### DIFF
--- a/lib/core/AxiosHeaders.js
+++ b/lib/core/AxiosHeaders.js
@@ -14,7 +14,9 @@ function normalizeValue(value) {
     return value;
   }
 
-  return utils.isArray(value) ? value.map(normalizeValue) : String(value);
+  return utils.isArray(value)
+    ? value.map(normalizeValue)
+    : String(value).replace(/[\r\n]+$/, '');
 }
 
 function parseTokens(str) {

--- a/test/unit/core/AxiosHeaders.js
+++ b/test/unit/core/AxiosHeaders.js
@@ -83,6 +83,30 @@ describe('AxiosHeaders', function () {
       assert.strictEqual(headers.get('x'), '123');
     });
 
+    it('should trim trailing CRLF from plain object header values', function () {
+      const headers = new AxiosHeaders();
+
+      headers.set({
+        'cache-control': 'no-cache\r',
+        expires: '-1\r\n',
+      });
+
+      assert.strictEqual(headers.get('cache-control'), 'no-cache');
+      assert.strictEqual(headers.get('expires'), '-1');
+    });
+
+    it('should trim trailing CRLF from iterable header values', function () {
+      const headers = new AxiosHeaders();
+
+      headers.set(new Map([
+        ['content-type', 'application/json; charset=utf-8\r'],
+        ['pragma', 'no-cache\r\n'],
+      ]));
+
+      assert.strictEqual(headers.get('content-type'), 'application/json; charset=utf-8');
+      assert.strictEqual(headers.get('pragma'), 'no-cache');
+    });
+
     it('should support setting multiple header values from an iterable source', function () {
       if (nodeMajorVersion < 18) {
         this.skip();


### PR DESCRIPTION
## Summary
- trim trailing `\r`/`\n` from normalized header values in `AxiosHeaders`
- preserve existing behavior for `null`/`false` and array values
- add regression tests for object and iterable header sources that include trailing CRLF

## Why
Issue #7455 reports response header values containing trailing carriage-return characters (`\r`) after upgrade.

## Testing
- `npm run test:mocha -- test/unit/core/AxiosHeaders.js`

Fixes #7455