### PR TITLE
fix(transformData): normalize headers with formatHeader to fix case-sensitivity issues

### DIFF
--- a/lib/core/AxiosHeaders.js
+++ b/lib/core/AxiosHeaders.js
@@ -343,4 +343,5 @@ utils.reduceDescriptors(AxiosHeaders.prototype, ({ value }, key) => {
 
 utils.freezeMethods(AxiosHeaders);
 
+export {formatHeader};
 export default AxiosHeaders;

--- a/lib/core/transformData.js
+++ b/lib/core/transformData.js
@@ -2,7 +2,7 @@
 
 import utils from '../utils.js';
 import defaults from '../defaults/index.js';
-import AxiosHeaders from '../core/AxiosHeaders.js';
+import AxiosHeaders, {formatHeader} from '../core/AxiosHeaders.js';
 
 /**
  * Transform the data for a request or a response
@@ -19,10 +19,10 @@ export default function transformData(fns, response) {
   let data = context.data;
 
   utils.forEach(fns, function transform(fn) {
-    data = fn.call(config, data, headers.normalize(), response ? response.status : undefined);
+    data = fn.call(config, data, headers.normalize(formatHeader), response ? response.status : undefined);
   });
 
-  headers.normalize();
+  headers.normalize(formatHeader);
 
   return data;
 }


### PR DESCRIPTION
Fixes #7393

The automatic URL-encoded serialization fails when the Content-Type header uses initial uppercase letters. This is because headers.normalize() was called without the formatHeader parameter.

Changes:
- Export the formatHeader function from AxiosHeaders.js
- Pass formatHeader to headers.normalize() in transformData.js

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize headers with `formatHeader` in `transformData` to fix case-sensitive `Content-Type` handling. Restores automatic URL-encoded serialization when header casing varies.

**Description**
- Summary of changes
  - Export `formatHeader` from `lib/core/AxiosHeaders.js`.
  - Pass `formatHeader` to `headers.normalize()` in `lib/core/transformData.js`.
- Reasoning
  - `headers.normalize()` without `formatHeader` failed to match mixed-case `Content-Type`, causing urlencoded serialization to be skipped.
- Additional context
  - Fixes #7393.
  - No breaking changes or migrations.

**Testing**
- No tests added in this PR.
- Add regression tests:
  - Ensure urlencoded serialization works with `Content-Type`, `content-type`, and other case variants.
  - Verify no change for already-lowercase headers.

<sup>Written for commit 2b0e2cdedcb6f6fc5854ca4145d9de0542b65d7e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

