### PR TITLE
Fixes #10610 Deprecation Warning : url.parse() is deprecated in Node.…

### DIFF
--- a/examples/abort-controller/server.js
+++ b/examples/abort-controller/server.js
@@ -1,8 +1,6 @@
-import url from 'url';
-
 export default function (req, res) {
-  const parsedUrl = url.parse(req.url, true);
-  const delay = parsedUrl.query.delay || 3000;
+  const parsedUrl = new URL(req.url, 'http://localhost');
+  const delay = parsedUrl.searchParams.get('delay') || 3000;
 
   setTimeout(() => {
     res.writeHead(200, {

--- a/examples/abort-controller/server.js
+++ b/examples/abort-controller/server.js
@@ -1,5 +1,12 @@
 export default function (req, res) {
-  const parsedUrl = new URL(req.url, 'http://localhost');
+  let parsedUrl;
+  try {
+    parsedUrl = new URL(req.url, 'http://localhost');
+  } catch {
+    res.writeHead(400, { 'Content-Type': 'text/plain' });
+    res.end('Invalid URL');
+    return;
+  }
   const delay = parsedUrl.searchParams.get('delay') || 3000;
 
   setTimeout(() => {

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -668,7 +668,6 @@ export default isHttpAdapterSupported &&
           protocol + '//' + parsed.hostname + (parsed.port ? ':' + parsed.port : '') + options.path
         );
       }
-
       let transport;
       const isHttpsRequest = isHttps.test(options.protocol);
       options.agent = isHttpsRequest ? config.httpsAgent : config.httpAgent;

--- a/lib/defaults/index.js
+++ b/lib/defaults/index.js
@@ -36,12 +36,7 @@ function stringifySafely(rawValue, parser, encoder) {
 const defaults = {
   transitional: transitionalDefaults,
 
-  // Prefer the native fetch adapter over the http adapter (which uses follow-redirects)
-  // when running in Node.js 18+ where global fetch is available. This avoids the
-  // DEP0169 url.parse() deprecation warning triggered by follow-redirects on Node.js v22+.
-  adapter: (platform.isNode && typeof fetch === 'function')
-    ? ['xhr', 'fetch', 'http']
-    : ['xhr', 'http', 'fetch'],
+  adapter: ['xhr', 'http', 'fetch'],
 
   transformRequest: [
     function transformRequest(data, headers) {

--- a/lib/defaults/index.js
+++ b/lib/defaults/index.js
@@ -36,7 +36,12 @@ function stringifySafely(rawValue, parser, encoder) {
 const defaults = {
   transitional: transitionalDefaults,
 
-  adapter: ['xhr', 'http', 'fetch'],
+  // Prefer the native fetch adapter over the http adapter (which uses follow-redirects)
+  // when running in Node.js 18+ where global fetch is available. This avoids the
+  // DEP0169 url.parse() deprecation warning triggered by follow-redirects on Node.js v22+.
+  adapter: (platform.isNode && typeof fetch === 'function')
+    ? ['xhr', 'fetch', 'http']
+    : ['xhr', 'http', 'fetch'],
 
   transformRequest: [
     function transformRequest(data, headers) {

--- a/sandbox/server.js
+++ b/sandbox/server.js
@@ -1,5 +1,4 @@
 import fs from 'fs';
-import url from 'url';
 import path from 'path';
 import http from 'http';
 
@@ -76,8 +75,8 @@ function handleApiRequest(req, res) {
 function requestHandler(req, res) {
   req.setEncoding('utf8');
 
-  const parsed = url.parse(req.url, true);
-  let pathname = parsed.pathname;
+  const parsed = new URL(req.url, 'http://localhost');
+  const pathname = parsed.pathname;
 
   console.log('[' + new Date() + ']', req.method, pathname);
 

--- a/tests/unit/adapters/http.test.js
+++ b/tests/unit/adapters/http.test.js
@@ -15,7 +15,6 @@ import http from 'http';
 import https from 'https';
 import net from 'net';
 import stream from 'stream';
-import url from 'url';
 import zlib from 'zlib';
 import fs from 'fs';
 import os from 'os';
@@ -492,7 +491,7 @@ describe('supports http with nodejs', () => {
           return;
         }
 
-        var parsed = url.parse(req.url);
+        var parsed = new URL(req.url, 'http://localhost');
         if (parsed.pathname === '/one') {
           res.setHeader('Location', '/two');
           res.statusCode = 302;
@@ -899,7 +898,7 @@ describe('supports http with nodejs', () => {
     const str = Array(100000).join('ж');
     const server = await startHTTPServer(
       (req, res) => {
-        const parsed = url.parse(req.url);
+        const parsed = new URL(req.url, 'http://localhost');
 
         if (parsed.pathname === '/two') {
           res.setHeader('Content-Type', 'text/html; charset=UTF-8');


### PR DESCRIPTION
Fix DEP0169 warning in Node.js 18+ by prioritizing fetch adapter

This pull request fixes the DEP0169 warning caused by follow-redirects using the legacy url.format() API internally when building redirect URLs. Axios uses follow-redirects via the HTTP adapter, which triggers this warning in Node.js 18+.

Solution:

In Node.js 18+ (where platform.isNode is true and global.fetch exists), the adapter priority is updated to ['xhr', 'fetch', 'http'].
This ensures the native fetch adapter is used instead of the HTTP adapter. Since fetch does not rely on follow-redirects, the warning is eliminated.
On older Node.js versions (<18) or in browsers, the original adapter order is preserved, so functionality remains unchanged and backward compatibility is maintained.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #10610 by replacing deprecated `url.parse` with `URL`/`URLSearchParams` in examples, sandbox, and tests. Removes Node v22 deprecation warnings and includes a tiny cleanup in `lib/adapters/http.js` (no behavior change).

## Description
- Replaced `url.parse` with `URL`/`URLSearchParams` in `examples/abort-controller/server.js`, `sandbox/server.js`, and tests.
- Added 400 handling for invalid URLs in `examples/abort-controller/server.js`.
- Minor cleanup in `lib/adapters/http.js` (formatting only).
- Reasoning: Use WHATWG URL API and silence Node v22 deprecation warnings.

## Docs
- No API changes. Update any docs/snippets that use `url.parse` to `URL`/`URLSearchParams`.

## Testing
- Updated `tests/unit/adapters/http.test.js` to use `URL`; behavior unchanged.
- No new tests needed. Run CI on Node v22 to confirm no deprecation warnings.

<sup>Written for commit 6da3bf494298f096e132fd87cb762740727273e4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

