### PR TITLE
fix: updated release flow to match the current flows

### DIFF
--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -44,11 +44,16 @@ jobs:
         run: npm run test:vitest:unit
       - name: Run browser tests
         run: npm run test:vitest:browser:headless
-      - name: Upload build artifact
+      - name: Pack npm tarball
+        run: npm pack
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v4
+      - name: Upload npm pack artifact
         uses: actions/upload-artifact@v7
         with:
-          name: axios
-          path: dist
+          name: axios-tarball
+          path: axios-*.tgz
+          if-no-files-found: error
           retention-days: 1
 
   cjs-smoke-tests:
@@ -70,17 +75,17 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: npm
           cache-dependency-path: tests/smoke/cjs/package-lock.json
-      - name: Install dependencies
-        if: matrix.node-version == 16 || matrix.node-version == 18
-        run: npm ci
-      - name: Download build artifact
+      - name: Download npm pack artifact
         uses: actions/download-artifact@v8
         with:
-          name: axios
-          path: dist
+          name: axios-tarball
+          path: artifacts
       - name: Install CJS smoke test dependencies
         working-directory: tests/smoke/cjs
         run: npm install
+      - name: Install packed axios
+        working-directory: tests/smoke/cjs
+        run: npm install --no-save ../../../artifacts/axios-*.tgz
       - name: Run CJS smoke tests
         working-directory: tests/smoke/cjs
         run: npm run test:smoke:cjs:mocha
@@ -104,19 +109,88 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: npm
           cache-dependency-path: tests/smoke/esm/package-lock.json
-      - name: Install dependencies
-        run: npm ci
-      - name: Download build artifact
+      - name: Download npm pack artifact
         uses: actions/download-artifact@v8
         with:
-          name: axios
-          path: dist
+          name: axios-tarball
+          path: artifacts
       - name: Install ESM smoke test dependencies
         working-directory: tests/smoke/esm
         run: npm install
+      - name: Install packed axios
+        working-directory: tests/smoke/esm
+        run: npm install --no-save ../../../artifacts/axios-*.tgz
       - name: Run ESM smoke tests
         working-directory: tests/smoke/esm
         run: npm run test:smoke:esm:vitest
+
+  cjs-module-tests:
+    name: CJS module tests (Node ${{ matrix.node-version }})
+    needs: build-and-run-vitest
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [12, 14, 16, 18]
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: true
+      - name: Setup node
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+          cache-dependency-path: tests/module/cjs/package-lock.json
+      - name: Download npm pack artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: axios-tarball
+          path: artifacts
+      - name: Install CJS module test dependencies
+        working-directory: tests/module/cjs
+        run: npm install
+      - name: Install packed axios
+        working-directory: tests/module/cjs
+        run: npm install --no-save ../../../artifacts/axios-*.tgz
+      - name: Run CJS module tests
+        working-directory: tests/module/cjs
+        run: npm run test:module:cjs
+
+  esm-module-tests:
+    name: ESM module tests (Node ${{ matrix.node-version }})
+    needs: build-and-run-vitest
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [20, 22, 24]
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: true
+      - name: Setup node
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+          cache-dependency-path: tests/module/esm/package-lock.json
+      - name: Download npm pack artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: axios-tarball
+          path: artifacts
+      - name: Install ESM module test dependencies
+        working-directory: tests/module/esm
+        run: npm install
+      - name: Install packed axios
+        working-directory: tests/module/esm
+        run: npm install --no-save ../../../artifacts/axios-*.tgz
+      - name: Run ESM module tests
+        working-directory: tests/module/esm
+        run: npm run test:module:esm
 
   bump-version-and-create-pr:
     name: Bump version and create PR

--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -46,8 +46,6 @@ jobs:
         run: npm run test:vitest:browser:headless
       - name: Pack npm tarball
         run: npm pack
-      - name: Dependency Review
-        uses: actions/dependency-review-action@v4
       - name: Upload npm pack artifact
         uses: actions/upload-artifact@v7
         with:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updates the release-branch workflow to build, upload, and test the packed npm tarball, aligning with the current publish flow. Adds CJS/ESM module tests across Node versions and removes the dependency review step.

## Description

- Summary of changes
  - Pack tarball with `npm pack` and upload `axios-*.tgz` as `axios-tarball` (fail if missing).
  - Update smoke tests to install from the packed tarball.
  - Add CJS module tests on Node 12/14/16/18.
  - Add ESM module tests on Node 20/22/24.
  - Migrate to `actions/checkout@v6`, `actions/setup-node@v6`, `actions/upload-artifact@v7`, `actions/download-artifact@v8`.
  - Remove dependency review step.

- Reasoning
  - Test the exact artifact we publish to npm.
  - Validate CJS/ESM behavior across supported Node versions.
  - Simplify the flow by dropping an unnecessary step.

- Additional context
  - Artifact renamed from `axios` (dist) to `axios-tarball` (npm pack).
  - Tarball installed via `npm install --no-save ../../../artifacts/axios-*.tgz`.
  - Review: should `bump-version-and-create-pr` also depend on the new module test jobs to fully gate releases?

## Testing

- No unit tests changed.
- CI updates:
  - Smoke tests now install `axios` from the packed tarball.
  - New module test jobs for CJS and ESM across Node versions.
- No additional tests needed beyond these CI checks; they cover the publishable artifact end-to-end.

<sup>Written for commit 183fedda759877512049c5a551289f1e7c025356. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

