### PR TITLE
fix(types): align request interceptor runWhen typings

### DIFF
--- a/index.d.cts
+++ b/index.d.cts
@@ -628,7 +628,7 @@ declare namespace axios {
 
   interface AxiosInterceptorOptions {
     synchronous?: boolean;
-    runWhen?: (config: InternalAxiosRequestConfig) => boolean;
+    runWhen?: (config: InternalAxiosRequestConfig) => boolean | null;
   }
 
   type AxiosInterceptorFulfilled<T> = (value: T) => T | Promise<T>;

--- a/index.d.cts
+++ b/index.d.cts
@@ -649,7 +649,7 @@ declare namespace axios {
     fulfilled: AxiosInterceptorFulfilled<T>;
     rejected?: AxiosInterceptorRejected;
     synchronous: boolean;
-    runWhen?: (config: AxiosRequestConfig) => boolean;
+    runWhen?: (config: InternalAxiosRequestConfig) => boolean | null;
   }
 
   interface AxiosInterceptorManager<V> {

--- a/index.d.ts
+++ b/index.d.ts
@@ -659,7 +659,7 @@ interface AxiosInterceptorHandler<T> {
   fulfilled: AxiosInterceptorFulfilled<T>;
   rejected?: AxiosInterceptorRejected;
   synchronous: boolean;
-  runWhen: (config: AxiosRequestConfig) => boolean | null;
+  runWhen?: (config: InternalAxiosRequestConfig) => boolean | null;
 }
 
 export interface AxiosInterceptorManager<V> {

--- a/index.d.ts
+++ b/index.d.ts
@@ -638,7 +638,7 @@ export interface CancelTokenSource {
 
 export interface AxiosInterceptorOptions {
   synchronous?: boolean;
-  runWhen?: (config: InternalAxiosRequestConfig) => boolean;
+  runWhen?: (config: InternalAxiosRequestConfig) => boolean | null;
 }
 
 type AxiosInterceptorFulfilled<T> = (value: T) => T | Promise<T>;


### PR DESCRIPTION
## Summary
- align `AxiosInterceptorHandler.runWhen` with `AxiosInterceptorOptions.runWhen` in `index.d.ts`
- make the CommonJS typings mirror the same `InternalAxiosRequestConfig` + `boolean | null` shape

## Why
Issue #7404 reports incompatible `runWhen` typings between exported interceptor options and stored interceptor handlers, which can surface as TS2719 in projects comparing Axios types across boundaries.

## Validation
- `git diff --check`
- attempted targeted TS module checks, but local setup could not resolve `axios` from `test/module/ts/index.ts` in this ephemeral environment

Closes #7404

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align interceptor runWhen typings across ESM and CJS to use InternalAxiosRequestConfig, allow boolean | null, and make handler runWhen optional. Fixes type mismatches that could trigger TS2719 (issue #7404).

**Description**
- Set AxiosInterceptorOptions.runWhen to (config: InternalAxiosRequestConfig) => boolean | null in index.d.ts and index.d.cts.
- Make AxiosInterceptorHandler.runWhen optional and typed as (config: InternalAxiosRequestConfig) => boolean | null in both ESM and CJS.
- Types-only change with no runtime impact.

**Testing**
- No tests added.
- Recommend a type test ensuring optional runWhen and boolean | null return types compile for both options and handler.

<sup>Written for commit 15f78eb76e7af1220518a7338f43c7b2257fc1e2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

