### PR TITLE
fix: pin 2 unpinned action(s),extract 2 unsafe expression(s) to env vars

### DIFF
--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -213,10 +213,12 @@ jobs:
       - name: Bump version with NPM version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_TYPE: ${{ github.event.inputs.type }}
+          INPUT_BETA: ${{ github.event.inputs.beta }}
         id: bump-version
         run: |
-          TYPE=${{ github.event.inputs.type }}
-          BETA=${{ github.event.inputs.beta }}
+          TYPE=${INPUT_TYPE}
+          BETA=${INPUT_BETA}
           if [ "$TYPE" = "auto" ]; then
             npm version $(npm version | grep -Eo 'patch|minor|major' | head -1)
           else
@@ -234,7 +236,7 @@ jobs:
       - name: Build project
         run: npm run build
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8
         with:
           branch: 'release'
           commit-message: 'chore(release): prepare release ${{ steps.bump-version.outputs.newTag }}'

--- a/.github/workflows/update-sponsor-block.yml
+++ b/.github/workflows/update-sponsor-block.yml
@@ -46,7 +46,7 @@ jobs:
           echo "$CONTENT"
         if: steps.sponsors-requires-update.outputs.changed == 'true'
       - name: Create pull request
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8
         with:
           branch: sponsors
           delete-branch: true


### PR DESCRIPTION
## Fix: CI/CD Security Vulnerabilities in GitHub Actions

Hi! [Runner Guard](https://github.com/Vigilant-LLC/runner-guard), an open-source
CI/CD security scanner by [Vigilant Cyber Security](https://www.vigilantdefense.com),
identified security vulnerabilities in this repository's GitHub Actions workflows.

This PR applies automated fixes where possible and reports additional findings
for your review.

### Fixes applied (in this PR)

| Rule | Severity | File | Description |
|------|----------|------|-------------|
| RGS-007 | high | `.github/workflows/release-branch.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-002 | high | `.github/workflows/release-branch.yml` | Extracted 2 unsafe expression(s) to env vars |
| RGS-007 | high | `.github/workflows/update-sponsor-block.yml` | Pinned 1 third-party action(s) to commit SHA |


### Advisory: additional findings (manual review recommended)

| Rule | Severity | File | Description |
| RGS-004 | high | `.github/workflows/moderator.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `.github/workflows/moderator.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-005 | medium | `.github/workflows/moderator.yml` | Excessive Permissions on Untrusted Trigger |


### Why this matters

GitHub Actions workflows that use untrusted input in `run:` blocks, expose
secrets inline, or use unpinned third-party actions are vulnerable to
code injection, credential theft, and supply chain attacks. These are the same
vulnerability classes exploited in the [tj-actions/changed-files incident](https://www.vigilantdefense.com/resources/runner-guard)
and subsequent supply chain attacks, which compromised CI secrets across
thousands of repositories.

### How to verify

Review the diff — each change is mechanical and preserves workflow behavior:
- **Expression extraction** (RGS-002/008/014): Moves `${{ }}` expressions from
  `run:` blocks into `env:` mappings, preventing shell injection
- **SHA pinning** (RGS-007): Pins third-party actions to immutable commit SHAs
  (original version tag preserved as comment)
- **Debug env removal** (RGS-015): Removes `ACTIONS_RUNNER_DEBUG`/`ACTIONS_STEP_DEBUG`
  which leak secrets in workflow logs

Run `brew install Vigilant-LLC/tap/runner-guard && runner-guard scan .` or install from the
[repo](https://github.com/Vigilant-LLC/runner-guard) to verify.

---

Found by [Runner Guard](https://github.com/Vigilant-LLC/runner-guard) | Built by [Vigilant Cyber Security](https://www.vigilantdefense.com) | [Learn more](https://www.vigilantdefense.com/resources/runner-guard)

If this PR is not welcome, just close it -- we won't send another.