### PR TITLE
fix(formDataToJSON): prevent nested arrays for duplicate FormData keys

### DIFF
--- a/lib/helpers/formDataToJSON.js
+++ b/lib/helpers/formDataToJSON.js
@@ -58,7 +58,11 @@ function formDataToJSON(formData) {
 
     if (isLast) {
       if (utils.hasOwnProp(target, name)) {
-        target[name] = [target[name], value];
+        if (utils.isArray(target[name])) {
+          target[name].push(value);
+        } else {
+          target[name] = [target[name], value];
+        }
       } else {
         target[name] = value;
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -92,6 +92,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -3776,6 +3777,7 @@
       "integrity": "sha512-2RU7pZELY9/aVMLmABNy1HeZ4FX23FXGY1jRuHLHgWa2zaAE49aNW2GLzebW+BmbTZIKKyFF1QXvk7DEWViUCQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/browser": "4.1.0",
         "@vitest/mocker": "4.1.0",
@@ -3981,6 +3983,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4526,6 +4529,7 @@
       "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -4809,6 +4813,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5612,6 +5617,7 @@
       "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -5965,31 +5971,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
-      }
-    },
-    "node_modules/encoding/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
@@ -6184,6 +6165,7 @@
       "integrity": "sha512-COV33RzXZkqhG9P2rZCFl9ZmJ7WL+gQSCRzE7RhkbclbQPtLAWReL7ysA0Sh4c8Im2U9ynybdR56PV0XcKvqaQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -12102,6 +12084,7 @@
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -13705,6 +13688,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13781,8 +13765,7 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.1",
@@ -14176,6 +14159,7 @@
       "integrity": "sha512-fPGaRNj9Zytaf8LEiBhY7Z6ijnFKdzU/+mL8EFBaKr7Vw1/FWcTBAMW0wLPJAGMPX38ZPVCVgLceWiEqeoqL2Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@oxc-project/runtime": "0.115.0",
         "lightningcss": "^1.32.0",
@@ -14270,6 +14254,7 @@
       "integrity": "sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.0",
         "@vitest/mocker": "4.1.0",


### PR DESCRIPTION
### Summary
Fixes an issue in `formDataToJSON` where multiple entries with the same key result in nested arrays instead of a flat array.

### Problem
When a FormData object contains more than two entries with the same key:

formData.append('file', 'A');
formData.append('file', 'B');
formData.append('file', 'C');

The current implementation produces:
[[A, B], C]

Instead of the expected:
[A, B, C]

### Fix
Ensure that values are appended to an existing array instead of wrapping repeatedly:

if (utils.hasOwnProp(target, name)) {
  if (utils.isArray(target[name])) {
    target[name].push(value);
  } else {
    target[name] = [target[name], value];
  }
}

### Impact
- Produces consistent flat arrays
- Prevents unexpected nested structures
- Improves handling of repeated FormData keys

### Verification
Tested locally by appending multiple values with the same key and confirming output is a flat array.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `formDataToJSON` so repeated FormData keys produce a flat array (e.g., [A, B, C]) instead of nested arrays. Improves consistency with common FormData semantics.

## Description

Ensures duplicate keys append to an existing array, rather than wrapping multiple times.

- Summary of changes
  - In `lib/helpers/formDataToJSON.js`, push to `target[name]` if it’s already an array; otherwise wrap once as `[existing, value]`.
- Reasoning
  - Previous logic nested arrays after the second duplicate (e.g., [[A, B], C]). The new logic returns a flat array for all duplicates.
- Additional context
  - `package-lock.json` updated (peer flags and minor cleanup). No runtime impact.

## Docs

- Update `formDataToJSON` docs to clarify: repeated keys return a flat array in insertion order.
- Add a brief note for users migrating from earlier v1.x that nested arrays are no longer produced.

## Testing

- No tests added in this PR.
- Tests recommended:
  - 3+ duplicates: A, B, C → [A, B, C]
  - 2 duplicates: A, B → [A, B]
  - Single value remains scalar (A) and becomes array only on second insert
  - Mixed value types (e.g., `File`, `Blob`, string) with duplicates remain flat and ordered.

<sup>Written for commit 1c33ad5a853152d71d408e99ca187a378d0c2985. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

