### PR TITLE
docs(buildURL): align encode() comment with current behavior

### DIFF
--- a/lib/helpers/buildURL.js
+++ b/lib/helpers/buildURL.js
@@ -4,8 +4,8 @@ import utils from '../utils.js';
 import AxiosURLSearchParams from '../helpers/AxiosURLSearchParams.js';
 
 /**
- * It replaces all instances of the characters `:`, `$`, `,`, `+`, `[`, and `]` with their
- * URI encoded counterparts
+ * It replaces all instances of the characters `:`, `$`, `,`, and spaces with their
+ * URI encoded counterparts.
  *
  * @param {string} val The value to be encoded.
  *


### PR DESCRIPTION
## Summary
- update `encode()` JSDoc in `lib/helpers/buildURL.js`
- remove mention of `+`, `[` and `]` replacements that no longer happen
- clarify that spaces are encoded as `+`

## Testing
- not run (comment-only change)

Fixes #7474


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the encode() JSDoc in lib/helpers/buildURL.js to match actual behavior: it encodes ':', '$', ',', and spaces (spaces -> '+') and no longer claims '+', '[' and ']' are encoded. Fixes #7474.

**Docs**
- Corrected the encode() JSDoc to reflect current encoding behavior.

**Testing**
- No code changes; no tests added or needed.

<sup>Written for commit a4f3fde1d05a02cd102ba7129cc31c3cbff23a15. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

