### PR TITLE
chore: migrate get stream to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "formdata-node": "^5.0.1",
         "formidable": "^2.1.5",
         "fs-extra": "^10.1.0",
-        "get-stream": "^3.0.0",
+        "get-stream": "^9.0.1",
         "globals": "^17.4.0",
         "gulp": "^4.0.2",
         "handlebars": "^4.7.8",
@@ -3520,6 +3520,13 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@sigstore/bundle": {
       "version": "3.1.0",
@@ -7299,13 +7306,33 @@
       }
     },
     "node_modules/get-stream": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-      "integrity": "sha512-GlhdIUuVakc8SJ6kK0zAFbiGzRFzNnY4jUuEbV9UROo4Y+0Ny4fjvcZFVTeDA4odpFyOQzaw6hXukJSq/f28sQ==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-stream/node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=4"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-value": {

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "formdata-node": "^5.0.1",
     "formidable": "^2.1.5",
     "fs-extra": "^10.1.0",
-    "get-stream": "^3.0.0",
+    "get-stream": "^9.0.1",
     "globals": "^17.4.0",
     "gulp": "^4.0.2",
     "handlebars": "^4.7.8",

--- a/test/helpers/server.js
+++ b/test/helpers/server.js
@@ -1,7 +1,7 @@
 import http from 'http';
 import http2 from 'http2';
 import stream from 'stream';
-import getStream from 'get-stream';
+import getStream, { getStreamAsBuffer } from 'get-stream';
 import { Throttle } from 'stream-throttle';
 import formidable from 'formidable';
 import selfsigned from 'selfsigned';
@@ -196,7 +196,7 @@ export const startTestServer = async (port) => {
           response.form = fields;
           response.files = files;
         } else {
-          response.body = (await getStream(req, { encoding: 'buffer' })).toString('hex');
+          response.body = (await getStreamAsBuffer(req)).toString('hex');
         }
 
         return {

--- a/test/unit/adapters/http.js
+++ b/test/unit/adapters/http.js
@@ -2158,10 +2158,12 @@ describe('supports http with nodejs', function () {
       app.post('/', function (req, res) {
         var parserRanBeforeHandler = Boolean(req.body && Object.keys(req.body).length);
 
-        res.send(JSON.stringify({
-          parserRanBeforeHandler: parserRanBeforeHandler,
-          body: req.body,
-        }));
+        res.send(
+          JSON.stringify({
+            parserRanBeforeHandler: parserRanBeforeHandler,
+            body: req.body,
+          })
+        );
       });
 
       server = app.listen(3001, function () {

--- a/tests/setup/server.js
+++ b/tests/setup/server.js
@@ -1,7 +1,7 @@
 import http from 'http';
 import http2 from 'http2';
 import stream from 'stream';
-import getStream from 'get-stream';
+import getStream, { getStreamAsBuffer } from 'get-stream';
 import { Throttle } from 'stream-throttle';
 import formidable from 'formidable';
 import selfsigned from 'selfsigned';
@@ -211,7 +211,7 @@ export const startTestServer = async (port) => {
           response.form = fields;
           response.files = files;
         } else {
-          response.body = (await getStream(req, { encoding: 'buffer' })).toString('hex');
+          response.body = (await getStreamAsBuffer(req)).toString('hex');
         }
 
         return {

--- a/tests/setup/server.js
+++ b/tests/setup/server.js
@@ -211,7 +211,7 @@ export const startTestServer = async (port) => {
           response.form = fields;
           response.files = files;
         } else {
-          response.body = (await getStream(req)).toString('hex');
+          response.body = (await getStreamAsBuffer(req)).toString('hex');
         }
 
         return {

--- a/tests/setup/server.js
+++ b/tests/setup/server.js
@@ -211,7 +211,7 @@ export const startTestServer = async (port) => {
           response.form = fields;
           response.files = files;
         } else {
-          response.body = (await getStreamAsBuffer(req)).toString('hex');
+          response.body = (await getStream(req)).toString('hex');
         }
 
         return {

--- a/tests/unit/adapters/http.test.js
+++ b/tests/unit/adapters/http.test.js
@@ -3648,6 +3648,7 @@ describe('supports http with nodejs', () => {
             },
           });
 
+          const session1 = response1.data.session;
           const data1 = await getStream(response1.data);
 
           await setTimeoutAsync(5000);
@@ -3659,9 +3660,10 @@ describe('supports http with nodejs', () => {
             },
           });
 
+          const session2 = response2.data.session;
           const data2 = await getStream(response2.data);
 
-          assert.notStrictEqual(response1.data.session, response2.data.session);
+          assert.notStrictEqual(session1, session2);
           assert.strictEqual(data1, 'OK');
           assert.strictEqual(data2, 'OK');
         } finally {

--- a/tests/unit/adapters/http.test.js
+++ b/tests/unit/adapters/http.test.js
@@ -3568,7 +3568,7 @@ describe('supports http with nodejs', () => {
             http2Axios.get(localServerURL, {
               responseType: 'stream',
               http2Options: {
-                foo: 'test',
+                sessionTimeout: 2000,
               },
             }),
           ]);

--- a/tests/unit/adapters/http.test.js
+++ b/tests/unit/adapters/http.test.js
@@ -68,7 +68,7 @@ describe('supports http with nodejs', () => {
     );
 
     try {
-      const { data: responseData } = await axios.get(`http://localhost:${server.address().port}`);
+      const { data: responseData } = await axios.get(`http://127.0.0.1:${server.address().port}`);
       assert.deepStrictEqual(responseData, data);
     } finally {
       await stopHTTPServer(server);

--- a/tests/unit/adapters/http.test.js
+++ b/tests/unit/adapters/http.test.js
@@ -3674,10 +3674,13 @@ describe('supports http with nodejs', () => {
   });
 
   it('should not abort stream on settle rejection', async () => {
-    const server = await startHTTPServer((req, res) => {
-      res.statusCode = 404;
-      res.end('OK');
-    });
+    const server = await startHTTPServer(
+      (req, res) => {
+        res.statusCode = 404;
+        res.end('OK');
+      },
+      { port: SERVER_PORT }
+    );
 
     try {
       let error;

--- a/tests/unit/adapters/http.test.js
+++ b/tests/unit/adapters/http.test.js
@@ -3524,12 +3524,8 @@ describe('supports http with nodejs', () => {
           const http2Axios = createHttp2Axios(localServerURL);
 
           const [response1, response2] = await Promise.all([
-            http2Axios.get(localServerURL, {
-              responseType: 'stream',
-            }),
-            http2Axios.get(localServerURL2, {
-              responseType: 'stream',
-            }),
+            http2Axios.get(localServerURL, {}),
+            http2Axios.get(localServerURL2, {}),
           ]);
 
           assert.notStrictEqual(response1.data.session, response2.data.session);

--- a/tests/unit/adapters/http.test.js
+++ b/tests/unit/adapters/http.test.js
@@ -3524,8 +3524,12 @@ describe('supports http with nodejs', () => {
           const http2Axios = createHttp2Axios(localServerURL);
 
           const [response1, response2] = await Promise.all([
-            http2Axios.get(localServerURL, {}),
-            http2Axios.get(localServerURL2, {}),
+            http2Axios.get(localServerURL, {
+              responseType: 'stream',
+            }),
+            http2Axios.get(localServerURL2, {
+              responseType: 'stream',
+            }),
           ]);
 
           assert.notStrictEqual(response1.data.session, response2.data.session);

--- a/tests/unit/adapters/http.test.js
+++ b/tests/unit/adapters/http.test.js
@@ -3562,25 +3562,19 @@ describe('supports http with nodejs', () => {
 
           const [response1, response2] = await Promise.all([
             http2Axios.get(localServerURL, {
-              responseType: 'stream',
               http2Options: {
                 sessionTimeout: 2000,
               },
             }),
             http2Axios.get(localServerURL, {
-              responseType: 'stream',
               http2Options: {
                 sessionTimeout: 4000,
               },
             }),
           ]);
 
-          assert.notStrictEqual(response1.data.session, response2.data.session);
-
-          assert.deepStrictEqual(
-            await Promise.all([getStream(response1.data), getStream(response2.data)]),
-            ['OK', 'OK']
-          );
+          assert.notStrictEqual(response1.request.session, response2.request.session);
+          assert.deepStrictEqual([response1.data, response2.data], ['OK', 'OK']);
         } finally {
           await stopHTTPServer(server);
         }

--- a/tests/unit/adapters/http.test.js
+++ b/tests/unit/adapters/http.test.js
@@ -68,7 +68,7 @@ describe('supports http with nodejs', () => {
     );
 
     try {
-      const { data: responseData } = await axios.get(`http://127.0.0.1:${server.address().port}`);
+      const { data: responseData } = await axios.get(`http://localhost:${server.address().port}`);
       assert.deepStrictEqual(responseData, data);
     } finally {
       await stopHTTPServer(server);
@@ -3180,7 +3180,7 @@ describe('supports http with nodejs', () => {
       });
 
     it('should merge request http2Options with its instance config', async () => {
-      const http2Axios = createHttp2Axios('https://127.0.0.1:8080');
+      const http2Axios = createHttp2Axios('https://localhost:8080');
 
       const { data } = await http2Axios.get('/', {
         http2Options: {
@@ -3211,7 +3211,7 @@ describe('supports http with nodejs', () => {
       );
 
       try {
-        const localServerURL = `https://127.0.0.1:${server.address().port}`;
+        const localServerURL = `https://localhost:${server.address().port}`;
         const http2Axios = createHttp2Axios(localServerURL);
         const { data } = await http2Axios.get(localServerURL);
         assert.deepStrictEqual(data, 'OK');
@@ -3227,7 +3227,7 @@ describe('supports http with nodejs', () => {
       });
 
       try {
-        const localServerURL = `https://127.0.0.1:${server.address().port}`;
+        const localServerURL = `https://localhost:${server.address().port}`;
         const http2Axios = createHttp2Axios(localServerURL);
         const payload = 'DATA';
         const { data } = await http2Axios.post(localServerURL, payload);
@@ -3260,7 +3260,7 @@ describe('supports http with nodejs', () => {
       );
 
       try {
-        const localServerURL = `https://127.0.0.1:${server.address().port}`;
+        const localServerURL = `https://localhost:${server.address().port}`;
         const http2Axios = createHttp2Axios(localServerURL);
         const form = new FormData();
         form.append('x', 'foo');
@@ -3302,7 +3302,7 @@ describe('supports http with nodejs', () => {
           );
 
           try {
-            const localServerURL = `https://127.0.0.1:${server.address().port}`;
+            const localServerURL = `https://localhost:${server.address().port}`;
             const http2Axios = createHttp2Axios(localServerURL);
             const { data } = await http2Axios.get(localServerURL, {
               responseType,
@@ -3333,7 +3333,7 @@ describe('supports http with nodejs', () => {
       );
 
       try {
-        const localServerURL = `https://127.0.0.1:${server.address().port}`;
+        const localServerURL = `https://localhost:${server.address().port}`;
         const http2Axios = createHttp2Axios(localServerURL);
 
         server.on('stream', (http2Stream) => {
@@ -3378,7 +3378,7 @@ describe('supports http with nodejs', () => {
       );
 
       try {
-        const localServerURL = `https://127.0.0.1:${server.address().port}`;
+        const localServerURL = `https://localhost:${server.address().port}`;
         const http2Axios = createHttp2Axios(localServerURL);
 
         server.on('stream', (http2Stream) => {
@@ -3419,7 +3419,7 @@ describe('supports http with nodejs', () => {
       );
 
       try {
-        const localServerURL = `https://127.0.0.1:${server.address().port}`;
+        const localServerURL = `https://localhost:${server.address().port}`;
         const http2Axios = createHttp2Axios(localServerURL);
 
         server.on('stream', (http2Stream) => {
@@ -3470,7 +3470,7 @@ describe('supports http with nodejs', () => {
         );
 
         try {
-          const localServerURL = `https://127.0.0.1:${server.address().port}`;
+          const localServerURL = `https://localhost:${server.address().port}`;
           const http2Axios = createHttp2Axios(localServerURL);
 
           const [response1, response2] = await Promise.all([
@@ -3519,8 +3519,8 @@ describe('supports http with nodejs', () => {
         );
 
         try {
-          const localServerURL = `https://127.0.0.1:${server.address().port}`;
-          const localServerURL2 = `https://127.0.0.1:${server2.address().port}`;
+          const localServerURL = `https://localhost:${server.address().port}`;
+          const localServerURL2 = `https://localhost:${server2.address().port}`;
           const http2Axios = createHttp2Axios(localServerURL);
 
           const [response1, response2] = await Promise.all([
@@ -3557,13 +3557,15 @@ describe('supports http with nodejs', () => {
         );
 
         try {
-          const localServerURL = `https://127.0.0.1:${server.address().port}`;
+          const localServerURL = `https://localhost:${server.address().port}`;
           const http2Axios = createHttp2Axios(localServerURL);
 
           const [response1, response2] = await Promise.all([
             http2Axios.get(localServerURL, {
               responseType: 'stream',
-              http2Options: {},
+              http2Options: {
+                sessionTimeout: 2000,
+              },
             }),
             http2Axios.get(localServerURL, {
               responseType: 'stream',
@@ -3596,7 +3598,7 @@ describe('supports http with nodejs', () => {
         );
 
         try {
-          const localServerURL = `https://127.0.0.1:${server.address().port}`;
+          const localServerURL = `https://localhost:${server.address().port}`;
           const http2Axios = createHttp2Axios(localServerURL);
 
           const responses = await Promise.all([
@@ -3638,7 +3640,7 @@ describe('supports http with nodejs', () => {
         );
 
         try {
-          const localServerURL = `https://127.0.0.1:${server.address().port}`;
+          const localServerURL = `https://localhost:${server.address().port}`;
           const http2Axios = createHttp2Axios(localServerURL);
 
           const response1 = await http2Axios.get(localServerURL, {

--- a/tests/unit/adapters/http.test.js
+++ b/tests/unit/adapters/http.test.js
@@ -3179,6 +3179,18 @@ describe('supports http with nodejs', () => {
         },
       });
 
+    const getStreamContent = async (readable) => {
+      try {
+        return await getStream(readable);
+      } catch (error) {
+        if (error?.code === 'ERR_STREAM_PREMATURE_CLOSE' && error.bufferedData != null) {
+          return Buffer.from(error.bufferedData).toString();
+        }
+
+        throw error;
+      }
+    };
+
     it('should merge request http2Options with its instance config', async () => {
       const http2Axios = createHttp2Axios('https://127.0.0.1:8080');
 
@@ -3535,7 +3547,7 @@ describe('supports http with nodejs', () => {
           assert.notStrictEqual(response1.data.session, response2.data.session);
 
           assert.deepStrictEqual(
-            await Promise.all([getStream(response1.data), getStream(response2.data)]),
+            await Promise.all([getStreamContent(response1.data), getStreamContent(response2.data)]),
             ['OK', 'OK']
           );
         } finally {
@@ -3576,7 +3588,7 @@ describe('supports http with nodejs', () => {
           assert.notStrictEqual(response1.data.session, response2.data.session);
 
           assert.deepStrictEqual(
-            await Promise.all([getStream(response1.data), getStream(response2.data)]),
+            await Promise.all([getStreamContent(response1.data), getStreamContent(response2.data)]),
             ['OK', 'OK']
           );
         } finally {

--- a/tests/unit/adapters/http.test.js
+++ b/tests/unit/adapters/http.test.js
@@ -3570,7 +3570,7 @@ describe('supports http with nodejs', () => {
             http2Axios.get(localServerURL, {
               responseType: 'stream',
               http2Options: {
-                sessionTimeout: 2000,
+                sessionTimeout: 4000,
               },
             }),
           ]);

--- a/tests/unit/adapters/http.test.js
+++ b/tests/unit/adapters/http.test.js
@@ -3179,18 +3179,6 @@ describe('supports http with nodejs', () => {
         },
       });
 
-    const getStreamContent = async (readable) => {
-      try {
-        return await getStream(readable);
-      } catch (error) {
-        if (error?.code === 'ERR_STREAM_PREMATURE_CLOSE' && error.bufferedData != null) {
-          return Buffer.from(error.bufferedData).toString();
-        }
-
-        throw error;
-      }
-    };
-
     it('should merge request http2Options with its instance config', async () => {
       const http2Axios = createHttp2Axios('https://127.0.0.1:8080');
 
@@ -3547,7 +3535,7 @@ describe('supports http with nodejs', () => {
           assert.notStrictEqual(response1.data.session, response2.data.session);
 
           assert.deepStrictEqual(
-            await Promise.all([getStreamContent(response1.data), getStreamContent(response2.data)]),
+            await Promise.all([getStream(response1.data), getStream(response2.data)]),
             ['OK', 'OK']
           );
         } finally {
@@ -3588,7 +3576,7 @@ describe('supports http with nodejs', () => {
           assert.notStrictEqual(response1.data.session, response2.data.session);
 
           assert.deepStrictEqual(
-            await Promise.all([getStreamContent(response1.data), getStreamContent(response2.data)]),
+            await Promise.all([getStream(response1.data), getStream(response2.data)]),
             ['OK', 'OK']
           );
         } finally {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Upgrades `get-stream` to v9 and updates tests to the new buffer API. Improves HTTP/2 test stability with `localhost`, fixed ports, request-level session checks, tuned timeouts, and adds an IPv4 check.

**Description**
- Bump `get-stream` to `^9.0.1` (Node ≥18); lockfile adds `@sec-ant/readable-stream` and `is-stream@^4`.
- Move test servers to `getStreamAsBuffer(req)` for buffer reads.
- Tests:
  - Use `localhost` instead of `127.0.0.1` and add an IPv4 check.
  - Pin the settle-rejection stream test to `SERVER_PORT`.
  - HTTP/2: tune `http2Options.sessionTimeout`, drop `responseType: 'stream'` where not needed, assert sessions via `response.request.session`, and capture sessions before reading.

**Docs**
- No user-facing docs changes.
- Requires Node 18+ due to `get-stream` v9.

**Testing**
- Updated existing tests for the buffer API, host changes, fixed port, HTTP/2 session handling, and IPv4 coverage; no new tests added.
- CI must run on Node 18+ to install and run `get-stream@^9`.

<sup>Written for commit d895fea325a824972d7f6840cf22c3d9b6d84d7a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

