### PR TITLE
chore: upgrade to latest ts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
         "stream-throttle": "^0.1.3",
         "string-replace-async": "^3.0.2",
         "tar-stream": "^3.1.8",
-        "typescript": "^4.9.5",
+        "typescript": "^5.9.3",
         "vitest": "^4.1.0"
       }
     },
@@ -1754,21 +1754,6 @@
         "@types/node": "*",
         "cosmiconfig": ">=9",
         "typescript": ">=5"
-      }
-    },
-    "node_modules/@commitlint/load/node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "node_modules/@commitlint/message": {
@@ -13713,9 +13698,9 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -13723,7 +13708,7 @@
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/uglify-js": {

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "stream-throttle": "^0.1.3",
     "string-replace-async": "^3.0.2",
     "tar-stream": "^3.1.8",
-    "typescript": "^4.9.5",
+    "typescript": "^5.9.3",
     "vitest": "^4.1.0"
   },
   "browser": {

--- a/test/module/ts-require-default/package.json
+++ b/test/module/ts-require-default/package.json
@@ -15,6 +15,6 @@
     "axios": "file:../../.."
   },
   "devDependencies": {
-    "typescript": "^4.8.4"
+    "typescript": "^5.9.3"
   }
 }

--- a/test/module/ts-require/package.json
+++ b/test/module/ts-require/package.json
@@ -15,6 +15,6 @@
     "axios": "file:../../.."
   },
   "devDependencies": {
-    "typescript": "^4.8.4"
+    "typescript": "^5.9.3"
   }
 }

--- a/test/module/ts/index.js
+++ b/test/module/ts/index.js
@@ -15,13 +15,23 @@ var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (
 }) : function(o, v) {
     o["default"] = v;
 });
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
-    __setModuleDefault(result, mod);
-    return result;
-};
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };

--- a/test/module/ts/package.json
+++ b/test/module/ts/package.json
@@ -15,6 +15,6 @@
     "axios": "file:../../.."
   },
   "devDependencies": {
-    "typescript": "^4.8.4"
+    "typescript": "^5.9.3"
   }
 }

--- a/test/module/typings/cjs/package.json
+++ b/test/module/typings/cjs/package.json
@@ -15,6 +15,6 @@
     "axios": "file:../../../.."
   },
   "devDependencies": {
-    "typescript": "^4.9.4"
+    "typescript": "^5.9.3"
   }
 }

--- a/test/module/typings/esm/package.json
+++ b/test/module/typings/esm/package.json
@@ -16,6 +16,6 @@
     "axios": "file:../../../.."
   },
   "devDependencies": {
-    "typescript": "^4.9.4"
+    "typescript": "^5.9.3"
   }
 }

--- a/tests/module/cjs/package-lock.json
+++ b/tests/module/cjs/package-lock.json
@@ -12,7 +12,7 @@
         "@types/node": "^18.11.3",
         "chai": "4.5.0",
         "mocha": "9.2.2",
-        "typescript": "^4.9.5"
+        "typescript": "^5.9.3"
       }
     },
     "node_modules/@types/node": {
@@ -1021,9 +1021,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1031,7 +1031,7 @@
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/undici-types": {

--- a/tests/module/cjs/package.json
+++ b/tests/module/cjs/package.json
@@ -10,9 +10,9 @@
   "author": "axios team",
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "^18.11.3",
+    "@types/node": "12.20.55",
     "chai": "4.5.0",
     "mocha": "9.2.2",
-    "typescript": "^5.9.3"
+    "typescript": "4.9.5"
   }
 }

--- a/tests/module/cjs/package.json
+++ b/tests/module/cjs/package.json
@@ -13,6 +13,6 @@
     "@types/node": "^18.11.3",
     "chai": "4.5.0",
     "mocha": "9.2.2",
-    "typescript": "^4.9.5"
+    "typescript": "^5.9.3"
   }
 }

--- a/tests/module/esm/package-lock.json
+++ b/tests/module/esm/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",
-        "typescript": "^4.9.5",
+        "typescript": "^5.9.3",
         "vitest": "4.1.0"
       }
     },
@@ -1092,9 +1092,9 @@
       "optional": true
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1102,7 +1102,7 @@
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/undici-types": {

--- a/tests/module/esm/package.json
+++ b/tests/module/esm/package.json
@@ -12,7 +12,7 @@
   "license": "MIT",
   "devDependencies": {
     "@types/node": "^20.0.0",
-    "typescript": "^4.9.5",
+    "typescript": "^5.9.3",
     "vitest": "4.1.0"
   }
 }

--- a/tests/module/esm/package.json
+++ b/tests/module/esm/package.json
@@ -11,7 +11,7 @@
   "author": "axios team",
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "^20.0.0",
+    "@types/node": "20.0.0",
     "typescript": "^5.9.3",
     "vitest": "4.1.0"
   }

--- a/tests/module/esm/package.json
+++ b/tests/module/esm/package.json
@@ -11,7 +11,7 @@
   "author": "axios team",
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "20.0.0",
+    "@types/node": "^20.0.0",
     "typescript": "^5.9.3",
     "vitest": "4.1.0"
   }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Upgrade to `typescript@^5.9.3` across the repo and fixtures, update generated helpers, and clean up lockfiles. Keep the CJS fixture on TS 4.9 for Node 12.

## Description

- Summary of changes
  - Bump `typescript` to `^5.9.3` in root and fixtures (`test/module/ts*`, `test/module/typings/*`, `tests/module/esm`).
  - Keep `tests/module/cjs` on `typescript@4.9.5` with `@types/node@12.20.55`.
  - Update `test/module/ts/index.js` to TS 5’s `__importStar` helper.
  - Refresh lockfiles; dedupe TS and reflect Node `>=14.17` for TS 5.
  - Stop pinning ESM `@types/node`; keep `^20.0.0`.

- Reasoning
  - Stay current and consistent with TS.
  - Align fixtures to intended Node versions; avoid duplicate installs.

- Additional context
  - Dev/test only; no runtime changes.

## Docs

- Update mentions of TypeScript to `5.9`.
- Note Node `>=14.17` for tasks using TS 5; the CJS fixture intentionally stays on TS 4.9 with Node 12 types.

## Testing

- No new tests. Only devDependencies/fixtures updated.
- Run existing suites to confirm no regressions.
- Ensure CI uses Node `>=14.17` for TS 5 tasks and a Node 12 job for the CJS fixture.

<sup>Written for commit 1741de375a1ab7d510705f5d9beb11a5c94756b8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

