### PR TITLE
feat: add Location to CommonRequestHeadersList type

### DIFF
--- a/index.d.cts
+++ b/index.d.cts
@@ -20,7 +20,8 @@ type CommonRequestHeadersList =
   | 'Content-Length'
   | 'User-Agent'
   | 'Content-Encoding'
-  | 'Authorization';
+  | 'Authorization'
+  | 'Location';
 
 type ContentType =
   | axios.AxiosHeaderValue

--- a/index.d.ts
+++ b/index.d.ts
@@ -132,7 +132,8 @@ type CommonRequestHeadersList =
   | "Content-Length"
   | "User-Agent"
   | "Content-Encoding"
-  | "Authorization";
+  | "Authorization"
+  | "Location";
 
 type ContentType =
   | AxiosHeaderValue


### PR DESCRIPTION
Fixes #7527

Adds 'Location' to the `CommonRequestHeadersList` type union in both `index.d.ts` and `index.d.cts`.

The `Location` header is used for HTTP redirects and should be included in the common request headers type definition, similar to other standard headers like `Accept`, `Authorization`, etc.

Reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers#redirects

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds 'Location' to `CommonRequestHeadersList` so TypeScript users can set/read the Location header without type errors. Updates `index.d.ts` and `index.d.cts`; no runtime changes.

## Description

- Summary of changes: Add `'Location'` to the `CommonRequestHeadersList` union in `index.d.ts` and `index.d.cts`.
- Reasoning: Support redirects by including a standard header in the common list; avoids TS typing gaps when handling `Location`.
- Additional context: Fixes #7527. Backward-compatible, declaration-only change.

## Docs

No docs changes needed. `Location` is now accepted wherever `CommonRequestHeadersList` is used.

## Testing

No tests updated. Recommend adding a small TypeScript type test to assert `headers['Location']` is permitted by `CommonRequestHeadersList` to prevent regressions.

<sup>Written for commit 56a491012a49082a5f53646f76da04841a55e205. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

