### PR TITLE
docs: add missing withXSRFToken option to Request Config documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,6 +497,23 @@ These are the available config options for making requests. Only the `url` is re
   // `undefined` (default) - set XSRF header only for the same origin requests
   withXSRFToken: boolean | undefined | ((config: InternalAxiosRequestConfig) => boolean | undefined),
 
+  // `withXSRFToken` controls whether Axios reads the XSRF cookie and sets the XSRF header.
+  // - `undefined` (default): the XSRF header is set only for same-origin requests.
+  // - `true`: attempt to set the XSRF header for all requests (including cross-origin).
+  // - `false`: never set the XSRF header.
+  // - function: a callback that receives the request `config` and returns `true`,
+  //   `false`, or `undefined` to decide per-request behavior.
+  //
+  // Note about `withCredentials`: `withCredentials` controls whether cross-site
+  // requests include credentials (cookies and HTTP auth). In older Axios versions,
+  // setting `withCredentials: true` implicitly caused Axios to set the XSRF header
+  // for cross-origin requests. Newer Axios separates these concerns: to allow the
+  // XSRF header to be sent for cross-origin requests you should set both
+  // `withCredentials: true` and `withXSRFToken: true`.
+  //
+  // Example:
+  // axios.get('/user', { withCredentials: true, withXSRFToken: true });
+
   // `onUploadProgress` allows handling of progress events for uploads
   // browser & node.js
   onUploadProgress: function ({loaded, total, progress, bytes, estimated, rate, upload = true}) {


### PR DESCRIPTION
## Description

This PR adds the missing `withXSRFToken` option to the Request Config documentation.

The `withXSRFToken` configuration option exists in Axios but is not currently documented in the official Request Config section. This update ensures the documentation accurately reflects the available configuration options.

## Changes Made

- Added documentation entry for `withXSRFToken`
- Maintained formatting consistency with existing config options

## Related Issue

Closes #7450

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the missing withXSRFToken option to the Request Config docs and explains how it works with withCredentials. Aligns the README with current Axios behavior and includes a small example.

**Description**
- Documented withXSRFToken (default, true/false, function callback).
- Clarified separation from withCredentials and how to send XSRF headers on cross-origin (set both).
- Added a usage example.
- Reason: option exists in Axios but was not documented, causing confusion.

**Testing**
- Docs-only change; no tests added or needed.

<sup>Written for commit 93496938a20508783f39d0366b8962d997917535. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

