### PR TITLE
fix: using variable interpolation `${{ in deprecate.yml (yaml.github-...

### DIFF
--- a/.github/workflows/deprecate.yml
+++ b/.github/workflows/deprecate.yml
@@ -24,7 +24,8 @@ jobs:
 
       - name: Deprecate selected version
         run: |
-          echo "Deprecating axios@${{ github.event.inputs.version }}"
-          npm deprecate axios@${{ github.event.inputs.version }} "🚨 SECURITY: compromised dependency (plain-crypto-js). DO NOT USE. Downgrade to 1.13.6"
+          echo "Deprecating axios@$VERSION"
+          npm deprecate "axios@$VERSION" "🚨 SECURITY: compromised dependency (plain-crypto-js). DO NOT USE. Downgrade to 1.13.6"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          VERSION: ${{ github.event.inputs.version }}


### PR DESCRIPTION
## Summary
Fix high severity security issue in `.github/workflows/deprecate.yml`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | yaml.github-actions.security.run-shell-injection.run-shell-injection |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `yaml.github-actions.security.run-shell-injection.run-shell-injection` |
| **File** | `.github/workflows/deprecate.yml:26` |

**Description**: Using variable interpolation `${{...}}` with `github` context data in a `run:` step could allow an attacker to inject their own code into the runner. This would allow them to steal secrets and code. `github` context data can have arbitrary user input and should be treated as untrusted. Instead, use an intermediate environment variable with `env:` to store the data and use the environment variable in the `run:` script. Be sure to use double-quotes the environment variable, like this: "$ENVVAR".

## Changes
- `.github/workflows/deprecate.yml`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] Code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a high-severity shell injection risk in `.github/workflows/deprecate.yml`. Moves `github.event.inputs.version` into a quoted `VERSION` env var and uses it in the `run` step for safer command execution.

## Description

- Summary of changes
  - Set `VERSION: ${{ github.event.inputs.version }}` under `env`.
  - Use `"axios@$VERSION"` in `echo` and `npm deprecate`, with quotes.
- Reasoning
  - Prevents shell injection by not interpolating GitHub context directly in `run:` steps.
- Additional context
  - Addresses rule `yaml.github-actions.security.run-shell-injection.run-shell-injection`.

## Docs

- No user-facing docs. For future workflows, pass inputs via `env` and quote variables in shell scripts.

## Testing

- No unit tests added; this is a CI workflow change.
- Suggested verification:
  - Trigger the workflow with test inputs (including special characters) to ensure safe handling.
  - Confirm security scanners no longer flag the step.

<sup>Written for commit f42b817f6960fe5aa5d33d83bcf171176fb3c95e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

