### PR TITLE
fix(http): switch to proxy-from-env v2 API

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -2,7 +2,7 @@ import utils from '../utils.js';
 import settle from '../core/settle.js';
 import buildFullPath from '../core/buildFullPath.js';
 import buildURL from '../helpers/buildURL.js';
-import proxyFromEnv from 'proxy-from-env';
+import {getProxyForUrl} from 'proxy-from-env';
 import http from 'http';
 import https from 'https';
 import http2 from 'http2';
@@ -187,7 +187,7 @@ function dispatchBeforeRedirect(options, responseDetails) {
 function setProxy(options, configProxy, location) {
   let proxy = configProxy;
   if (!proxy && proxy !== false) {
-    const proxyUrl = proxyFromEnv.getProxyForUrl(location);
+    const proxyUrl = getProxyForUrl(location);
     if (proxyUrl) {
       proxy = new URL(proxyUrl);
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.0.0"
       },
       "devDependencies": {
         "@babel/core": "^7.28.6",
@@ -17495,9 +17495,9 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.0.0.tgz",
+      "integrity": "sha512-h2lD3OfRraP3R51rNFKIE8nX+qoLr1mE74X91YhVxtDbt+OD6ntoNZv56+JgI4RCdtwQ5eexsOk1KdOQDfvPCQ==",
       "license": "MIT"
     },
     "node_modules/prr": {
@@ -17639,6 +17639,13 @@
       "engines": {
         "node": ">= 6.0.0"
       }
+    },
+    "node_modules/puppeteer-core/node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/puppeteer-core/node_modules/ws": {
       "version": "7.5.10",

--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
   "dependencies": {
     "follow-redirects": "^1.15.11",
     "form-data": "^4.0.5",
-    "proxy-from-env": "^1.1.0"
+    "proxy-from-env": "^2.0.0"
   },
   "bundlesize": [
     {


### PR DESCRIPTION
## Summary
- upgrade `proxy-from-env` from `^1.1.0` to `^2.0.0`
- switch HTTP adapter import to `getProxyForUrl` named export used by v2
- keep proxy resolution behavior unchanged while removing dependency on legacy `url.parse()` internals

## Testing
- `NODE_OPTIONS=--openssl-legacy-provider npx mocha test/unit/adapters/http.js --timeout 30000 --exit`

Closes #7228


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade proxy-from-env to v2 and switch the HTTP adapter to the new getProxyForUrl API. This removes Node DEP0169 deprecation warnings without changing proxy behavior.

## Description

- Summary of changes
  - Bump proxy-from-env from ^1.1.0 to ^2.0.0.
  - Replace default import with named getProxyForUrl in lib/adapters/http.js.
  - Update package-lock.json accordingly.
- Reasoning
  - v2 avoids legacy url.parse internals that trigger DEP0169 warnings in newer Node versions.
- Additional context
  - HTTP(S)_PROXY and NO_PROXY behavior is unchanged.
  - A dev-only nested dependency still includes proxy-from-env v1 under puppeteer-core; it does not affect runtime behavior.

## Docs

No user-facing changes. Proxy resolution still honors HTTP_PROXY, HTTPS_PROXY, and NO_PROXY. No docs updates needed.

## Testing

No test files changed. Existing HTTP adapter tests continue to pass. Verified locally with:
- npx mocha test/unit/adapters/http.js --timeout 30000 --exit

<sup>Written for commit 5dd14a8f8bf924eb7e9e7914a1b8f7fa212f5a8e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

