### PR TITLE
refactor: migrate husky 9

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npx commitlint --edit "$1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "get-stream": "^3.0.0",
         "gulp": "^4.0.2",
         "handlebars": "^4.7.8",
-        "husky": "^9.0.0",
+        "husky": "^9.1.7",
         "lint-staged": "^15.2.10",
         "memoizee": "^0.4.17",
         "minimist": "^1.2.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "get-stream": "^3.0.0",
         "gulp": "^4.0.2",
         "handlebars": "^4.7.8",
-        "husky": "^8.0.3",
+        "husky": "^9.0.0",
         "lint-staged": "^15.2.10",
         "memoizee": "^0.4.17",
         "minimist": "^1.2.8",
@@ -7705,16 +7705,16 @@
       }
     },
     "node_modules/husky": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
-      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
       "dev": true,
       "license": "MIT",
       "bin": {
-        "husky": "lib/bin.js"
+        "husky": "bin.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/typicode"

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "get-stream": "^3.0.0",
     "gulp": "^4.0.2",
     "handlebars": "^4.7.8",
-    "husky": "^9.0.0",
+    "husky": "^9.1.7",
     "lint-staged": "^15.2.10",
     "memoizee": "^0.4.17",
     "minimist": "^1.2.8",

--- a/package.json
+++ b/package.json
@@ -57,8 +57,7 @@
     "start": "node ./sandbox/server.js",
     "examples": "node ./examples/server.js",
     "fix": "eslint --fix lib/**/*.js",
-    "prepare": "husky install && npm run prepare:hooks",
-    "prepare:hooks": "npx husky set .husky/commit-msg \"npx commitlint --edit $1\""
+    "prepare": "husky"
   },
   "repository": {
     "type": "git",
@@ -108,7 +107,7 @@
     "get-stream": "^3.0.0",
     "gulp": "^4.0.2",
     "handlebars": "^4.7.8",
-    "husky": "^8.0.3",
+    "husky": "^9.0.0",
     "lint-staged": "^15.2.10",
     "memoizee": "^0.4.17",
     "minimist": "^1.2.8",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Migrated to `husky` v9 and adopted the new hook bootstrap. Simplified the `commit-msg` hook and switched the `prepare` script to the v9 command with no change to `commitlint` behavior.

- **Dependencies**
  - Bump `husky` from `^8.0.3` to `^9.1.7` (lockfile `9.1.7`).
  - Note: `husky` v9 requires Node >=18 for dev environments.

- **Migration**
  - Replace `prepare` script with `husky`.
  - Update `.husky/commit-msg`: remove husky shim; keep `npx commitlint --edit "$1"`.
  - Devs: run `npm run prepare` once, then make a test commit to confirm `commitlint` runs.

<sup>Written for commit 1998a094b9d2eccd1b60a08a24c02f70a140c28b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

