### PR TITLE
fix(ci): add zizmor scanner and fix workflow security findings

### DIFF
--- a/.github/workflows/moderator.yml
+++ b/.github/workflows/moderator.yml
@@ -17,6 +17,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: github/ai-moderator@81159c370785e295c97461ade67d7c33576e9319 # v1.1.4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,12 +15,14 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 24.x
-          cache: npm
           registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
       - name: Install dependencies
         run: npm ci
       - name: Build project

--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -213,10 +213,12 @@ jobs:
       - name: Bump version with NPM version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_TYPE: ${{ github.event.inputs.type }}
+          INPUT_BETA: ${{ github.event.inputs.beta }}
         id: bump-version
         run: |
-          TYPE=${{ github.event.inputs.type }}
-          BETA=${{ github.event.inputs.beta }}
+          TYPE="${INPUT_TYPE}"
+          BETA="${INPUT_BETA}"
           if [ "$TYPE" = "auto" ]; then
             npm version $(npm version | grep -Eo 'patch|minor|major' | head -1)
           else

--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          persist-credentials: true
+          persist-credentials: false
       - name: Setup node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
@@ -66,7 +66,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          persist-credentials: true
+          persist-credentials: false
       - name: Setup node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
@@ -100,7 +100,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          persist-credentials: true
+          persist-credentials: false
       - name: Setup node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
@@ -134,7 +134,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          persist-credentials: true
+          persist-credentials: false
       - name: Setup node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
@@ -168,7 +168,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          persist-credentials: true
+          persist-credentials: false
       - name: Setup node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:

--- a/.github/workflows/run-ci.yml
+++ b/.github/workflows/run-ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          persist-credentials: true
+          persist-credentials: false
       - name: Setup node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
@@ -60,7 +60,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          persist-credentials: true
+          persist-credentials: false
       - name: Setup node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
@@ -94,7 +94,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          persist-credentials: true
+          persist-credentials: false
       - name: Setup node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
@@ -128,7 +128,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          persist-credentials: true
+          persist-credentials: false
       - name: Setup node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
@@ -162,7 +162,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          persist-credentials: true
+          persist-credentials: false
       - name: Setup node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:

--- a/.github/workflows/update-sponsor-block.yml
+++ b/.github/workflows/update-sponsor-block.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: git config
         run: |
           git config user.name "${GITHUB_ACTOR}"

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,24 @@
+name: GitHub Actions Security Analysis with zizmor
+
+on:
+  push:
+    branches: [v1.x]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
+

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,9 @@
+rules:
+  unpinned-uses:
+    # TODO: pin all action references to commit SHAs
+    disable: true
+
+  excessive-permissions:
+    # TODO: audit and narrow permissions across all workflows
+    disable: true
+

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,8 +1,4 @@
 rules:
-  unpinned-uses:
-    # TODO: pin all action references to commit SHAs
-    disable: true
-
   excessive-permissions:
     # TODO: audit and narrow permissions across all workflows
     disable: true


### PR DESCRIPTION
## Summary

Adds [zizmor](https://github.com/zizmorcore/zizmor) as a GitHub Actions security scanner and fixes the issues it flagged. All fixes are low-risk, zero-cost improvements to CI hygiene.

### Template injection (`deprecate.yml`, `release-branch.yml`)

Routes `${{ github.event.inputs.* }}` through `env:` blocks instead of interpolating directly in `run:` shells. Both workflows are maintainer-only (`workflow_dispatch`), so the practical risk was minimal, but the fix is trivial and eliminates the code smell entirely. See [zizmor's template-injection docs](https://docs.zizmor.sh/audits/github/template-injection/).

### Credential persistence (all workflows)

Sets `persist-credentials: false` on every `actions/checkout` step. Risk here was also low, but there's no reason to leave credentials around when no workflow needs them for post-checkout git operations. `update-sponsor-block.yml` uses `peter-evans/create-pull-request@v8`, which [manages its own credentials](https://github.com/peter-evans/create-pull-request/issues/4228) and does not depend on checkout's. See [zizmor's artipacked docs](https://docs.zizmor.sh/audits/github/artipacked/).

### Continuous scanning (`zizmor.yml`)

New workflow runs zizmor on pushes to `v1.x` and on PRs, uploading SARIF results to GitHub code scanning.

### Exceptions

~~Two~~ One zizmor rule~~s are~~ is disabled in `.github/zizmor.yml` since fixing ~~them~~ it here would add noise:
- ~~`unpinned-uses`: covered separately by #10615; exception can be removed once that merges~~ Removed — addressed by #10627.
- `excessive-permissions`: narrowing permissions to job level requires auditing each job individually; planned as a follow-up

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `zizmor` GitHub Actions security scanning and hardens CI by removing template-injection vectors and disabling checkout credential persistence. No changes to build or release behavior.

## Description

- Summary of changes
  - Added `.github/workflows/zizmor.yml` to run `zizmor` on pushes to `v1.x` and on all PRs, uploading SARIF with job-level `security-events: write` and workflow `permissions: {}`.
  - Added `.github/zizmor.yml` with `excessive-permissions` temporarily disabled.
  - Routed `${{ github.event.inputs.* }}` through `env` in `release-branch.yml` to prevent shell template injection.
  - Set `persist-credentials: false` on all `actions/checkout` steps across workflows.
  - In `publish.yml`, replaced `cache: npm` with `package-manager-cache: false` to avoid unused cache config.

- Reasoning
  - Prevent template injection in `run:` shells.
  - Reduce token exposure by not persisting checkout credentials.

- Additional context
  - `update-sponsor-block.yml` uses `peter-evans/create-pull-request`, which manages its own credentials.
  - We'll re-enable the `excessive-permissions` rule after a permissions audit.

## Docs

- `zizmor` findings appear under Security > Code scanning alerts.
- The scanner runs on PRs and on pushes to `v1.x`.

## Testing

- No application tests; CI-only changes.
- Verified by running workflows via this PR; `workflow_dispatch` inputs in `release-branch.yml` now flow through `env`.
- No additional tests needed.

<sup>Written for commit 18d24a2c846573c58772e3eaa07693d3745d9f63. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

