### PR TITLE
feat: add QUERY HTTP method support

### DIFF
--- a/index.d.cts
+++ b/index.d.cts
@@ -220,6 +220,16 @@ declare class Axios {
     data?: D,
     config?: axios.AxiosRequestConfig<D>
   ): Promise<R>;
+  query<T = any, R = axios.AxiosResponse<T>, D = any>(
+    url: string,
+    data?: D,
+    config?: axios.AxiosRequestConfig<D>
+  ): Promise<R>;
+  queryForm<T = any, R = axios.AxiosResponse<T>, D = any>(
+    url: string,
+    data?: D,
+    config?: axios.AxiosRequestConfig<D>
+  ): Promise<R>;
 }
 
 declare enum HttpStatusCode {
@@ -364,7 +374,9 @@ declare namespace axios {
     | 'link'
     | 'LINK'
     | 'unlink'
-    | 'UNLINK';
+    | 'UNLINK'
+    | 'query'
+    | 'QUERY';
 
   type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata';
 
@@ -577,6 +589,7 @@ declare namespace axios {
     purge?: RawAxiosRequestHeaders;
     link?: RawAxiosRequestHeaders;
     unlink?: RawAxiosRequestHeaders;
+    query?: RawAxiosRequestHeaders;
   }
 
   interface AxiosDefaults<D = any> extends Omit<AxiosRequestConfig<D>, 'headers'> {

--- a/index.d.ts
+++ b/index.d.ts
@@ -291,7 +291,9 @@ export type Method =
   | "link"
   | "LINK"
   | "unlink"
-  | "UNLINK";
+  | "UNLINK"
+  | "query"
+  | "QUERY";
 
 export type ResponseType =
   | "arraybuffer"
@@ -537,6 +539,7 @@ export interface HeadersDefaults {
   purge?: RawAxiosRequestHeaders;
   link?: RawAxiosRequestHeaders;
   unlink?: RawAxiosRequestHeaders;
+  query?: RawAxiosRequestHeaders;
 }
 
 export interface AxiosDefaults<D = any> extends Omit<
@@ -724,6 +727,16 @@ export class Axios {
     config?: AxiosRequestConfig<D>,
   ): Promise<R>;
   patchForm<T = any, R = AxiosResponse<T>, D = any>(
+    url: string,
+    data?: D,
+    config?: AxiosRequestConfig<D>,
+  ): Promise<R>;
+  query<T = any, R = AxiosResponse<T>, D = any>(
+    url: string,
+    data?: D,
+    config?: AxiosRequestConfig<D>,
+  ): Promise<R>;
+  queryForm<T = any, R = AxiosResponse<T>, D = any>(
     url: string,
     data?: D,
     config?: AxiosRequestConfig<D>,

--- a/lib/core/Axios.js
+++ b/lib/core/Axios.js
@@ -132,7 +132,7 @@ class Axios {
     let contextHeaders = headers && utils.merge(headers.common, headers[config.method]);
 
     headers &&
-      utils.forEach(['delete', 'get', 'head', 'post', 'put', 'patch', 'common'], (method) => {
+      utils.forEach(['delete', 'get', 'head', 'post', 'put', 'patch', 'query', 'common'], (method) => {
         delete headers[method];
       });
 
@@ -235,7 +235,7 @@ utils.forEach(['delete', 'get', 'head', 'options'], function forEachMethodNoData
   };
 });
 
-utils.forEach(['post', 'put', 'patch'], function forEachMethodWithData(method) {
+utils.forEach(['post', 'put', 'patch', 'query'], function forEachMethodWithData(method) {
   /*eslint func-names:0*/
 
   function generateHTTPMethod(isForm) {

--- a/lib/core/dispatchRequest.js
+++ b/lib/core/dispatchRequest.js
@@ -39,7 +39,7 @@ export default function dispatchRequest(config) {
   // Transform request data
   config.data = transformData.call(config, config.transformRequest);
 
-  if (['post', 'put', 'patch'].indexOf(config.method) !== -1) {
+  if (['post', 'put', 'patch', 'query'].indexOf(config.method) !== -1) {
     config.headers.setContentType('application/x-www-form-urlencoded', false);
   }
 

--- a/lib/defaults/index.js
+++ b/lib/defaults/index.js
@@ -165,7 +165,7 @@ const defaults = {
   },
 };
 
-utils.forEach(['delete', 'get', 'head', 'post', 'put', 'patch'], (method) => {
+utils.forEach(['delete', 'get', 'head', 'post', 'put', 'patch', 'query'], (method) => {
   defaults.headers[method] = {};
 });
 

--- a/test/specs/api.spec.js
+++ b/test/specs/api.spec.js
@@ -8,6 +8,7 @@ describe('static api', function () {
     expect(typeof axios.post).toEqual('function');
     expect(typeof axios.put).toEqual('function');
     expect(typeof axios.patch).toEqual('function');
+    expect(typeof axios.query).toEqual('function');
   });
 
   it('should have promise method helpers', function () {
@@ -71,6 +72,7 @@ describe('instance api', function () {
     expect(typeof instance.post).toEqual('function');
     expect(typeof instance.put).toEqual('function');
     expect(typeof instance.patch).toEqual('function');
+    expect(typeof instance.query).toEqual('function');
   });
 
   it('should have interceptors', function () {


### PR DESCRIPTION
Adds `axios.query()` as a convenience method for the QUERY HTTP method ([RFC 9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-query), [HTTP QUERY draft](https://datatracker.ietf.org/doc/draft-ietf-httpbis-safe-method-w-body/)).

QUERY is like GET but allows sending a request body, useful for complex queries that don't fit in URL parameters. This follows the same "with data" pattern as `post`/`put`/`patch`, and also adds `queryForm` like the other methods.

Changes:
- Add `query` to the "with data" methods list in `Axios.js` (alongside post, put, patch)
- Add `query` to headers flattening list
- Add TypeScript definitions for `query()` and `queryForm()` in both `.d.ts` and `.d.cts`
- Add `'query' | 'QUERY'` to the `Method` type
- Update API tests to verify the method exists

Closes #5465

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds axios.query() and axios.queryForm() to support the HTTP QUERY method, enabling request bodies with a safe, GET-like method. Includes header defaults and Content-Type handling so QUERY behaves like post/put/patch, aligned with RFC 9110 and the HTTP QUERY draft.

**Description**
- Add query/queryForm helpers (static and instance).
- Treat QUERY like post/put/patch in Axios, defaults headers, and Content-Type handling.
- Extend Method type with 'query' | 'QUERY', and add TypeScript defs in .d.ts and .d.cts.

**Testing**
- Added API tests to assert axios.query and instance.query exist.
- No adapter-level tests yet for body handling, header defaults, or queryForm; recommend adding.

<sup>Written for commit f43169c699a0c94fc144858a215532e80635ce7b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

