### PR TITLE
Feature: Dispatch Retry Changes

### DIFF
--- a/lib/core/dispatchRequest.js
+++ b/lib/core/dispatchRequest.js
@@ -5,7 +5,7 @@ import isCancel from '../cancel/isCancel.js';
 import defaults from '../defaults/index.js';
 import CanceledError from '../cancel/CanceledError.js';
 import AxiosHeaders from '../core/AxiosHeaders.js';
-import adapters from '../adapters/adapters.js';
+import adapters from "../adapters/adapters.js";
 
 /**
  * Throws a `CanceledError` if cancellation has been requested.
@@ -37,26 +37,56 @@ export default function dispatchRequest(config) {
   config.headers = AxiosHeaders.from(config.headers);
 
   // Transform request data
-  config.data = transformData.call(config, config.transformRequest);
+  config.data = transformData.call(
+    config,
+    config.transformRequest
+  );
 
   if (['post', 'put', 'patch'].indexOf(config.method) !== -1) {
     config.headers.setContentType('application/x-www-form-urlencoded', false);
   }
-
   const adapter = adapters.getAdapter(config.adapter || defaults.adapter, config);
 
-  return adapter(config).then(
-    function onAdapterResolution(response) {
+  const maxRetries = typeof config.retry === 'number' ? config.retry : defaults.retry;
+  const retryDelay = typeof config.retryDelay === 'number' ? config.retryDelay : defaults.retryDelay;
+
+  let attempt = 0;
+
+  function shouldRetry(error, response) {
+    // Do not retry for cancellations
+    if (isCancel(error)) return false;
+
+    // Retry on network errors (no response)
+    if (!response) return true;
+
+    // Retry on server errors (5xx)
+    const status = response.status;
+    if (status >= 500 && status <= 599) return true;
+
+    return false;
+  }
+
+  function backoffDelay(attempt) {
+    // simple linear backoff: base * attempt
+    return retryDelay * attempt;
+  }
+
+  function dispatch() {
+    attempt++;
+    return adapter(config).then(function onAdapterResolution(response) {
       throwIfCancellationRequested(config);
 
       // Transform response data
-      response.data = transformData.call(config, config.transformResponse, response);
+      response.data = transformData.call(
+        config,
+        config.transformResponse,
+        response
+      );
 
       response.headers = AxiosHeaders.from(response.headers);
 
       return response;
-    },
-    function onAdapterRejection(reason) {
+    }, async function onAdapterRejection(reason) {
       if (!isCancel(reason)) {
         throwIfCancellationRequested(config);
 
@@ -71,7 +101,19 @@ export default function dispatchRequest(config) {
         }
       }
 
+      const resp = reason && reason.response ? reason.response : undefined;
+
+      if (attempt <= maxRetries && shouldRetry(reason, resp)) {
+        const delay = backoffDelay(attempt);
+        const result = await new Promise(function (resolve) {
+          setTimeout(resolve, delay);
+        });
+        return dispatch(result);
+      }
+
       return Promise.reject(reason);
-    }
-  );
+    });
+  }
+
+  return dispatch();
 }

--- a/lib/defaults/index.js
+++ b/lib/defaults/index.js
@@ -142,6 +142,17 @@ const defaults = {
    */
   timeout: 0,
 
+  /**
+   * Number of times to retry a request when it fails due to a network error
+   * or a server error (status >= 500). Default is 0 (no retries).
+   */
+  retry: 0,
+
+  /**
+   * Delay in milliseconds between retry attempts.
+   */
+  retryDelay: 1000,
+
   xsrfCookieName: 'XSRF-TOKEN',
   xsrfHeaderName: 'X-XSRF-TOKEN',
 


### PR DESCRIPTION
<!-- Instructions

If you would like to add a PR description you may do so or let our AI agent create one, after the creation
you may then edit the file if the AI agent got it wrong.

Please read and follow the instructions before creating and submitting a pull request:

- Create an issue explaining the feature. It could save you some effort in case we don't consider it should be included in axios.
- If you're fixing a bug, try to commit the failing test/s and the code fixing it in different commits.
- Ensure you're following our [contributing guide](https://github.com/axios/axios/blob/main/CONTRIBUTING.md).

**⚠️👆 Delete the instructions before submitting the pull request 👆⚠️**

Describe your pull request here. -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds configurable retry support to request dispatch with linear backoff. Retries on network failures and 5xx responses, and respects cancellation.

- **Description**
  - Summary of changes: adds config.retry and config.retryDelay defaults; implements retry loop in dispatchRequest with linear backoff; retries on network errors or 5xx; skips retries on cancellation.
  - Reasoning: improve resilience against transient failures without changing default behavior (retry=0).
  - Additional context: retry defaults are retry=0, retryDelay=1000ms; backoff = retryDelay * attempt; transforms still run on each attempt.

- **Testing**
  - No tests added.
  - Needed tests:
    - Retries on network error (no response) and 5xx; does not retry on 4xx or cancellation.
    - Honors max attempts and delay timing.
    - Ensures request/response transforms and headers apply on each retry.
    - Confirms default behavior when retry options are not provided.

<sup>Written for commit b438d262d68ec98f2e8d6d9e85e8e793a6965bc6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

