### PR TITLE
test: add regression coverage for urlencoded Content-Type casing (#7393)

### DIFF
--- a/tests/unit/adapters/http.test.js
+++ b/tests/unit/adapters/http.test.js
@@ -2503,7 +2503,7 @@ describe('supports http with nodejs', () => {
   });
 
   describe('URLEncoded Form', () => {
-    it('should post object data as url-encoded form if content-type is application/x-www-form-urlencoded', async () => {
+    it('should post object data as url-encoded form regardless of content-type header casing', async () => {
       const app = express();
       const obj = {
         arr1: ['1', '2', '3'],
@@ -2530,12 +2530,15 @@ describe('supports http with nodejs', () => {
       );
 
       try {
-        const response = await axios.post(`http://localhost:${server.address().port}/`, obj, {
-          headers: {
-            'content-type': 'application/x-www-form-urlencoded',
-          },
-        });
-        assert.deepStrictEqual(response.data, obj);
+        for (const headerName of ['content-type', 'Content-Type']) {
+          const response = await axios.post(`http://localhost:${server.address().port}/`, obj, {
+            headers: {
+              [headerName]: 'application/x-www-form-urlencoded',
+            },
+          });
+
+          assert.deepStrictEqual(response.data, obj);
+        }
       } finally {
         await new Promise((resolve, reject) => {
           server.close((error) => {


### PR DESCRIPTION
Current `v1.x` already appears to handle this correctly. This PR adds focused regression coverage for `#7393` so automatic `application/x-www-form-urlencoded` serialization stays case-insensitive with respect to the `Content-Type` header name.

This is intentionally test-only and does not include a production change.

Validation:
- `npm ci`
- direct `node -` repro against `./index.js`
- `npx vitest run --project unit tests/unit/adapters/http.test.js -t "regardless of content-type header casing"`
- `npx eslint tests/unit/adapters/http.test.js`
- `npm run build`
- direct `node -` repro against `./dist/node/axios.cjs`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a regression test to ensure `application/x-www-form-urlencoded` auto-serialization is case-insensitive to `Content-Type` header casing in `v1.x`. Test-only; prevents regressions for #7393.

**Description**
- Update `tests/unit/adapters/http.test.js` to loop over both `content-type` and `Content-Type` when posting object data and assert identical results.
- Verifies current behavior is correct; no production changes.

**Testing**
- Modified a single unit test; verified locally with `npx vitest run --project unit tests/unit/adapters/http.test.js -t "regardless of content-type header casing"`.

<sup>Written for commit 0812d44b90fe498b89228e958615617b28365f76. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

