### PR TITLE
fix(fetch): cancel ReadableStream body after request stream capability probe

### DIFF
--- a/lib/adapters/fetch.js
+++ b/lib/adapters/fetch.js
@@ -66,14 +66,18 @@ const factory = (env) => {
     test(() => {
       let duplexAccessed = false;
 
+      const body = new ReadableStream();
+
       const hasContentType = new Request(platform.origin, {
-        body: new ReadableStream(),
+        body,
         method: 'POST',
         get duplex() {
           duplexAccessed = true;
           return 'half';
         },
       }).headers.has('Content-Type');
+
+      body.cancel();
 
       return duplexAccessed && !hasContentType;
     });

--- a/tests/unit/adapters/fetch.test.js
+++ b/tests/unit/adapters/fetch.test.js
@@ -9,6 +9,7 @@ import {
   makeEchoStream,
 } from '../../setup/server.js';
 import axios from '../../../index.js';
+import { getFetch } from '../../../lib/adapters/fetch.js';
 import stream from 'stream';
 import { AbortController } from 'abortcontroller-polyfill/dist/cjs-ponyfill.js';
 import util from 'util';
@@ -649,6 +650,34 @@ describe.runIf(typeof fetch === 'function')('supports fetch with nodejs', () => 
       } finally {
         vi.stubGlobal('fetch', globalFetch);
         await stopHTTPServer(server);
+      }
+    });
+  });
+
+  describe('capability probe cleanup', () => {
+    it('should cancel the ReadableStream created during the request stream probe', () => {
+      // The fetch adapter factory probes for request-stream support by creating
+      // a ReadableStream as a Request body.  Previously the stream was never
+      // cancelled, leaving a dangling pull-algorithm promise (async resource leak
+      // visible via `--detect-async-leaks` or Node.js async_hooks).
+      //
+      // Calling getFetch with a unique env triggers a fresh factory() execution
+      // (including the probe).  We spy on ReadableStream.prototype.cancel to
+      // verify it is invoked during the probe.
+
+      const cancelSpy = vi.spyOn(ReadableStream.prototype, 'cancel');
+
+      try {
+        // Unique fetch function ensures cache miss → factory() re-runs the probe.
+        const uniqueFetch = async () => new Response('ok');
+        getFetch({ env: { fetch: uniqueFetch } });
+
+        assert.ok(
+          cancelSpy.mock.calls.length > 0,
+          'ReadableStream.prototype.cancel should be called during the capability probe'
+        );
+      } finally {
+        cancelSpy.mockRestore();
       }
     });
   });


### PR DESCRIPTION
## Problem

The module-level capability probe in the fetch adapter (`lib/adapters/fetch.js`) creates a `new ReadableStream()` as a `Request` body to test for streaming support, but never cancels it. The `Request` constructor sets up an internal pull pipeline on the stream body; since the stream is never consumed or cancelled, the `[[pullAlgorithm]]` Promise remains pending indefinitely, causing an async resource leak.

## How to reproduce

Run any test file that imports axios (with the default fetch adapter, which has been the default since v1.7) using Vitest with async leak detection:

```bash
vitest --detect-async-leaks
```

This reports 1 `PROMISE` leak per test file due to the uncancelled stream from the probe.

## Root cause

In the `factory()` function, the `supportsRequestStream` probe creates a `ReadableStream` inline:

```js
const hasContentType = new Request(platform.origin, {
  body: new ReadableStream(),  // ← never cancelled
  method: 'POST',
  // ...
}).headers.has('Content-Type');
```

The `Request` constructor enqueues an internal pull on the stream. Without cancellation, this pull promise persists for the lifetime of the process.

## Fix

Extract the `ReadableStream` to a variable and call `body.cancel()` after the probe completes:

```js
const body = new ReadableStream();

const hasContentType = new Request(platform.origin, {
  body,
  method: 'POST',
  // ...
}).headers.has('Content-Type');

body.cancel();
```

## Impact

Affects every project using the axios fetch adapter (default since v1.7) under test tooling with async leak detection (Vitest `--detect-async-leaks`, Jest `--detectOpenHandles`, Node.js `async_hooks`). The fix is a single `cancel()` call with no behavioral change to the probe logic.

## Test

Added a unit test that spies on `ReadableStream.prototype.cancel` during a fresh `getFetch()` call (via a unique env to bypass the seed cache) and asserts the cancel method is invoked.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an async resource leak in the fetch adapter by cancelling the `ReadableStream` used in the request-stream capability probe. Adds a unit test to verify the stream is cancelled.

**Bug Fixes**
- Cancel the probe `ReadableStream` in `lib/adapters/fetch.js` after creating the `Request`.
- Prevents a pending pull promise and async leaks seen in `vitest --detect-async-leaks`, Jest open handles, and Node `async_hooks`.
- No behavior change to request-stream support detection.

**Testing**
- Added a unit test that spies on `ReadableStream.prototype.cancel` during a fresh `getFetch()` run; asserts it is called.
- No other tests changed.

<sup>Written for commit 69588e8ba11e8955ba465106240ac1c0017a68be. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

