### PR TITLE
feat: export encode function from buildURL for paramsSerializer reuse

### DIFF
--- a/index.d.cts
+++ b/index.d.cts
@@ -708,6 +708,7 @@ declare namespace axios {
       config1: AxiosRequestConfig<D>,
       config2: AxiosRequestConfig<D>
     ): AxiosRequestConfig<D>;
+    encode(val: string): string;
   }
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -786,6 +786,8 @@ export function mergeConfig<D = any>(
   config2: AxiosRequestConfig<D>,
 ): AxiosRequestConfig<D>;
 
+export function encode(val: string): string;
+
 export interface AxiosStatic extends AxiosInstance {
   Cancel: CancelStatic;
   CancelToken: CancelTokenStatic;
@@ -803,6 +805,7 @@ export interface AxiosStatic extends AxiosInstance {
   CanceledError: typeof CanceledError;
   AxiosHeaders: typeof AxiosHeaders;
   mergeConfig: typeof mergeConfig;
+  encode: typeof encode;
 }
 
 declare const axios: AxiosStatic;

--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ const {
   formToJSON,
   getAdapter,
   mergeConfig,
+  encode,
 } = axios;
 
 export {
@@ -40,4 +41,5 @@ export {
   formToJSON,
   getAdapter,
   mergeConfig,
+  encode,
 };

--- a/lib/axios.js
+++ b/lib/axios.js
@@ -17,6 +17,7 @@ import isAxiosError from './helpers/isAxiosError.js';
 import AxiosHeaders from './core/AxiosHeaders.js';
 import adapters from './adapters/adapters.js';
 import HttpStatusCode from './helpers/HttpStatusCode.js';
+import { encode } from './helpers/buildURL.js';
 
 /**
  * Create an instance of Axios
@@ -82,6 +83,9 @@ axios.formToJSON = (thing) => formDataToJSON(utils.isHTMLForm(thing) ? new FormD
 axios.getAdapter = adapters.getAdapter;
 
 axios.HttpStatusCode = HttpStatusCode;
+
+// Expose encode function for reuse in paramsSerializer
+axios.encode = encode;
 
 axios.default = axios;
 

--- a/lib/helpers/buildURL.js
+++ b/lib/helpers/buildURL.js
@@ -11,7 +11,7 @@ import AxiosURLSearchParams from '../helpers/AxiosURLSearchParams.js';
  *
  * @returns {string} The encoded value.
  */
-function encode(val) {
+export function encode(val) {
   return encodeURIComponent(val)
     .replace(/%3A/gi, ':')
     .replace(/%24/g, '$')


### PR DESCRIPTION
Exports the internal `encode` function from `helpers/buildURL.js` so users can implement custom paramsSerializers without duplicating the URL encoding logic.

## Use Case

Users who need custom parameter serialization can now reuse the same encoding logic that axios uses internally:

```js
import { encode } from 'axios';

const paramsSerializer = (params) => {
  return encode(Qs.stringify(params));
};
```

This is a non-breaking enhancement that makes an existing internal function available to consumers.

---
*Contributed by [theluckystrike](https://github.com/theluckystrike) | [Zovo](https://zovo.one) — Chrome Extension Studio*