### PR TITLE
fix: add null check for iterator in forEachEntry function

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -607,6 +607,10 @@ const forEachEntry = (obj, fn) => {
 
   const _iterator = generator.call(obj);
 
+  if (!_iterator || !isFunction(_iterator.next)) {
+    return;
+  }
+
   let result;
 
   while ((result = _iterator.next()) && !result.done) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -601,6 +601,10 @@ const isTypedArray = ((TypedArray) => {
 const forEachEntry = (obj, fn) => {
   const generator = obj && obj[iterator];
 
+  if (!isFunction(generator)) {
+    return;
+  }
+
   const _iterator = generator.call(obj);
 
   let result;


### PR DESCRIPTION
## Summary
Fixes potential TypeError crash in `forEachEntry` utility function when iterating over objects with invalid iterators.

## Problem
The `forEachEntry` function didn't validate that `obj[Symbol.iterator]` is actually a function before calling it with `.call()`, leading to potential crashes when:
- Object has `Symbol.iterator` property that's not a function  
- Object is null/undefined
- Iterator property exists but is invalid

## Solution
Added safety check using existing `isFunction` utility before attempting to call the iterator:

```javascript
if (!isFunction(generator)) {
  return;
}

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents TypeError crashes in `forEachEntry` by validating the iterator is callable and that the returned iterator has a `next` function. Safely no-ops for invalid or missing iterators, including null/undefined.

## Description

- Add `isFunction` guard for `obj[Symbol.iterator]`; return early if not a function.
- Validate the returned iterator exists and has a callable `next`; return early if not.
- No behavior change for valid iterables.

## Testing

- No tests updated in this PR.
- Recommended: add unit tests for:
  - `Symbol.iterator` present but not a function.
  - Iterator object returned without `next`, or with non-function `next`.
  - `null` and `undefined` inputs.

<sup>Written for commit 3b801e1d2f72353d3ae7209c7bedbe74f9bac41d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

