### PR TITLE
fix(parseHeaders): prevent prototype pollution using Object.create(null)

### DIFF
--- a/lib/helpers/parseHeaders.js
+++ b/lib/helpers/parseHeaders.js
@@ -39,7 +39,7 @@ const ignoreDuplicateOf = utils.toObjectSet([
  * @returns {Object} Headers parsed into an object
  */
 export default (rawHeaders) => {
-  const parsed = {};
+  const parsed = Object.create(null);
   let key;
   let val;
   let i;


### PR DESCRIPTION
### Summary
Fixes a potential prototype pollution issue in `parseHeaders` by replacing a plain object `{}` with `Object.create(null)`.

### Problem
The current implementation initializes the parsed headers object using:

```js
const parsed = {};

This creates an object with a prototype (Object.prototype). If a malicious or malformed header includes keys like __proto__ or constructor, it could modify the prototype chain and lead to unexpected behavior.

Fix

Initialize the object without a prototype:

const parsed = Object.create(null);
Impact

Prevents prototype pollution

Ensures safer handling of untrusted header input

No breaking changes

Verification

Verified locally

No changes in normal header parsing behavior


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent prototype pollution in `parseHeaders` by initializing the headers map with `Object.create(null)` instead of `{}`. This secures parsing of untrusted header keys without changing expected behavior.

## Description

Use this section for review hints, explanations or discussion points.

- Summary of changes
  - Initialize parsed headers with `Object.create(null)` to avoid inherited prototype.
- Reasoning
  - Blocks `__proto__`, `constructor`, and similar keys from mutating `Object.prototype`.
- Additional context
  - Internal-only change; no API or behavior changes for valid headers.

## Docs

- No docs updates needed; behavior and API remain the same.

## Testing

- No tests added in this PR.
- Recommended: add a regression test to ensure headers containing `__proto__`/`constructor` do not modify `Object.prototype` and are treated as plain keys.

<sup>Written for commit 999dbbe367683de9fea6be656638daab501e2238. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

