### PR TITLE
chore(ci): pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/deprecate.yml
+++ b/.github/workflows/deprecate.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org/

--- a/.github/workflows/moderator.yml
+++ b/.github/workflows/moderator.yml
@@ -16,8 +16,8 @@ jobs:
       models: read
       contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: github/ai-moderator@v1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: github/ai-moderator@81159c370785e295c97461ade67d7c33576e9319 # v1.1.4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           spam-label: 'spam'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 24.x
           cache: npm

--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -26,11 +26,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: true
       - name: Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 24.x
           cache: npm
@@ -47,7 +47,7 @@ jobs:
       - name: Pack npm tarball
         run: npm pack
       - name: Upload npm pack artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: axios-tarball
           path: axios-*.tgz
@@ -64,17 +64,17 @@ jobs:
         node-version: [12, 14, 16, 18]
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: true
       - name: Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
           cache-dependency-path: tests/smoke/cjs/package-lock.json
       - name: Download npm pack artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: axios-tarball
           path: artifacts
@@ -98,17 +98,17 @@ jobs:
         node-version: [20, 22, 24]
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: true
       - name: Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
           cache-dependency-path: tests/smoke/esm/package-lock.json
       - name: Download npm pack artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: axios-tarball
           path: artifacts
@@ -132,17 +132,17 @@ jobs:
         node-version: [12, 14, 16, 18]
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: true
       - name: Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
           cache-dependency-path: tests/module/cjs/package-lock.json
       - name: Download npm pack artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: axios-tarball
           path: artifacts
@@ -166,17 +166,17 @@ jobs:
         node-version: [20, 22, 24]
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: true
       - name: Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
           cache-dependency-path: tests/module/esm/package-lock.json
       - name: Download npm pack artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: axios-tarball
           path: artifacts
@@ -196,11 +196,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 24.x
           cache: npm
@@ -234,7 +234,7 @@ jobs:
       - name: Build project
         run: npm run build
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         with:
           branch: 'release'
           commit-message: 'chore(release): prepare release ${{ steps.bump-version.outputs.newTag }}'

--- a/.github/workflows/run-ci.yml
+++ b/.github/workflows/run-ci.yml
@@ -18,11 +18,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: true
       - name: Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 24.x
           cache: npm
@@ -39,9 +39,9 @@ jobs:
       - name: Pack npm tarball
         run: npm pack
       - name: Dependency Review
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
       - name: Upload npm pack artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: axios-tarball
           path: axios-*.tgz
@@ -58,17 +58,17 @@ jobs:
         node-version: [12, 14, 16, 18]
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: true
       - name: Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
           cache-dependency-path: tests/smoke/cjs/package-lock.json
       - name: Download npm pack artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: axios-tarball
           path: artifacts
@@ -92,17 +92,17 @@ jobs:
         node-version: [20, 22, 24]
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: true
       - name: Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
           cache-dependency-path: tests/smoke/esm/package-lock.json
       - name: Download npm pack artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: axios-tarball
           path: artifacts
@@ -126,17 +126,17 @@ jobs:
         node-version: [12, 14, 16, 18]
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: true
       - name: Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
           cache-dependency-path: tests/module/cjs/package-lock.json
       - name: Download npm pack artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: axios-tarball
           path: artifacts
@@ -160,17 +160,17 @@ jobs:
         node-version: [20, 22, 24]
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: true
       - name: Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
           cache-dependency-path: tests/module/esm/package-lock.json
       - name: Download npm pack artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: axios-tarball
           path: artifacts

--- a/.github/workflows/update-sponsor-block.yml
+++ b/.github/workflows/update-sponsor-block.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - name: git config
@@ -25,7 +25,7 @@ jobs:
           git config user.name "${GITHUB_ACTOR}"
           git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
       - name: Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 24.x
           cache: npm
@@ -54,7 +54,7 @@ jobs:
           echo "$CONTENT"
         if: steps.sponsors-requires-update.outputs.changed == 'true' && steps.readme-tracked-change.outputs.readme_changed == 'true'
       - name: Create pull request
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         with:
           branch: sponsors
           delete-branch: true


### PR DESCRIPTION
Pins all GitHub Action references to commit SHAs.

This is a recommended best-practice in the official GHA [docs](https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions), effectively treating the action as an immutable release. Since tags are mutable, they can be force-pushed with malicious updates in supply-chain attacks (e.g. the recent attack with [Trivy](https://github.com/aquasecurity/trivy/discussions/10425), the `tj-actions/changed-files` [compromise](https://github.com/tj-actions/changed-files/security/advisories/GHSA-mw4p-6x4p-x5m5).

Notes:
- This has no immediately functional change; the resolved action code is identical, just referenced by SHA instead of tag
- Generated with [pinact](https://github.com/suzuki-shunsuke/pinact); version comments can be verified for integrity / correctness with tools like [zizmor](https://github.com/zizmorcore/zizmor)
- Dependabot already updates pinned SHAs and version comments as part of its standard `github-actions` ecosystem PRs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pinned all GitHub Actions in our workflows to immutable commit SHAs to harden CI against tag-based supply-chain attacks. No behavior change; workflows resolve to the same action versions.

**Description**
- Pins third-party actions like `actions/checkout`, `actions/setup-node`, `actions/download-artifact`, `actions/upload-artifact`, `actions/dependency-review-action`, `peter-evans/create-pull-request`, and `github/ai-moderator` to SHAs across all CI workflows.
- Treats actions as immutable releases and prevents tag tampering per GitHub’s security guidance.
- Generated with `pinact`; version comments are kept so Dependabot can update pinned SHAs via the `github-actions` ecosystem.

**Testing**
- No tests added or changed; CI logic and outputs remain the same.
- No new tests needed since this is a security hardening of workflow references only.

<sup>Written for commit 24d0993eda00ec202e766c3ae8e6359bfdcf4888. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

