### PR TITLE
feat: update sponsors script and how this works for more consistency

### DIFF
--- a/.github/workflows/update-sponsor-block.yml
+++ b/.github/workflows/update-sponsor-block.yml
@@ -33,18 +33,26 @@ jobs:
         run: npm ci
       - name: Check if sponsors require updates
         id: sponsors-requires-update
-        run: node ./bin/sponsors.js
+        run: node ./scripts/sponsors/update-readme-sponsors.mjs
+      - name: Check tracked README sponsor diff
+        id: readme-tracked-change
+        run: |
+          if git diff --quiet -- README.md; then
+            echo "readme_changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "readme_changed=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Read sponsors.md file content
         run: |
           echo 'CONTENT<<EOF' >> $GITHUB_ENV
           cat ./temp/sponsors.md >> $GITHUB_ENV
           echo 'EOF' >> $GITHUB_ENV
         shell: bash
-        if: steps.sponsors-requires-update.outputs.changed == 'true'
+        if: steps.sponsors-requires-update.outputs.changed == 'true' && steps.readme-tracked-change.outputs.readme_changed == 'true'
       - name: Echo sponsors content
         run: |
           echo "$CONTENT"
-        if: steps.sponsors-requires-update.outputs.changed == 'true'
+        if: steps.sponsors-requires-update.outputs.changed == 'true' && steps.readme-tracked-change.outputs.readme_changed == 'true'
       - name: Create pull request
         uses: peter-evans/create-pull-request@v8
         with:
@@ -61,4 +69,4 @@ jobs:
             type::automated-pr
           signoff: false
           draft: false
-        if: steps.sponsors-requires-update.outputs.changed == 'true'
+        if: steps.sponsors-requires-update.outputs.changed == 'true' && steps.readme-tracked-change.outputs.readme_changed == 'true'

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ backup/
 dist/
 .vscode/
 docs/
+openspec/

--- a/scripts/sponsors/update-readme-sponsors.mjs
+++ b/scripts/sponsors/update-readme-sponsors.mjs
@@ -1,7 +1,5 @@
 import fs from 'fs/promises';
-import _axios from '../index.js';
-import { exec } from './repo.js';
-import { colorize } from './helpers/colorize.js';
+import _axios from '../../index.js';
 
 const axios = _axios.create({
   headers: {
@@ -27,6 +25,15 @@ const getWithRetry = (url, retries = 3) => {
   return doRequest();
 };
 
+const setGithubOutput = async (key, value) => {
+  if (!process.env.GITHUB_OUTPUT) {
+    console.warn(`GITHUB_OUTPUT is not set; skipping output ${key}=${value}`);
+    return;
+  }
+
+  await fs.appendFile(process.env.GITHUB_OUTPUT, `${key}=${value}\n`);
+};
+
 const updateReadmeSponsors = async (url, path, marker = '<!--<div>marker</div>-->') => {
   let fileContent = (await fs.readFile(path)).toString();
 
@@ -41,14 +48,14 @@ const updateReadmeSponsors = async (url, path, marker = '<!--<div>marker</div>--
     const currentSponsorContent = fileContent.slice(0, index);
 
     if (currentSponsorContent !== sponsorContent) {
-      console.log(colorize()`Sponsor block in [${path}] is outdated`);
+      console.log(`Sponsor block in [${path}] is outdated`);
       await fs.writeFile(path, sponsorContent + readmeContent);
       return sponsorContent;
-    } else {
-      console.log(colorize()`Sponsor block in [${path}] is up to date`);
     }
+
+    console.log(`Sponsor block in [${path}] is up to date`);
   } else {
-    console.warn(colorize()`Can not find marker (${marker}) in ${path} to inject sponsor block`);
+    console.warn(`Can not find marker (${marker}) in ${path} to inject sponsor block`);
   }
 
   return false;
@@ -57,7 +64,7 @@ const updateReadmeSponsors = async (url, path, marker = '<!--<div>marker</div>--
 (async (url) => {
   const newContent = await updateReadmeSponsors(url, './README.md');
 
-  await exec(`echo "changed=${newContent ? 'true' : 'false'}" >> $GITHUB_OUTPUT`);
+  await setGithubOutput('changed', newContent ? 'true' : 'false');
   if (newContent !== false) {
     await fs.mkdir('./temp').catch(() => {});
     await fs.writeFile('./temp/sponsors.md', newContent);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make the sponsors automation more reliable and consistent by only creating PRs when the README sponsor block actually changes and simplifying the update script.

- **Description**
  - Workflow now runs `scripts/sponsors/update-readme-sponsors.mjs` and gates later steps on both `changed` and `readme_changed`.
  - Adds a “Check tracked README sponsor diff” step to skip PRs when no README changes are detected.
  - Replaces shell `exec` with a `setGithubOutput` helper and simplifies logging; updates axios import path to `../../index.js`.
  - Writes updated sponsor content to `./temp/sponsors.md` for PR content.
  - Adds `openspec/` to `.gitignore`.
  - Result: fewer noisy PRs and consistent behavior in CI and local runs.

- **Testing**
  - No tests added. This is a GitHub Actions workflow and script change.
  - Validation done via workflow conditions: only proceeds when both outputs indicate changes.
  - Follow-up (optional): add a small script unit test for `setGithubOutput` using a temp file to ensure outputs append correctly.

<sup>Written for commit 54e7556de768e554aeea55c7321d80b29721ecbb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

