### PR TITLE
Fix runWhen type inconsistency causing build failures

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -638,7 +638,7 @@ export interface CancelTokenSource {
 
 export interface AxiosInterceptorOptions {
   synchronous?: boolean;
-  runWhen?: (config: InternalAxiosRequestConfig) => boolean;
+  runWhen?: ((config: InternalAxiosRequestConfig) => boolean) | null;
 }
 
 type AxiosInterceptorFulfilled<T> = (value: T) => T | Promise<T>;
@@ -659,7 +659,7 @@ interface AxiosInterceptorHandler<T> {
   fulfilled: AxiosInterceptorFulfilled<T>;
   rejected?: AxiosInterceptorRejected;
   synchronous: boolean;
-  runWhen: (config: AxiosRequestConfig) => boolean | null;
+  runWhen?: ((config: AxiosRequestConfig) => boolean) | null;
 }
 
 export interface AxiosInterceptorManager<V> {


### PR DESCRIPTION
Fixes #7404. The runWhen type was inconsistent between AxiosInterceptorOptions and AxiosInterceptorHandler, causing TypeScript build failures. The type now allows null values and is optional to match the implementation where runWhen defaults to null when not provided.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns `runWhen` typing across interceptor options and handler by making it optional and nullable. Fixes TypeScript build failures when `runWhen` is omitted.

## Description

- Summary of changes
  - In `AxiosInterceptorOptions`: `runWhen?: ((config: InternalAxiosRequestConfig) => boolean) | null`
  - In `AxiosInterceptorHandler`: `runWhen?: ((config: AxiosRequestConfig) => boolean) | null`
- Reasoning
  - The implementation defaults `runWhen` to `null` when not provided.
  - Prior mismatch marked it as required in the handler, causing TS errors.
- Additional context
  - Fixes #7404
  - Types only; no runtime behavior change.

## Docs

- Update type docs for `axios` interceptors to note:
  - `runWhen` is optional and can be `null` for both options and handler.

## Testing

- No tests added.
- Recommend adding a small TS type test (e.g., `tsd`/`dtslint`) to cover:
  - Omitted `runWhen`
  - `runWhen: null`
  - Valid function signature usage.

<sup>Written for commit 3c3c1259740292ef34f560d18ae77204c013322b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

