### PR TITLE
fix: include response data in AxiosError.toJSON() output

### DIFF
--- a/lib/core/AxiosError.js
+++ b/lib/core/AxiosError.js
@@ -69,6 +69,12 @@ class AxiosError extends Error {
       config: utils.toJSONObject(this.config),
       code: this.code,
       status: this.status,
+      response: this.response ? {
+        data: this.response.data,
+        status: this.response.status,
+        statusText: this.response.statusText,
+        headers: utils.toJSONObject(this.response.headers),
+      } : null,
     };
   }
 }

--- a/tests/unit/core/AxiosError.test.js
+++ b/tests/unit/core/AxiosError.test.js
@@ -19,10 +19,8 @@ describe('core::AxiosError', () => {
   });
 
   it('serializes to JSON safely', () => {
-    // request/response are intentionally omitted from the serialized shape
-    // to avoid circular-reference problems.
     const request = { path: '/foo' };
-    const response = { status: 200, data: { foo: 'bar' } };
+    const response = { status: 200, statusText: 'OK', data: { foo: 'bar' }, headers: { 'content-type': 'application/json' } };
     const error = new AxiosError('Boom!', 'ESOMETHING', { foo: 'bar' }, request, response);
     const json = error.toJSON();
 
@@ -31,7 +29,59 @@ describe('core::AxiosError', () => {
     expect(json.code).toBe('ESOMETHING');
     expect(json.status).toBe(200);
     expect(json.request).toBeUndefined();
-    expect(json.response).toBeUndefined();
+    expect(json.response).toEqual({
+      data: { foo: 'bar' },
+      status: 200,
+      statusText: 'OK',
+      headers: { 'content-type': 'application/json' },
+    });
+  });
+
+  it('serializes response as null when no response is present', () => {
+    const error = new AxiosError('Network Error', 'ERR_NETWORK', { foo: 'bar' });
+    const json = error.toJSON();
+
+    expect(json.response).toBeNull();
+  });
+
+  it('serializes response without config or request to avoid circular references', () => {
+    const config = { url: '/test' };
+    const request = { path: '/test' };
+    const response = {
+      data: 'error body',
+      status: 500,
+      statusText: 'Internal Server Error',
+      headers: { 'x-request-id': 'abc123' },
+      config,
+      request,
+    };
+    const error = new AxiosError('Server Error', 'ERR_BAD_RESPONSE', config, request, response);
+    const json = error.toJSON();
+
+    // response should not include config or request (circular reference prevention)
+    expect(json.response.config).toBeUndefined();
+    expect(json.response.request).toBeUndefined();
+    // but should include the useful fields
+    expect(json.response.data).toBe('error body');
+    expect(json.response.status).toBe(500);
+    expect(json.response.statusText).toBe('Internal Server Error');
+    expect(json.response.headers).toEqual({ 'x-request-id': 'abc123' });
+  });
+
+  it('produces JSON.stringify-safe output', () => {
+    const config = { url: '/test' };
+    const request = { path: '/test' };
+    const response = {
+      data: { message: 'Not Found' },
+      status: 404,
+      statusText: 'Not Found',
+      headers: {},
+      config,
+      request,
+    };
+    const error = new AxiosError('Not Found', 'ERR_BAD_REQUEST', config, request, response);
+
+    expect(() => JSON.stringify(error.toJSON())).not.toThrow();
   });
 
   describe('AxiosError.from', () => {


### PR DESCRIPTION
## Summary

`AxiosError.toJSON()` now includes a safe subset of the response object instead of omitting it entirely.

**Before:** `error.toJSON().response` was `undefined` — logging an AxiosError lost all response context.

**After:** `error.toJSON().response` includes `{ data, status, statusText, headers }` — the useful fields for debugging, without circular references.

## Problem

When using structured logging libraries (Pino, Winston, Bunyan), AxiosError's `toJSON()` output was missing the response entirely. This made it difficult to debug API errors from logs without writing custom serializers or interceptor workarounds.

```js
try {
  await axios.get('https://api.example.com/resource');
} catch (error) {
  logger.error(error); // response data was completely lost in the serialized output
}
```

Many users have been working around this with custom interceptors or serializers (see #4836 discussion).

## Solution

Include `data`, `status`, `statusText`, and `headers` from the response in `toJSON()`. Explicitly **exclude** `config` and `request` to prevent the circular reference issue that was the original reason the response was omitted ([reference commit](https://github.com/axios/axios/commit/6b44e80adebf66984b7ad41fd71fcaac28f3fed8)).

When no response is present (e.g., network errors), `response` is `null`.

## Testing

- Updated existing `toJSON` test to verify response inclusion
- Added test for `null` response when no response exists
- Added test verifying `config`/`request` are excluded from serialized response
- Added `JSON.stringify` safety test to confirm no circular reference errors
- All 305 unit tests pass, lint clean

Closes #4836

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a safe subset of the response to `AxiosError.toJSON()` so logs keep useful response details without circular references. Improves debugging with structured loggers like Pino or Winston.

**Description**
- Include `{ data, status, statusText, headers }` under `response`; set to `null` when absent.
- Exclude `config` and `request` to avoid circular refs and keep `JSON.stringify` safe.
- Makes error logs more useful without custom serializers. Addresses #4836.

**Testing**
- Updated `toJSON` tests to verify response inclusion, `null` fallback, and exclusion of `config`/`request`.
- Added `JSON.stringify` safety test.
- All unit tests pass.

<sup>Written for commit f71c3be134f02a1372d96a830c3c0755d178cd72. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

