### PR TITLE
feat: add support for the QUERY HTTP method

### DIFF
--- a/index.d.cts
+++ b/index.d.cts
@@ -220,6 +220,16 @@ declare class Axios {
     data?: D,
     config?: axios.AxiosRequestConfig<D>
   ): Promise<R>;
+  query<T = any, R = axios.AxiosResponse<T>, D = any>(
+    url: string,
+    data?: D,
+    config?: axios.AxiosRequestConfig<D>
+  ): Promise<R>;
+  queryForm<T = any, R = axios.AxiosResponse<T>, D = any>(
+    url: string,
+    data?: D,
+    config?: axios.AxiosRequestConfig<D>
+  ): Promise<R>;
 }
 
 declare enum HttpStatusCode {
@@ -364,7 +374,9 @@ declare namespace axios {
     | 'link'
     | 'LINK'
     | 'unlink'
-    | 'UNLINK';
+    | 'UNLINK'
+    | 'query'
+    | 'QUERY';
 
   type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata';
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -291,7 +291,9 @@ export type Method =
   | "link"
   | "LINK"
   | "unlink"
-  | "UNLINK";
+  | "UNLINK"
+  | "query"
+  | "QUERY";
 
 export type ResponseType =
   | "arraybuffer"
@@ -724,6 +726,16 @@ export class Axios {
     config?: AxiosRequestConfig<D>,
   ): Promise<R>;
   patchForm<T = any, R = AxiosResponse<T>, D = any>(
+    url: string,
+    data?: D,
+    config?: AxiosRequestConfig<D>,
+  ): Promise<R>;
+  query<T = any, R = AxiosResponse<T>, D = any>(
+    url: string,
+    data?: D,
+    config?: AxiosRequestConfig<D>,
+  ): Promise<R>;
+  queryForm<T = any, R = AxiosResponse<T>, D = any>(
     url: string,
     data?: D,
     config?: AxiosRequestConfig<D>,

--- a/lib/core/Axios.js
+++ b/lib/core/Axios.js
@@ -132,7 +132,7 @@ class Axios {
     let contextHeaders = headers && utils.merge(headers.common, headers[config.method]);
 
     headers &&
-      utils.forEach(['delete', 'get', 'head', 'post', 'put', 'patch', 'common'], (method) => {
+      utils.forEach(['delete', 'get', 'head', 'post', 'put', 'patch', 'query', 'common'], (method) => {
         delete headers[method];
       });
 
@@ -235,7 +235,7 @@ utils.forEach(['delete', 'get', 'head', 'options'], function forEachMethodNoData
   };
 });
 
-utils.forEach(['post', 'put', 'patch'], function forEachMethodWithData(method) {
+utils.forEach(['post', 'put', 'patch', 'query'], function forEachMethodWithData(method) {
   function generateHTTPMethod(isForm) {
     return function httpMethod(url, data, config) {
       return this.request(

--- a/lib/core/dispatchRequest.js
+++ b/lib/core/dispatchRequest.js
@@ -39,7 +39,7 @@ export default function dispatchRequest(config) {
   // Transform request data
   config.data = transformData.call(config, config.transformRequest);
 
-  if (['post', 'put', 'patch'].indexOf(config.method) !== -1) {
+  if (['post', 'put', 'patch', 'query'].indexOf(config.method) !== -1) {
     config.headers.setContentType('application/x-www-form-urlencoded', false);
   }
 

--- a/lib/defaults/index.js
+++ b/lib/defaults/index.js
@@ -165,7 +165,7 @@ const defaults = {
   },
 };
 
-utils.forEach(['delete', 'get', 'head', 'post', 'put', 'patch'], (method) => {
+utils.forEach(['delete', 'get', 'head', 'post', 'put', 'patch', 'query'], (method) => {
   defaults.headers[method] = {};
 });
 

--- a/tests/unit/api.test.js
+++ b/tests/unit/api.test.js
@@ -12,6 +12,14 @@ describe('static api', () => {
     assert.strictEqual(typeof axios.post, 'function');
     assert.strictEqual(typeof axios.put, 'function');
     assert.strictEqual(typeof axios.patch, 'function');
+    assert.strictEqual(typeof axios.query, 'function');
+  });
+
+  it('should have request method form helpers', () => {
+    assert.strictEqual(typeof axios.postForm, 'function');
+    assert.strictEqual(typeof axios.putForm, 'function');
+    assert.strictEqual(typeof axios.patchForm, 'function');
+    assert.strictEqual(typeof axios.queryForm, 'function');
   });
 
   it('should have promise method helpers', async () => {
@@ -88,6 +96,7 @@ describe('instance api', () => {
     assert.strictEqual(typeof instance.post, 'function');
     assert.strictEqual(typeof instance.put, 'function');
     assert.strictEqual(typeof instance.patch, 'function');
+    assert.strictEqual(typeof instance.query, 'function');
   });
 
   it('should have interceptors', () => {

--- a/tests/unit/core/query-method.test.js
+++ b/tests/unit/core/query-method.test.js
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import assert from 'assert';
+import axios from '../../../index.js';
+import { startHTTPServer, stopHTTPServer } from '../../setup/server.js';
+
+describe('QUERY HTTP method', () => {
+  it('should have query and queryForm on Axios prototype', () => {
+    const instance = axios.create();
+    expect(typeof instance.query).toBe('function');
+    expect(typeof instance.queryForm).toBe('function');
+  });
+
+  it('should send a QUERY request with a body', async () => {
+    const server = await startHTTPServer(async (req, res) => {
+      res.setHeader('Content-Type', 'application/json');
+      let body = '';
+      for await (const chunk of req) {
+        body += chunk;
+      }
+      res.end(JSON.stringify({
+        method: req.method,
+        body: body || null,
+      }));
+    });
+
+    try {
+      const { data } = await axios.query(`http://localhost:${server.address().port}/`, {
+        filter: 'active',
+      });
+
+      assert.strictEqual(data.method, 'QUERY');
+      assert.ok(data.body, 'QUERY request should include a body');
+      const parsed = JSON.parse(data.body);
+      assert.strictEqual(parsed.filter, 'active');
+    } finally {
+      await stopHTTPServer(server);
+    }
+  });
+
+  it('should set default content-type for query method', async () => {
+    const server = await startHTTPServer(async (req, res) => {
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify({
+        contentType: req.headers['content-type'],
+      }));
+    });
+
+    try {
+      const { data } = await axios.query(`http://localhost:${server.address().port}/`, {
+        key: 'value',
+      });
+
+      // Should have application/json content type (from default transformRequest)
+      assert.ok(
+        data.contentType.includes('application/json'),
+        `Expected application/json but got ${data.contentType}`
+      );
+    } finally {
+      await stopHTTPServer(server);
+    }
+  });
+
+  it('should support queryForm for multipart/form-data', async () => {
+    const server = await startHTTPServer(async (req, res) => {
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify({
+        method: req.method,
+        contentType: req.headers['content-type'],
+      }));
+    });
+
+    try {
+      const { data } = await axios.queryForm(`http://localhost:${server.address().port}/`, {
+        field: 'value',
+      });
+
+      assert.strictEqual(data.method, 'QUERY');
+      assert.ok(
+        data.contentType.includes('multipart/form-data'),
+        `Expected multipart/form-data but got ${data.contentType}`
+      );
+    } finally {
+      await stopHTTPServer(server);
+    }
+  });
+
+  it('should work with axios({ method: "query" }) syntax', async () => {
+    const server = await startHTTPServer(async (req, res) => {
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify({ method: req.method }));
+    });
+
+    try {
+      const { data } = await axios({
+        method: 'query',
+        url: `http://localhost:${server.address().port}/`,
+        data: { search: 'test' },
+      });
+
+      assert.strictEqual(data.method, 'QUERY');
+    } finally {
+      await stopHTTPServer(server);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds `axios.query()` and `axios.queryForm()` as shorthand methods for the [QUERY HTTP method](https://www.ietf.org/archive/id/draft-ietf-httpbis-safe-method-w-body-02.html) (RFC draft-ietf-httpbis-safe-method-w-body).

QUERY is a safe, idempotent method like GET but allows a request body — ideal for complex queries that don't fit in URL parameters.

## Usage

```js
// Send a QUERY request with a JSON body
const { data } = await axios.query('/search', {
  filter: { status: 'active', tags: ['urgent', 'open'] },
  limit: 50,
});

// With multipart/form-data
await axios.queryForm('/search', { filter: 'active' });

// Using generic config
await axios({ method: 'query', url: '/search', data: { q: 'test' } });
```

## Changes

| File | Change |
|------|--------|
| `lib/core/Axios.js` | Add `query` to methods-with-data aliases (generates `query` + `queryForm`) and headers flattening list |
| `lib/core/dispatchRequest.js` | Add `query` to content-type dispatch list |
| `lib/defaults/index.js` | Add `query` to default headers initialization |
| `index.d.ts` | Add `query`/`QUERY` to `Method` type, add `query()`/`queryForm()` to `Axios` class |
| `index.d.cts` | Same TypeScript changes for CJS declarations |
| `tests/unit/api.test.js` | Add `query` and `queryForm` to method existence checks |
| `tests/unit/core/query-method.test.js` | Dedicated test suite for QUERY method |

## Testing

- `axios.query()` sends QUERY request with JSON body
- `axios.queryForm()` sends QUERY request with multipart/form-data
- `axios({ method: 'query' })` generic syntax works
- Content-Type defaults applied correctly
- API existence checks for both static and instance methods
- All 308 unit tests pass, lint clean

Closes #5465

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for the QUERY HTTP method to `axios` via `axios.query()` and `axios.queryForm()`. Enables safe, idempotent requests with a body for complex queries.

**Description**
- Adds `query` to methods-with-data; generates `query`/`queryForm` on static and instance APIs.
- Includes `query` in headers flattening, defaults init, and content-type handling.
- Updates TypeScript types in `index.d.ts` and `index.d.cts` with `'query' | 'QUERY'` and new methods.
- Works with `axios({ method: 'query' })`; no breaking changes.
- Docs: add API reference and examples for `query`/`queryForm`. Closes #5465.

**Testing**
- Added `tests/unit/core/query-method.test.js` for JSON body, `queryForm` multipart, content-type defaults, and generic config path.
- Updated `tests/unit/api.test.js` to check `query` and `queryForm` exist on static and instance APIs.
- All existing tests pass locally.

<sup>Written for commit 8ed320c8517256a9fdd0b466439404dfe7b2eb19. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

