### PR TITLE
Fixes #7494 Fetch Adapter: Content length header is missing in POST request

### DIFF
--- a/lib/adapters/fetch.js
+++ b/lib/adapters/fetch.js
@@ -168,8 +168,6 @@ const factory = (env) => {
 
     responseType = responseType ? (responseType + '').toLowerCase() : 'text';
 
-    // In Node.js environments, set headers that the http adapter sets automatically
-    // but the fetch API does not (User-Agent, Content-Length, Accept-Encoding).
     // Host and Connection are managed by the fetch implementation itself.
     if (platform.isNode) {
       headers.set('User-Agent', 'axios/' + VERSION, false);

--- a/lib/adapters/fetch.js
+++ b/lib/adapters/fetch.js
@@ -11,6 +11,7 @@ import {
 } from '../helpers/progressEventReducer.js';
 import resolveConfig from '../helpers/resolveConfig.js';
 import settle from '../core/settle.js';
+import { VERSION } from '../env/data.js';
 
 const DEFAULT_CHUNK_SIZE = 64 * 1024;
 
@@ -166,6 +167,21 @@ const factory = (env) => {
     let _fetch = envFetch || fetch;
 
     responseType = responseType ? (responseType + '').toLowerCase() : 'text';
+
+    // In Node.js environments, set headers that the http adapter sets automatically
+    // but the fetch API does not (User-Agent, Content-Length, Accept-Encoding).
+    // Host and Connection are managed by the fetch implementation itself.
+    if (platform.isNode) {
+      headers.set('User-Agent', 'axios/' + VERSION, false);
+      headers.set('Accept-Encoding', 'gzip, compress, deflate, br', false);
+
+      if (data != null && !headers.hasContentLength()) {
+        const byteLength = await getBodyLength(data);
+        if (byteLength != null) {
+          headers.setContentLength(byteLength);
+        }
+      }
+    }
 
     let composedSignal = composeSignals(
       [signal, cancelToken && cancelToken.toAbortSignal()],

--- a/lib/adapters/fetch.js
+++ b/lib/adapters/fetch.js
@@ -176,7 +176,20 @@ const factory = (env) => {
       headers.set('Accept-Encoding', 'gzip, compress, deflate, br', false);
 
       if (data != null && !headers.hasContentLength()) {
-        const byteLength = await getBodyLength(data);
+        // Only compute Content-Length for body types that can be safely measured
+        // without consuming the body (FormData and streams cannot be re-read).
+        let byteLength;
+
+        if (utils.isBlob(data)) {
+          byteLength = data.size;
+        } else if (utils.isArrayBufferView(data) || utils.isArrayBuffer(data)) {
+          byteLength = data.byteLength;
+        } else if (utils.isString(data)) {
+          byteLength = (await encodeText(data)).byteLength;
+        } else if (utils.isURLSearchParams(data)) {
+          byteLength = (await encodeText(data + '')).byteLength;
+        }
+
         if (byteLength != null) {
           headers.setContentLength(byteLength);
         }


### PR DESCRIPTION
### Description

Fixes inconsistency between the fetch adapter and the default http adapter in Node.js, where several headers are not automatically included.

Issues #7494

### Problem

When using Axios fetch adapter in Node.js (v1.13.6), the following headers are not automatically set, unlike the default http adapter:

User-Agent
Content-Length
Accept-Encoding
Host
Connection

This leads to inconsistent behavior between adapters and may cause issues with servers that rely on these headers.

### Solution

This PR updates the fetch adapter to align with the default http adapter behavior in Node.js:

Adds User-Agent: axios/<version> if not already provided
Adds Accept-Encoding: gzip, compress, deflate, br if not already provided
Computes and sets Content-Length when possible
### Notes
Host and Connection headers are intentionally not set
These are controlled internally by the fetch implementation
Manually setting them is either ignored or disallowed (forbidden headers)
### Testing
Verified headers are correctly added when using the fetch adapter in Node.js
Confirmed no override occurs if headers are explicitly provided by the user

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the Node.js `fetch` adapter with the Node `http` adapter by auto-setting `User-Agent`, `Accept-Encoding`, and computing `Content-Length` when safe. Fixes #7494 to prevent missing headers in POST requests; no browser changes.

**Description**
- Node-only defaults in `lib/adapters/fetch.js` using `VERSION`.
- Set `User-Agent: axios/<version>` and `Accept-Encoding: gzip, compress, deflate, br` if missing.
- Compute `Content-Length` for measurable bodies (Blob, ArrayBuffer/View, string, URLSearchParams); skip `FormData`/streams.
- Do not override user headers; do not set `Host` or `Connection` (managed by fetch).
- Keeps behavior consistent with the Node `http` adapter.
- Rebased on latest `v1.x`; no behavior change.

**Docs**
- Node-only behavior; consider noting default headers for the `fetch` adapter in Node.
- No changes needed for browsers.

**Testing**
- No tests added.
- Suggested Node tests:
  - Defaults applied when absent; headers not overridden if provided.
  - `Content-Length` set for measurable bodies; skipped for `FormData`/streams.
  - Guard that browser builds do not include these defaults.

<sup>Written for commit c61f3a56f73fb844e1c8fd632cfccd58128241f1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

