### PR TITLE
fix(types): align interceptor handler runWhen typing

### DIFF
--- a/index.d.cts
+++ b/index.d.cts
@@ -649,7 +649,7 @@ declare namespace axios {
     fulfilled: AxiosInterceptorFulfilled<T>;
     rejected?: AxiosInterceptorRejected;
     synchronous: boolean;
-    runWhen?: (config: AxiosRequestConfig) => boolean;
+    runWhen: AxiosInterceptorOptions['runWhen'] | null;
   }
 
   interface AxiosInterceptorManager<V> {

--- a/index.d.ts
+++ b/index.d.ts
@@ -659,7 +659,7 @@ interface AxiosInterceptorHandler<T> {
   fulfilled: AxiosInterceptorFulfilled<T>;
   rejected?: AxiosInterceptorRejected;
   synchronous: boolean;
-  runWhen: (config: AxiosRequestConfig) => boolean | null;
+  runWhen: AxiosInterceptorOptions['runWhen'] | null;
 }
 
 export interface AxiosInterceptorManager<V> {

--- a/test/module/typings/cjs/index.ts
+++ b/test/module/typings/cjs/index.ts
@@ -253,6 +253,13 @@ axios
 const instance1: axios.AxiosInstance = axios.create();
 const instance2: axios.AxiosInstance = axios.create(config);
 
+type RequestInterceptorHandler = NonNullable<
+  axios.AxiosInstance['interceptors']['request']['handlers']
+>[number];
+const runWhenFromHandler: RequestInterceptorHandler['runWhen'] = null;
+const runWhenFromOptions: axios.AxiosInterceptorOptions['runWhen'] | null = runWhenFromHandler;
+void runWhenFromOptions;
+
 instance1(config).then(handleResponse).catch(handleError);
 
 instance1.request(config).then(handleResponse).catch(handleError);

--- a/test/module/typings/esm/index.ts
+++ b/test/module/typings/esm/index.ts
@@ -7,6 +7,7 @@ import axios, {
   AxiosResponse,
   AxiosError,
   AxiosInstance,
+  AxiosInterceptorOptions,
   AxiosAdapter,
   Cancel,
   CancelTokenSource,
@@ -274,6 +275,13 @@ axios
 
 const instance1: AxiosInstance = axios.create();
 const instance2: AxiosInstance = instance1.create(config);
+
+type RequestInterceptorHandler = NonNullable<
+  AxiosInstance['interceptors']['request']['handlers']
+>[number];
+const runWhenFromHandler: RequestInterceptorHandler['runWhen'] = null;
+const runWhenFromOptions: AxiosInterceptorOptions['runWhen'] | null = runWhenFromHandler;
+void runWhenFromOptions;
 
 instance1(config).then(handleResponse).catch(handleError);
 


### PR DESCRIPTION
## Summary
This fixes an inconsistency between request interceptor option typing and the internal request interceptor handler typing.

Before this change:
- `AxiosInterceptorOptions['runWhen']` was typed as `(config: InternalAxiosRequestConfig) => boolean`
- `AxiosInterceptorManager['handlers'][number]['runWhen']` was typed differently in `index.d.ts` / `index.d.cts`

That mismatch can cause assignability issues when working with `AxiosInstance` types across module boundaries.

This patch:
- aligns `AxiosInterceptorHandler['runWhen']` to `AxiosInterceptorOptions['runWhen'] | null` in both `index.d.ts` and `index.d.cts`
- adds typings coverage in both ESM and CJS typings tests to ensure handler and options `runWhen` types stay compatible

Fixes #7404.

## Testing
- `npm test --prefix test/module/typings/esm`
- `npm test --prefix test/module/typings/cjs`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the interceptor handler runWhen type with AxiosInterceptorOptions to prevent assignability errors across module boundaries. Adds ESM and CJS typing tests to lock the contract.

## Description

- Summary of changes
  - Set AxiosInterceptorHandler['runWhen'] to AxiosInterceptorOptions['runWhen'] | null in index.d.ts and index.d.cts.
  - Added minimal ESM/CJS typing tests asserting handler and options runWhen compatibility.
- Reasoning
  - Handler and option runWhen types diverged, causing type errors when sharing AxiosInstance types between modules.
- Additional context
  - Types-only change; no runtime behavior affected.
  - Fixes #7404.

## Docs

No docs changes needed. This only aligns TypeScript typings.

## Testing

- Added compile-time tests in:
  - test/module/typings/esm/index.ts
  - test/module/typings/cjs/index.ts
- How to run:
  - npm test --prefix test/module/typings/esm
  - npm test --prefix test/module/typings/cjs
- No runtime tests required for this types-only fix.

<sup>Written for commit 8ec423f57540cbd78aee2e573116d5949924a43b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

