### PR TITLE
fix: make AxiosError.cause non-enumerable to prevent circular reference in JSON.stringify

### DIFF
--- a/lib/core/AxiosError.js
+++ b/lib/core/AxiosError.js
@@ -5,7 +5,7 @@ import utils from '../utils.js';
 class AxiosError extends Error {
   static from(error, code, config, request, response, customProps) {
     const axiosError = new AxiosError(error.message, code || error.code, config, request, response);
-    axiosError.cause = error;
+    Object.defineProperty(axiosError, 'cause', {value: error, configurable: true, writable: true});
     axiosError.name = error.name;
 
     // Preserve status from the original error if not already set from response


### PR DESCRIPTION
Fixes #7205

Since v1.12.0, `AxiosError.from()` sets `cause` as a regular (enumerable) property via direct assignment. When the original error contains circular references (common with network errors that include socket objects), `JSON.stringify(axiosError)` fails with "Converting circular structure to JSON".

The existing `toJSON()` method already handles serialization correctly by explicitly listing safe properties — but `JSON.stringify` still walks all enumerable properties including `cause` before `toJSON()` gets a chance to intervene when used in contexts like `console.log` with certain formatters or logging libraries that don't call `toJSON()`.

**Fix:** Use `Object.defineProperty` to set `cause` as non-enumerable (matching how native `Error.cause` behaves in V8), while keeping it configurable and writable for compatibility.

This is a one-line change that restores the v1.11.0 behavior where `JSON.stringify(error)` works without throwing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `AxiosError.cause` non-enumerable to avoid `JSON.stringify` circular reference errors introduced in v1.12.0. Restores pre-1.12 behavior and aligns with native `Error.cause`.

- **Bug Fixes**
  - Set `cause` via `Object.defineProperty` as non-enumerable (still configurable, writable).
  - Prevents `JSON.stringify(axiosError)` from throwing when the original error has circular refs.
  - No API changes; `toJSON()` unchanged. No tests added—consider a regression test for `JSON.stringify` with a circular `cause`.

<sup>Written for commit 05d15386a7f33d04c89323f53654dc1e447c36af. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

