### PR TITLE
Update index.d.cts - narrowing AxiosHeaders

### DIFF
--- a/index.d.cts
+++ b/index.d.cts
@@ -43,7 +43,7 @@ type BrowserProgressEvent = any;
 declare class AxiosHeaders {
   constructor(headers?: RawAxiosHeaders | AxiosHeaders | string);
 
-  [key: string]: any;
+  [key: string]: axios.AxiosHeaderValue;
 
   set(
     headerName?: string,


### PR DESCRIPTION
closes https://github.com/axios/axios/issues/7487

the type of AxiosHeaders fields => `axios.AxiosHeaderValue`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tighten `AxiosHeaders` index signature to return `axios.AxiosHeaderValue` instead of `any`. Improves type safety for header access and addresses the typing issue reported in #7487.

## Description
- Summary of changes: Update `[key: string]` in `AxiosHeaders` to `axios.AxiosHeaderValue` in `index.d.cts`.
- Reasoning: Aligns headers map with the exported `AxiosHeaderValue` type and removes unsafe `any`.
- Additional context: Resolves TypeScript inference gaps and supports strict TS settings (ref #7487).

## Testing
- No tests added or modified; this is a declaration-only change.
- Tests not needed: behavior is unchanged at runtime; TS now correctly infers `AxiosHeaderValue` for header lookups.

<sup>Written for commit b2557fae9dcc545467bf237656907f17a5430b9a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

