### PR TITLE
docs: fix typos in markdown documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,7 +180,7 @@
 
 ### Bug Fixes
 
-- form-data npm pakcage ([#6970](https://github.com/axios/axios/issues/6970)) ([e72c193](https://github.com/axios/axios/commit/e72c193722530db538b19e5ddaaa4544d226b253))
+- form-data npm package ([#6970](https://github.com/axios/axios/issues/6970)) ([e72c193](https://github.com/axios/axios/commit/e72c193722530db538b19e5ddaaa4544d226b253))
 - prevent RangeError when using large Buffers ([#6961](https://github.com/axios/axios/issues/6961)) ([a2214ca](https://github.com/axios/axios/commit/a2214ca1bc60540baf2c80573cea3a0ff91ba9d1))
 - **types:** resolve type discrepancies between ESM and CJS TypeScript declaration files ([#6956](https://github.com/axios/axios/issues/6956)) ([8517aa1](https://github.com/axios/axios/commit/8517aa16f8d082fc1d5309c642220fa736159110))
 
@@ -1407,7 +1407,7 @@ This functionality is considered as a fix.
 - [Stephen Jennings](https://github.com/jennings)
 - [C.T.Lin](https://github.com/chentsulin)
 - [mia-z](https://github.com/mia-z)
-- [Parth Banathia](https://github.com/Parth0105)
+- [Path Banathia](https://github.com/Parth0105)
 - [parth0105pluang](https://github.com/parth0105pluang)
 - [Marco Weber](https://github.com/mrcwbr)
 - [Luca Pizzini](https://github.com/lpizzinidev)


### PR DESCRIPTION
This PR fixes a few minor typographical errors in the markdown documentation (README, etc.) to improve readability. Found via codespell.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two typos in the changelog to improve readability; no code changes.

## Description

- Summary of changes
  - Corrected "pakcage" → "package" in the bug fixes entry for `form-data`.
  - Updated contributor name "Parth Banathia" → "Path Banathia" (please confirm this is correct).

- Reasoning
  - Minor spelling fixes found via codespell.

- Additional context
  - Docs-only change. No runtime impact.

## Docs

No new docs. This updates `CHANGELOG.md` only.

## Testing

No tests added. Not needed for documentation-only changes.
Please verify the contributor name change is accurate before merging.

<sup>Written for commit 0dff0bb5ae0cc52a2a57ce3842e900bd3d24dc30. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

