### PR TITLE
fix(core): serialize custom properties in AxiosError.toJSON (#6511)

### DIFF
--- a/lib/core/AxiosError.js
+++ b/lib/core/AxiosError.js
@@ -65,6 +65,7 @@ class AxiosError extends Error {
     });
 
     return {
+      ...customProps,
       // Standard
       message: this.message,
       name: this.name,
@@ -80,8 +81,6 @@ class AxiosError extends Error {
       config: utils.toJSONObject(this.config),
       code: this.code,
       status: this.status,
-      // Custom properties (set via AxiosError.from customProps)
-      ...customProps,
     };
   }
 }

--- a/lib/core/AxiosError.js
+++ b/lib/core/AxiosError.js
@@ -53,6 +53,17 @@ class AxiosError extends Error {
     }
 
   toJSON() {
+    // Collect any enumerable own properties that are not part of the
+    // standard AxiosError fields or are intentionally excluded from JSON
+    // (request/response can have circular references; cause is a raw Error).
+    const knownNonSerializable = ['request', 'response', 'cause'];
+    const customProps = {};
+    Object.keys(this).forEach((key) => {
+        if (!knownNonSerializable.includes(key)) {
+            customProps[key] = this[key];
+        }
+    });
+
     return {
       // Standard
       message: this.message,
@@ -69,6 +80,8 @@ class AxiosError extends Error {
       config: utils.toJSONObject(this.config),
       code: this.code,
       status: this.status,
+      // Custom properties (set via AxiosError.from customProps)
+      ...customProps,
     };
   }
 }

--- a/test/specs/core/AxiosError.spec.js
+++ b/test/specs/core/AxiosError.spec.js
@@ -67,6 +67,17 @@ describe('core::AxiosError', function () {
       const axiosError = AxiosError.from(error, 'ERR_BAD_REQUEST', {}, null, response);
       expect(axiosError.status).toBe(404);
     });
+
+    it('should serialize custom properties in toJSON() (issue #6511)', function() {
+      const error = new Error('Network Error');
+      const axiosError = AxiosError.from(error, 'ERR_NETWORK', null, null, null, {
+        requestId: 'abc-123',
+        traceId: 'xyz-789'
+      });
+      const json = axiosError.toJSON();
+      expect(json.requestId).toBe('abc-123');
+      expect(json.traceId).toBe('xyz-789');
+    });
   });
 
   it('should be a native error as checked by the NodeJS `isNativeError` function', function () {


### PR DESCRIPTION
### Summary
Fixes [#6511](https://github.com/axios/axios/issues/6511)

When using `AxiosError.from(...)`, it's possible to pass `customProps` which are merged onto the error instance. However, if the error was serialized via `AxiosError.toJSON()`, those custom properties were completely omitted from the output. This affected users attempting to log [AxiosError](cci:2://file:///Users/sudipkumarprasad/Desktop/axios/lib/core/AxiosError.js:4:0-69:1) objects using JSON-based loggers like Pino.

This PR updates `AxiosError.toJSON()` to spread any enumerable own properties of the error instance into the resulting JSON object. `request`, `response`, and `cause` are intentionally excluded to prevent circular reference errors or serializing raw Error instances.

### Important Changes
- Modified `AxiosError.prototype.toJSON` to dynamically capture custom properties.
- Added a regression test in [AxiosError.spec.js](cci:7://file:///Users/sudipkumarprasad/Desktop/axios/test/specs/core/AxiosError.spec.js:0:0-0:0) to ensure custom properties successfully serialize. 

### Testing
- [x] Verified unit tests (`npm run test:node`) pass successfully.
- [x] Verified package typing and build tests (`npm run test:package`) pass successfully.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serialize custom properties in `AxiosError.toJSON()` so fields from `AxiosError.from()` are kept in JSON and show up in loggers. Spread custom props before standard fields so canonical error fields always win. Fixes #6511.

## Description

- Summary of changes
  - Updated `toJSON()` to include own enumerable properties and exclude `request`, `response`, and `cause`.
  - Spread custom props first, then standard fields (`message`, `name`, etc.) to prevent overrides.
- Reasoning
  - Custom props from `AxiosError.from(...)` were dropped, hiding context like request/trace IDs in logs.
- Additional context
  - Exclusions avoid circular references and raw `Error` serialization.

## Docs

No docs changes.

## Testing

- Added unit test in `test/specs/core/AxiosError.spec.js` to assert custom props appear in `toJSON()` output.
- Existing tests pass.

<sup>Written for commit fceca01cbb3b1d797830546f6560a3af9eb7e79a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

