### PR TITLE
fix(types): add 'Location' to CommonRequestHeadersList

### DIFF
--- a/index.d.cts
+++ b/index.d.cts
@@ -20,7 +20,8 @@ type CommonRequestHeadersList =
   | 'Content-Length'
   | 'User-Agent'
   | 'Content-Encoding'
-  | 'Authorization';
+  | 'Authorization'
+  | 'Location';
 
 type ContentType =
   | axios.AxiosHeaderValue

--- a/index.d.ts
+++ b/index.d.ts
@@ -132,7 +132,8 @@ type CommonRequestHeadersList =
   | "Content-Length"
   | "User-Agent"
   | "Content-Encoding"
-  | "Authorization";
+  | "Authorization"
+  | "Location";
 
 type ContentType =
   | AxiosHeaderValue


### PR DESCRIPTION
## Summary

This PR adds the 'Location' header to the `CommonRequestHeadersList` type in both `index.d.ts` and `index.d.cts`.

## Motivation

The Location header is a standard HTTP header used in redirect responses (3xx status codes) to indicate the URL to redirect to. It is documented in [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers#redirects).

Adding this header to the type definition improves TypeScript DX by providing proper type completion and validation for the Location header when working with Axios request configurations.

## Changes

- Added `'Location'` to `CommonRequestHeadersList` type in `index.d.ts`
- Added `'Location'` to `CommonRequestHeadersList` type in `index.d.cts`

## Related Issue

Fixes #7527

## Checklist

- [x] Type definitions updated
- [x] No breaking changes
- [x] Follows conventional commit format

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds 'Location' to `CommonRequestHeadersList` in `index.d.ts` and `index.d.cts` to enable proper TypeScript typing and autocompletion for redirect headers. No runtime changes.

**Description**
- Summary of changes: Add 'Location' to `CommonRequestHeadersList` in `index.d.ts` and `index.d.cts`.
- Reasoning: `Location` is a standard redirect header; typing it improves DX when configuring `axios`. MDN: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Location
- Additional context: Fixes #7527.

**Testing**
- No tests modified; this is a types-only change.
- Tests not required. If we have a type test for header lists, consider adding a case for 'Location'.

<sup>Written for commit 2a17945ea8579c0980e2fb47889927fcf29ce5be. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

