### PR TITLE
fix: pin 2 unpinned action(s), extract 2 unsafe expression(s) to env vars

### DIFF
--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -213,10 +213,12 @@ jobs:
       - name: Bump version with NPM version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_TYPE: ${{ github.event.inputs.type }}
+          INPUT_BETA: ${{ github.event.inputs.beta }}
         id: bump-version
         run: |
-          TYPE=${{ github.event.inputs.type }}
-          BETA=${{ github.event.inputs.beta }}
+          TYPE="${INPUT_TYPE}"
+          BETA="${INPUT_BETA}"
           if [ "$TYPE" = "auto" ]; then
             npm version $(npm version | grep -Eo 'patch|minor|major' | head -1)
           else
@@ -234,7 +236,7 @@ jobs:
       - name: Build project
         run: npm run build
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8
         with:
           branch: 'release'
           commit-message: 'chore(release): prepare release ${{ steps.bump-version.outputs.newTag }}'

--- a/.github/workflows/update-sponsor-block.yml
+++ b/.github/workflows/update-sponsor-block.yml
@@ -46,7 +46,7 @@ jobs:
           echo "$CONTENT"
         if: steps.sponsors-requires-update.outputs.changed == 'true'
       - name: Create pull request
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8
         with:
           branch: sponsors
           delete-branch: true


### PR DESCRIPTION
Re-submission of #10569. Had a problem with my fork and had to delete it, which closed the original PR. Apologies for the noise.

## Summary

This PR pins GitHub Actions to immutable commit SHAs and extracts `workflow_dispatch` input expressions from `run:` blocks into `env:` mappings.

- Pin 2 unpinned actions to full 40-character SHAs
- Extract 2 `workflow_dispatch` inputs from run blocks to env vars

## How to verify

Review the diff, each change is mechanical and preserves workflow behavior:
- **SHA pinning**: `action@v3` becomes `action@abc123 # v3`, original version preserved as comment
- **Expression extraction**: `${{ github.event.inputs.* }}` in `run:` moves to `env:` block, referenced as `"${ENV_VAR}"` in the script
- No workflow logic, triggers, or permissions are modified

I've been researching CI/CD supply chain attack vectors and submitting fixes to affected repos. Based on that research I built a scanner called Runner Guard and open sourced it [here](https://github.com/Vigilant-LLC/runner-guard) so you can scan yourself if you want to. I'll be posting more advisories over the next few weeks [on Twitter](https://x.com/vigilance_one) if you want to stay in the loop.

If you have any questions, reach out. I'll be monitoring comms.

\- Chris (dagecko)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins `peter-evans/create-pull-request` to a specific commit SHA and moves `workflow_dispatch` inputs into `env` to harden CI. Behavior is unchanged.

**Description**
- Summary of changes: Pin 2 uses of `peter-evans/create-pull-request` to a 40‑char SHA (comment notes `v8`); move `github.event.inputs.type` and `github.event.inputs.beta` from `run` into `env` as `INPUT_TYPE`/`INPUT_BETA` and reference them in the script.
- Reasoning: Reduce supply‑chain risk and avoid expression interpolation in shell while preserving current workflow behavior.
- Additional context: No changes to triggers, permissions, or build steps.

**Testing**
- No tests added; workflow-only change.
- Manual checks:
  - Dispatch release workflow with inputs to confirm version bump and PR creation still work.
  - Run sponsors update job to confirm it opens a PR when content changes.

<sup>Written for commit f61ce9dbb1b2c6aac587169d5338a5adbeda855d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

