### PR TITLE
fix(adapters): preserve AbortController abort reason in CanceledError

### DIFF
--- a/lib/adapters/fetch.js
+++ b/lib/adapters/fetch.js
@@ -284,6 +284,11 @@ const factory = (env) => {
     } catch (err) {
       unsubscribe && unsubscribe();
 
+      if (err && err.name === 'AbortError') {
+        const reason = err.reason || err.cause || err.message;
+        throw new CanceledError(reason, config, request);
+      }
+
       if (err && err.name === 'TypeError' && /Load failed|fetch/i.test(err.message)) {
         throw Object.assign(
           new AxiosError(

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -373,7 +373,7 @@ export default isHttpAdapterSupported &&
         try {
           abortEmitter.emit(
             'abort',
-            !reason || reason.type ? new CanceledError(null, config, req) : reason
+            !reason || reason.type ? new CanceledError(reason && reason.type && config.signal ? config.signal.reason : null, config, req) : reason
           );
         } catch (err) {
           console.warn('emit error', err);

--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -190,7 +190,7 @@ export default isXHRAdapterSupported &&
           if (!request) {
             return;
           }
-          reject(!cancel || cancel.type ? new CanceledError(null, config, request) : cancel);
+          reject(!cancel || cancel.type ? new CanceledError(_config.signal && _config.signal.reason || null, config, request) : cancel);
           request.abort();
           request = null;
         };

--- a/tests/unit/test-abort-reason.test.js
+++ b/tests/unit/test-abort-reason.test.js
@@ -1,0 +1,86 @@
+/**
+ * Test to verify that abort reason is preserved in CanceledError
+ * This tests the fix for GitHub issue: axios breaks with AbortController abort reasons
+ */
+
+'use strict';
+
+import axios from '../../index.js';
+
+// Test 1: Node.js environment with http adapter
+async function testNodeHttpAdapter() {
+  console.log('\n=== Test 1: Node.js HTTP Adapter ===');
+  const controller = new AbortController();
+  
+  // Simulate a request (without actually making it)
+  const timeout = setTimeout(() => {
+    console.log('Aborting with TimeoutError reason...');
+    controller.abort('TimeoutError');
+  }, 100);
+
+  try {
+    await axios.get('http://httpbin.org/delay/10', {
+      signal: controller.signal
+    });
+  } catch (error) {
+    clearTimeout(timeout);
+    console.log('Error caught:');
+    console.log(`  - message: "${error.message}"`);
+    console.log(`  - code: ${error.code}`);
+    console.log(`  - isCancel: ${error.__CANCEL__}`);
+    
+    if (error.message === 'TimeoutError') {
+      console.log('✓ Success: Abort reason "TimeoutError" was preserved!');
+    } else {
+      console.log('✗ Failed: Abort reason was not preserved. Got:', error.message);
+    }
+  }
+}
+
+// Test 2: Custom reason scenarios
+async function testCustomReasons() {
+  console.log('\n=== Test 2: Custom Abort Reasons ===');
+  
+  const testCases = [
+    { reason: 'UserCanceled', description: 'User clicked cancel' },
+    { reason: 'NavigationAbort', description: 'User navigated away' },
+    { reason: 'RequestTimeout', description: 'Custom timeout' },
+  ];
+
+  for (const testCase of testCases) {
+    const controller = new AbortController();
+    
+    const timeout = setTimeout(() => {
+      controller.abort(testCase.reason);
+    }, 50);
+
+    try {
+      await axios.get('http://httpbin.org/delay/10', {
+        signal: controller.signal
+      });
+    } catch (error) {
+      clearTimeout(timeout);
+      if (error.message === testCase.reason) {
+        console.log(`✓ ${testCase.description}: "${testCase.reason}" preserved`);
+      } else {
+        console.log(`✗ ${testCase.description}: Expected "${testCase.reason}", got "${error.message}"`);
+      }
+    }
+  }
+}
+
+// Run tests
+async function runTests() {
+  console.log('Testing AbortController abort reason preservation...');
+  
+  try {
+    await testNodeHttpAdapter();
+    await testCustomReasons();
+  } catch (error) {
+    console.error('Test suite error:', error);
+  }
+  
+  console.log('\n=== Tests Complete ===');
+}
+
+runTests();


### PR DESCRIPTION
- Add abort reason handling in fetch adapter for AbortError

- Update http and xhr adapters to include signal.reason in CanceledError

- Add test file to verify abort reason preservation across adapters

<!-- Instructions

If you would like to add a PR description you may do so or let our AI agent create one, after the creation
you may then edit the file if the AI agent got it wrong.

Please read and follow the instructions before creating and submitting a pull request:

- Create an issue explaining the feature. It could save you some effort in case we don't consider it should be included in axios.
- If you're fixing a bug, try to commit the failing test/s and the code fixing it in different commits.
- Ensure you're following our [contributing guide](https://github.com/axios/axios/blob/main/CONTRIBUTING.md).

**⚠️👆 Delete the instructions before submitting the pull request 👆⚠️**

Describe your pull request here. -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves AbortController abort reasons in `CanceledError` across `fetch`, `http`, and `xhr` adapters so user-provided messages (e.g., "TimeoutError") are surfaced consistently. Adds tests to validate reason propagation.

## Description

A clear and concise description of the PR.

Use this section for review hints, explanations or discussion points.

- Summary of changes
  - `fetch` adapter: map `AbortError` to `CanceledError` with `err.reason || err.cause || err.message`.
  - `http` and `xhr` adapters: include `signal.reason` in `CanceledError` when available.
  - Added unit test to confirm abort reason is preserved.
- Reasoning
  - Keeps custom abort messages intact for better debugging and UX.
  - Aligns with the platform spec for `AbortController` reasons.
- Additional context
  - No API changes. Error message now reflects the provided abort reason instead of a generic message.

## Docs

- Update cancellation docs to note that `CanceledError.message` will include the abort reason when `AbortController.abort(reason)` is used.
- Add a short example showing how to pass and receive a custom reason.

## Testing

- Added tests: `tests/unit/test-abort-reason.test.js` to verify the abort reason is preserved and exposed on `CanceledError.message`.
- Coverage notes: current tests exercise Node/http scenarios and custom reasons. Consider follow-up adapter-specific tests for `fetch` and `xhr` in appropriate environments if needed.

<sup>Written for commit 732cb235bc008a24dc8a1af75a0beb816a829f1a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

