### PR TITLE
test: add unit tests for parseProtocol, speedometer, throttle, and composeSignals helpers

### DIFF
--- a/tests/unit/helpers/composeSignals.test.js
+++ b/tests/unit/helpers/composeSignals.test.js
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import composeSignals from '../../../lib/helpers/composeSignals.js';
+
+describe('helpers::composeSignals', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should return undefined when no signals and no timeout', () => {
+    expect(composeSignals([], 0)).toBeUndefined();
+  });
+
+  it('should return undefined for null signals and no timeout', () => {
+    expect(composeSignals(null, 0)).toBeUndefined();
+  });
+
+  it('should return an AbortSignal when timeout is provided', () => {
+    const signal = composeSignals([], 5000);
+    expect(signal).toBeDefined();
+    expect(signal.aborted).toBe(false);
+  });
+
+  it('should abort after timeout', () => {
+    vi.useFakeTimers();
+
+    const signal = composeSignals([], 100);
+    expect(signal.aborted).toBe(false);
+
+    vi.advanceTimersByTime(100);
+
+    expect(signal.aborted).toBe(true);
+    expect(signal.reason).toBeDefined();
+    expect(signal.reason.code).toBe('ETIMEDOUT');
+    expect(signal.reason.message).toBe('timeout of 100ms exceeded');
+  });
+
+  it('should compose with an external AbortSignal', () => {
+    const controller = new AbortController();
+    const signal = composeSignals([controller.signal], 0);
+
+    expect(signal).toBeDefined();
+    expect(signal.aborted).toBe(false);
+
+    controller.abort();
+
+    expect(signal.aborted).toBe(true);
+  });
+
+  it('should filter out falsy signals', () => {
+    const signal = composeSignals([null, undefined, false], 1000);
+    expect(signal).toBeDefined();
+    expect(signal.aborted).toBe(false);
+  });
+
+  it('should return undefined for all-falsy signals and no timeout', () => {
+    expect(composeSignals([null, undefined, false], 0)).toBeUndefined();
+  });
+
+  it('should have an unsubscribe method on the returned signal', () => {
+    const signal = composeSignals([], 5000);
+    expect(typeof signal.unsubscribe).toBe('function');
+  });
+
+  it('should expose unsubscribe that can be called without error', () => {
+    const signal = composeSignals([], 5000);
+    expect(() => signal.unsubscribe()).not.toThrow();
+  });
+
+  it('should compose multiple abort signals', () => {
+    const controller1 = new AbortController();
+    const controller2 = new AbortController();
+    const signal = composeSignals([controller1.signal, controller2.signal], 0);
+
+    expect(signal.aborted).toBe(false);
+
+    controller2.abort();
+
+    expect(signal.aborted).toBe(true);
+  });
+});

--- a/tests/unit/helpers/parseProtocol.test.js
+++ b/tests/unit/helpers/parseProtocol.test.js
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import parseProtocol from '../../../lib/helpers/parseProtocol.js';
+
+describe('helpers::parseProtocol', () => {
+  it('should parse http protocol', () => {
+    expect(parseProtocol('http://example.com')).toEqual('http');
+  });
+
+  it('should parse https protocol', () => {
+    expect(parseProtocol('https://example.com')).toEqual('https');
+  });
+
+  it('should parse ftp protocol', () => {
+    expect(parseProtocol('ftp://files.example.com')).toEqual('ftp');
+  });
+
+  it('should parse protocols with + character', () => {
+    expect(parseProtocol('coap+tcp://example.com')).toEqual('coap+tcp');
+  });
+
+  it('should parse protocols with - character', () => {
+    expect(parseProtocol('coap-tcp://example.com')).toEqual('coap-tcp');
+  });
+
+  it('should parse data URIs', () => {
+    expect(parseProtocol('data:text/plain;base64,SGVsbG8=')).toEqual('data');
+  });
+
+  it('should parse file protocol', () => {
+    expect(parseProtocol('file:///path/to/file')).toEqual('file');
+  });
+
+  it('should return empty string for URLs without protocol', () => {
+    expect(parseProtocol('/relative/path')).toEqual('');
+  });
+
+  it('should return empty string for empty string', () => {
+    expect(parseProtocol('')).toEqual('');
+  });
+
+  it('should return empty string for protocol-like strings exceeding 25 chars', () => {
+    const longProtocol = 'a'.repeat(26) + '://example.com';
+    expect(parseProtocol(longProtocol)).toEqual('');
+  });
+
+  it('should handle protocol names up to 25 characters', () => {
+    const maxProtocol = 'a'.repeat(25);
+    expect(parseProtocol(maxProtocol + '://example.com')).toEqual(maxProtocol);
+  });
+});

--- a/tests/unit/helpers/speedometer.test.js
+++ b/tests/unit/helpers/speedometer.test.js
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import speedometer from '../../../lib/helpers/speedometer.js';
+
+describe('helpers::speedometer', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should return a function', () => {
+    const speed = speedometer();
+    expect(typeof speed).toBe('function');
+  });
+
+  it('should return undefined before minimum time elapsed', () => {
+    const speed = speedometer(10, 1000);
+    const result = speed(100);
+    expect(result).toBeUndefined();
+  });
+
+  it('should calculate speed after minimum time elapsed', () => {
+    const speed = speedometer(10, 500);
+
+    speed(1000);
+    vi.advanceTimersByTime(600);
+    speed(2000);
+
+    vi.advanceTimersByTime(600);
+    const result = speed(3000);
+
+    expect(result).toBeDefined();
+    expect(typeof result).toBe('number');
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it('should use default samplesCount of 10', () => {
+    const speed = speedometer();
+
+    // Push more than 10 samples to test circular buffer wrapping
+    for (let i = 0; i < 15; i++) {
+      vi.advanceTimersByTime(200);
+      speed(100);
+    }
+
+    // After min time (default 1000ms), should return a value
+    const result = speed(100);
+    expect(result).toBeDefined();
+  });
+
+  it('should use default min of 1000ms', () => {
+    const speed = speedometer(10);
+
+    speed(500);
+    vi.advanceTimersByTime(500);
+    expect(speed(500)).toBeUndefined(); // Still under 1000ms
+
+    vi.advanceTimersByTime(600);
+    const result = speed(500);
+    expect(result).toBeDefined();
+  });
+
+  it('should handle custom min of 0', () => {
+    const speed = speedometer(10, 0);
+
+    speed(1000);
+    vi.advanceTimersByTime(100);
+    // With min=0, but startedAt won't be defined on first call
+    // After second sample with time elapsed, it should work
+    vi.advanceTimersByTime(100);
+    speed(1000);
+
+    vi.advanceTimersByTime(100);
+    const result = speed(1000);
+    expect(result).toBeDefined();
+  });
+
+  it('should return a numeric rate after sufficient samples and time', () => {
+    const speed = speedometer(10, 0);
+
+    speed(1000);
+    vi.advanceTimersByTime(500);
+    speed(1000);
+    vi.advanceTimersByTime(500);
+    const result = speed(1000);
+
+    expect(result).toBeDefined();
+    expect(typeof result).toBe('number');
+    expect(result).toBeGreaterThan(0);
+  });
+});

--- a/tests/unit/helpers/throttle.test.js
+++ b/tests/unit/helpers/throttle.test.js
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import throttle from '../../../lib/helpers/throttle.js';
+
+describe('helpers::throttle', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should return an array with throttled function and flush', () => {
+    const [throttled, flush] = throttle(() => {}, 10);
+    expect(typeof throttled).toBe('function');
+    expect(typeof flush).toBe('function');
+  });
+
+  it('should invoke function immediately on first call', () => {
+    const fn = vi.fn();
+    const [throttled] = throttle(fn, 10);
+
+    throttled('a');
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith('a');
+  });
+
+  it('should throttle subsequent calls within threshold', () => {
+    const fn = vi.fn();
+    const [throttled] = throttle(fn, 10); // 100ms threshold
+
+    throttled('first');
+    throttled('second');
+    throttled('third');
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith('first');
+  });
+
+  it('should invoke with latest args after threshold', () => {
+    const fn = vi.fn();
+    const [throttled] = throttle(fn, 10); // 100ms threshold
+
+    throttled('first');
+    throttled('second');
+    throttled('latest');
+
+    // Advance past threshold
+    vi.advanceTimersByTime(100);
+
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(fn).toHaveBeenLastCalledWith('latest');
+  });
+
+  it('should allow calls after threshold expires', () => {
+    const fn = vi.fn();
+    const [throttled] = throttle(fn, 10); // 100ms threshold
+
+    throttled('first');
+    vi.advanceTimersByTime(100);
+    throttled('second');
+
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(fn).toHaveBeenLastCalledWith('second');
+  });
+
+  it('should flush pending calls', () => {
+    const fn = vi.fn();
+    const [throttled, flush] = throttle(fn, 10);
+
+    throttled('first');
+    throttled('pending');
+
+    flush();
+
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(fn).toHaveBeenLastCalledWith('pending');
+  });
+
+  it('should not flush if no pending calls', () => {
+    const fn = vi.fn();
+    const [throttled, flush] = throttle(fn, 10);
+
+    throttled('first');
+    flush();
+
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('should pass multiple arguments', () => {
+    const fn = vi.fn();
+    const [throttled] = throttle(fn, 10);
+
+    throttled('a', 'b', 'c');
+
+    expect(fn).toHaveBeenCalledWith('a', 'b', 'c');
+  });
+});


### PR DESCRIPTION
## Summary

Adds missing unit test coverage for four helper utilities that had no dedicated tests:

- **`parseProtocol`** — protocol parsing from URLs (http, https, ftp, data URIs, custom protocols, max length boundary)
- **`speedometer`** — data transfer rate calculation using circular buffer (default params, custom min, rate computation)
- **`throttle`** — function throttling decorator (immediate invocation, threshold enforcement, flush, multi-arg passthrough)
- **`composeSignals`** — AbortSignal composition with timeout (timeout abort, external signal forwarding, falsy signal filtering, unsubscribe)

These helpers are used by the core library and fetch adapter but previously had no dedicated unit tests. This brings the tested helper count from 9/32 to 13/32.

## Motivation

While working with the fetch adapter in a project, I noticed these core helpers lacked test coverage. `composeSignals` and `throttle` in particular are critical for request timeout and progress event handling — having tests for them helps catch regressions during future changes.

## Test Details

| Helper | Tests Added | Key Scenarios |
|--------|------------|---------------|
| `parseProtocol` | 11 | http/https/ftp, `+`/`-` chars, data URIs, file protocol, no protocol, empty string, 25-char boundary |
| `speedometer` | 7 | return type, pre-min undefined, post-min calculation, default params, custom min, zero min, rate accuracy |
| `throttle` | 8 | return shape, immediate call, throttling, deferred latest args, threshold expiry, flush, no-op flush, multi-args |
| `composeSignals` | 10 | no signals, null signals, timeout signal, timeout abort, external signal, falsy filtering, unsubscribe |

**Total: 36 new tests, all passing.**

## Testing

```bash
npx vitest run tests/unit/helpers/
# 13 test files, 74 tests — all passing
```

Lint is clean (`npm run lint` passes).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds unit tests for `parseProtocol`, `speedometer`, `throttle`, and `composeSignals` to cover critical paths and edge cases. Improves reliability around timeouts, throttling, and protocol parsing with no production code changes.

- **Description**
  - `parseProtocol`: http/https/ftp, + and -, data/file URIs, no protocol, 25-char limit.
  - `speedometer`: default vs custom min, circular buffer wrap, numeric rate after min elapsed.
  - `throttle`: immediate call, threshold enforcement, latest args after wait, flush, multi-arg passthrough.
  - `composeSignals`: timeout abort with ETIMEDOUT reason, multiple signals, falsy filtering, unsubscribe support.

- **Testing**
  - 4 new test files under `tests/unit/helpers/`; 36 tests added, all passing.
  - Run: `npx vitest run tests/unit/helpers/`.
  - No changes to production code or existing tests; no additional tests needed.

<sup>Written for commit 635af952392de923895ebd6887bfb31490c12076. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

