### PR TITLE
fix: dependabot uses the correct labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,30 +1,35 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: 'github-actions'
+    directory: '/'
     groups:
       github-actions:
         patterns:
-          - "*"  # Group all Actions updates into a single larger pull request
+          - '*'
+    labels:
+      - 'commit::chore'
+      - 'type::automated-pr'
     schedule:
-      interval: "weekly"
-  # Upgrade for npm packages, minor and patch versions only
-  - package-ecosystem: "npm"
-    directory: "/"
+      interval: 'weekly'
+  - package-ecosystem: 'npm'
+    directory: '/'
     schedule:
-      interval: "weekly"
+      interval: 'weekly'
     open-pull-requests-limit: 5
     groups:
       production_dependencies:
-        dependency-type: "production"
+        dependency-type: 'production'
         update-types:
-          - "minor"
-          - "patch"
+          - 'minor'
+          - 'patch'
       development_dependencies:
-        dependency-type: "development"
+        dependency-type: 'development'
         update-types:
-          - "minor"
-          - "patch"
+          - 'minor'
+          - 'patch'
     ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
+      - dependency-name: '*'
+        update-types: ['version-update:semver-major']
+    labels:
+      - 'commit::chore'
+      - 'type::automated-pr'


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes Dependabot so PRs for `github-actions` and `npm` updates are labeled with `commit::chore` and `type::automated-pr`. Normalizes the YAML config while keeping the weekly cadence and existing grouping behavior.

## Description

- Added labels to both `github-actions` and `npm` update configs.
- Kept weekly schedule, grouping, ignore rules for majors, and `open-pull-requests-limit: 5`.
- Normalized quoting and wildcard patterns for consistency.

Reasoning:
- Ensures our triage and automation flows key off consistent labels.
- Reduces manual tagging for Dependabot PRs.

Additional context:
- No change to update frequency or scope (still minor/patch for prod/dev).

## Docs

- No docs updates needed.
- Note: Dependabot PRs will include `commit::chore` and `type::automated-pr`.

## Testing

- No tests added (config-only change).
- YAML validated; verification will occur on the next Dependabot run (PRs should include the new labels).

<sup>Written for commit e5d3e337ed84b31a2c3b8c8a0117309d6108a3c9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

