### PR TITLE
fix: bug axios breaks commonjs compatibility main entry

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,30 +1,35 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: 'github-actions'
+    directory: '/'
     groups:
       github-actions:
         patterns:
-          - "*"  # Group all Actions updates into a single larger pull request
+          - '*'
+    labels:
+      - 'commit::chore'
+      - 'type::automated-pr'
     schedule:
-      interval: "weekly"
-  # Upgrade for npm packages, minor and patch versions only
-  - package-ecosystem: "npm"
-    directory: "/"
+      interval: 'weekly'
+  - package-ecosystem: 'npm'
+    directory: '/'
     schedule:
-      interval: "weekly"
+      interval: 'weekly'
     open-pull-requests-limit: 5
     groups:
       production_dependencies:
-        dependency-type: "production"
+        dependency-type: 'production'
         update-types:
-          - "minor"
-          - "patch"
+          - 'minor'
+          - 'patch'
       development_dependencies:
-        dependency-type: "development"
+        dependency-type: 'development'
         update-types:
-          - "minor"
-          - "patch"
+          - 'minor'
+          - 'patch'
     ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
+      - dependency-name: '*'
+        update-types: ['version-update:semver-major']
+    labels:
+      - 'commit::chore'
+      - 'type::automated-pr'

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "axios",
   "version": "1.13.6",
   "description": "Promise based HTTP client for the browser and node.js",
-  "main": "./index.js",
+  "main": "./dist/node/axios.cjs",
   "module": "./index.js",
   "exports": {
     ".": {


### PR DESCRIPTION
Closes #7463

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores CommonJS compatibility by pointing `axios`'s `main` entry to the built CJS bundle so `require('axios')` works in Node again. ESM exports are unchanged.

**Description**
- Summary of changes: Set `"main"` to `./dist/node/axios.cjs` in `package.json`.
- Reasoning: Fixes the CJS require regression (fixes #7463).
- Additional context: `"module"` and `"exports"` stay the same; ESM and browser builds are unaffected.

**Testing**
- No tests changed.
- Recommend adding a smoke test that `require('axios')` loads successfully and exposes expected APIs (e.g., `axios.get`).

<sup>Written for commit 652b68ce9900c88cc83e03e277cfcbfa1708ad78. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

