### PR TITLE
Fixes #7434 Cannot differentiate between cancellation use cases. Only a generic CanceledError is thrown with no abort reason.

### DIFF
--- a/lib/adapters/fetch.js
+++ b/lib/adapters/fetch.js
@@ -11,6 +11,7 @@ import {
 } from '../helpers/progressEventReducer.js';
 import resolveConfig from '../helpers/resolveConfig.js';
 import settle from '../core/settle.js';
+import { VERSION } from '../env/data.js';
 
 const DEFAULT_CHUNK_SIZE = 64 * 1024;
 
@@ -166,6 +167,21 @@ const factory = (env) => {
     let _fetch = envFetch || fetch;
 
     responseType = responseType ? (responseType + '').toLowerCase() : 'text';
+
+    // In Node.js environments, set headers that the http adapter sets automatically
+    // but the fetch API does not (User-Agent, Content-Length, Accept-Encoding).
+    // Host and Connection are managed by the fetch implementation itself.
+    if (platform.isNode) {
+      headers.set('User-Agent', 'axios/' + VERSION, false);
+      headers.set('Accept-Encoding', 'gzip, compress, deflate, br', false);
+
+      if (data != null && !headers.hasContentLength()) {
+        const byteLength = await getBodyLength(data);
+        if (byteLength != null) {
+          headers.setContentLength(byteLength);
+        }
+      }
+    }
 
     let composedSignal = composeSignals(
       [signal, cancelToken && cancelToken.toAbortSignal()],

--- a/lib/adapters/fetch.js
+++ b/lib/adapters/fetch.js
@@ -1,6 +1,7 @@
 import platform from '../platform/index.js';
 import utils from '../utils.js';
 import AxiosError from '../core/AxiosError.js';
+import CanceledError from '../cancel/CanceledError.js';
 import composeSignals from '../helpers/composeSignals.js';
 import { trackStream } from '../helpers/trackStream.js';
 import AxiosHeaders from '../core/AxiosHeaders.js';
@@ -287,6 +288,21 @@ const factory = (env) => {
       });
     } catch (err) {
       unsubscribe && unsubscribe();
+
+      if (err && err.name === 'AbortError') {
+        // Propagate the abort reason directly if it's already an AxiosError/CanceledError,
+        // otherwise wrap it in a CanceledError preserving the original reason.
+        const reason = composedSignal && composedSignal.reason;
+        if (reason instanceof AxiosError) {
+          throw reason;
+        }
+        throw new CanceledError(
+          reason instanceof Error ? reason.message : (reason != null ? String(reason) : null),
+          config,
+          request,
+          reason
+        );
+      }
 
       if (err && err.name === 'TypeError' && /Load failed|fetch/i.test(err.message)) {
         throw Object.assign(

--- a/lib/adapters/fetch.js
+++ b/lib/adapters/fetch.js
@@ -11,7 +11,6 @@ import {
 } from '../helpers/progressEventReducer.js';
 import resolveConfig from '../helpers/resolveConfig.js';
 import settle from '../core/settle.js';
-import { VERSION } from '../env/data.js';
 
 const DEFAULT_CHUNK_SIZE = 64 * 1024;
 
@@ -167,34 +166,6 @@ const factory = (env) => {
     let _fetch = envFetch || fetch;
 
     responseType = responseType ? (responseType + '').toLowerCase() : 'text';
-
-    // In Node.js environments, set headers that the http adapter sets automatically
-    // but the fetch API does not (User-Agent, Content-Length, Accept-Encoding).
-    // Host and Connection are managed by the fetch implementation itself.
-    if (platform.isNode) {
-      headers.set('User-Agent', 'axios/' + VERSION, false);
-      headers.set('Accept-Encoding', 'gzip, compress, deflate, br', false);
-
-      if (data != null && !headers.hasContentLength()) {
-        // Only compute Content-Length for body types that can be safely measured
-        // without consuming the body (FormData and streams cannot be re-read).
-        let byteLength;
-
-        if (utils.isBlob(data)) {
-          byteLength = data.size;
-        } else if (utils.isArrayBufferView(data) || utils.isArrayBuffer(data)) {
-          byteLength = data.byteLength;
-        } else if (utils.isString(data)) {
-          byteLength = (await encodeText(data)).byteLength;
-        } else if (utils.isURLSearchParams(data)) {
-          byteLength = (await encodeText(data + '')).byteLength;
-        }
-
-        if (byteLength != null) {
-          headers.setContentLength(byteLength);
-        }
-      }
-    }
 
     let composedSignal = composeSignals(
       [signal, cancelToken && cancelToken.toAbortSignal()],

--- a/lib/adapters/fetch.js
+++ b/lib/adapters/fetch.js
@@ -296,11 +296,13 @@ const factory = (env) => {
         if (reason instanceof AxiosError) {
           throw reason;
         }
+        // If reason is a default AbortError (no user-provided reason), use null message
+        const isDefaultAbort = reason instanceof Error && reason.name === 'AbortError';
         throw new CanceledError(
-          reason instanceof Error ? reason.message : (reason != null ? String(reason) : null),
+          isDefaultAbort ? null : (reason instanceof Error ? reason.message : (reason != null ? String(reason) : null)),
           config,
           request,
-          reason
+          isDefaultAbort ? undefined : reason
         );
       }
 

--- a/lib/adapters/fetch.js
+++ b/lib/adapters/fetch.js
@@ -176,7 +176,20 @@ const factory = (env) => {
       headers.set('Accept-Encoding', 'gzip, compress, deflate, br', false);
 
       if (data != null && !headers.hasContentLength()) {
-        const byteLength = await getBodyLength(data);
+        // Only compute Content-Length for body types that can be safely measured
+        // without consuming the body (FormData and streams cannot be re-read).
+        let byteLength;
+
+        if (utils.isBlob(data)) {
+          byteLength = data.size;
+        } else if (utils.isArrayBufferView(data) || utils.isArrayBuffer(data)) {
+          byteLength = data.byteLength;
+        } else if (utils.isString(data)) {
+          byteLength = (await encodeText(data)).byteLength;
+        } else if (utils.isURLSearchParams(data)) {
+          byteLength = (await encodeText(data + '')).byteLength;
+        }
+
         if (byteLength != null) {
           headers.setContentLength(byteLength);
         }

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -369,11 +369,20 @@ export default isHttpAdapterSupported &&
 
       const abortEmitter = new EventEmitter();
 
+      // Returns the user-provided abort reason, or null if it's the default AbortError
+      function resolveAbortReason(signal) {
+        const reason = signal && signal.reason;
+        // Default abort() with no argument sets reason to a DOMException(AbortError) — treat as generic cancel
+        return (reason && !(reason.name === 'AbortError' && reason instanceof DOMException))
+          ? reason
+          : null;
+      }
+
       function abort(reason) {
         try {
-          // If called from signal's abort event, prefer the signal's reason
-          const abortReason = (!reason || reason.type === 'abort') && config.signal && config.signal.reason
-            ? config.signal.reason
+          // If called from signal's abort event, prefer the signal's user-provided reason
+          const abortReason = (!reason || reason.type === 'abort')
+            ? resolveAbortReason(config.signal)
             : (reason && !reason.type ? reason : null);
 
           let err;

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -372,10 +372,8 @@ export default isHttpAdapterSupported &&
       // Returns the user-provided abort reason, or null if it's the default AbortError
       function resolveAbortReason(signal) {
         const reason = signal && signal.reason;
-        // Default abort() with no argument sets reason to a DOMException(AbortError) — treat as generic cancel
-        return (reason && !(reason.name === 'AbortError' && reason instanceof DOMException))
-          ? reason
-          : null;
+        // Default abort() with no argument sets reason to an AbortError — treat as generic cancel
+        return (reason && reason.name !== 'AbortError') ? reason : null;
       }
 
       function abort(reason) {

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -371,10 +371,26 @@ export default isHttpAdapterSupported &&
 
       function abort(reason) {
         try {
-          abortEmitter.emit(
-            'abort',
-            !reason || reason.type ? new CanceledError(null, config, req) : reason
-          );
+          // If called from signal's abort event, read the signal's reason
+          const abortReason = (!reason || reason.type === 'abort') && config.signal && config.signal.reason
+            ? config.signal.reason
+            : reason;
+
+          let err;
+          if (!abortReason || abortReason.type) {
+            err = new CanceledError(null, config, req);
+          } else if (abortReason instanceof Error) {
+            err = abortReason;
+          } else {
+            err = new CanceledError(
+              typeof abortReason === 'string' ? abortReason : null,
+              config,
+              req,
+              abortReason
+            );
+          }
+
+          abortEmitter.emit('abort', err);
         } catch (err) {
           console.warn('emit error', err);
         }

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -371,23 +371,23 @@ export default isHttpAdapterSupported &&
 
       function abort(reason) {
         try {
-          // If called from signal's abort event, read the signal's reason
+          // If called from signal's abort event, prefer the signal's reason
           const abortReason = (!reason || reason.type === 'abort') && config.signal && config.signal.reason
             ? config.signal.reason
-            : reason;
+            : (reason && !reason.type ? reason : null);
 
           let err;
-          if (!abortReason || abortReason.type) {
-            err = new CanceledError(null, config, req);
-          } else if (abortReason instanceof Error) {
+          if (abortReason instanceof Error) {
             err = abortReason;
-          } else {
+          } else if (abortReason != null) {
             err = new CanceledError(
               typeof abortReason === 'string' ? abortReason : null,
               config,
               req,
               abortReason
             );
+          } else {
+            err = new CanceledError(null, config, req);
           }
 
           abortEmitter.emit('abort', err);

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -373,7 +373,7 @@ export default isHttpAdapterSupported &&
       function resolveAbortReason(signal) {
         const reason = signal && signal.reason;
         // Default abort() with no argument sets reason to an AbortError — treat as generic cancel
-        return (reason && reason.name !== 'AbortError') ? reason : null;
+        return (reason != null && reason.name !== 'AbortError') ? reason : null;
       }
 
       function abort(reason) {

--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -190,7 +190,13 @@ export default isXHRAdapterSupported &&
           if (!request) {
             return;
           }
-          reject(!cancel || cancel.type ? new CanceledError(null, config, request) : cancel);
+          // Preserve the abort reason from the signal if available
+          const reason = cancel && cancel.type === 'abort' && _config.signal && _config.signal.reason;
+          reject(
+            reason
+              ? (reason instanceof Error ? reason : new CanceledError(reason instanceof Error ? reason.message : String(reason), config, request, reason))
+              : (!cancel || cancel.type ? new CanceledError(null, config, request) : cancel)
+          );
           request.abort();
           request = null;
         };

--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -194,7 +194,7 @@ export default isXHRAdapterSupported &&
           // Ignore the default AbortError set when abort() is called with no argument.
           const signalReason = _config.signal && _config.signal.reason;
           const abortReason =
-            (signalReason && signalReason.name !== 'AbortError')
+            (signalReason != null && signalReason.name !== 'AbortError')
               ? signalReason
               : (cancel && !cancel.type ? cancel : null);
 

--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -190,13 +190,25 @@ export default isXHRAdapterSupported &&
           if (!request) {
             return;
           }
-          // Preserve the abort reason from the signal if available
-          const reason = cancel && cancel.type === 'abort' && _config.signal && _config.signal.reason;
-          reject(
-            reason
-              ? (reason instanceof Error ? reason : new CanceledError(reason instanceof Error ? reason.message : String(reason), config, request, reason))
-              : (!cancel || cancel.type ? new CanceledError(null, config, request) : cancel)
-          );
+          // Prefer the signal's reason (set via controller.abort(reason)) over the generic cancel event
+          const abortReason = (_config.signal && _config.signal.reason) ||
+            (cancel && !cancel.type && cancel);
+
+          let err;
+          if (abortReason instanceof Error) {
+            err = abortReason;
+          } else if (abortReason != null) {
+            err = new CanceledError(
+              typeof abortReason === 'string' ? abortReason : null,
+              config,
+              request,
+              abortReason
+            );
+          } else {
+            err = new CanceledError(null, config, request);
+          }
+
+          reject(err);
           request.abort();
           request = null;
         };

--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -191,10 +191,10 @@ export default isXHRAdapterSupported &&
             return;
           }
           // Prefer the signal's reason (set via controller.abort(reason)) over the generic cancel event.
-          // Ignore the default DOMException(AbortError) set when abort() is called with no argument.
+          // Ignore the default AbortError set when abort() is called with no argument.
           const signalReason = _config.signal && _config.signal.reason;
           const abortReason =
-            (signalReason && !(signalReason.name === 'AbortError' && signalReason instanceof DOMException))
+            (signalReason && signalReason.name !== 'AbortError')
               ? signalReason
               : (cancel && !cancel.type ? cancel : null);
 

--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -190,9 +190,13 @@ export default isXHRAdapterSupported &&
           if (!request) {
             return;
           }
-          // Prefer the signal's reason (set via controller.abort(reason)) over the generic cancel event
-          const abortReason = (_config.signal && _config.signal.reason) ||
-            (cancel && !cancel.type && cancel);
+          // Prefer the signal's reason (set via controller.abort(reason)) over the generic cancel event.
+          // Ignore the default DOMException(AbortError) set when abort() is called with no argument.
+          const signalReason = _config.signal && _config.signal.reason;
+          const abortReason =
+            (signalReason && !(signalReason.name === 'AbortError' && signalReason instanceof DOMException))
+              ? signalReason
+              : (cancel && !cancel.type ? cancel : null);
 
           let err;
           if (abortReason instanceof Error) {

--- a/lib/cancel/CanceledError.js
+++ b/lib/cancel/CanceledError.js
@@ -9,13 +9,17 @@ class CanceledError extends AxiosError {
    * @param {string=} message The message.
    * @param {Object=} config The config.
    * @param {Object=} request The request.
+   * @param {*=} cause The abort reason or original cause.
    *
    * @returns {CanceledError} The created error.
    */
-  constructor(message, config, request) {
+  constructor(message, config, request, cause) {
     super(message == null ? 'canceled' : message, AxiosError.ERR_CANCELED, config, request);
     this.name = 'CanceledError';
     this.__CANCEL__ = true;
+    if (cause !== undefined) {
+      this.cause = cause;
+    }
   }
 }
 

--- a/lib/helpers/composeSignals.js
+++ b/lib/helpers/composeSignals.js
@@ -15,8 +15,8 @@ const composeSignals = (signals, timeout) => {
         aborted = true;
         unsubscribe();
         const err = reason instanceof Error ? reason : this.reason;
-        // Treat the default DOMException(AbortError) (from abort() with no argument) as no reason
-        const isDefaultAbort = err instanceof DOMException && err.name === 'AbortError';
+        // Treat the default AbortError (from abort() with no argument) as no reason
+        const isDefaultAbort = err instanceof Error && err.name === 'AbortError';
         controller.abort(
           err instanceof AxiosError
             ? err

--- a/lib/helpers/composeSignals.js
+++ b/lib/helpers/composeSignals.js
@@ -15,10 +15,17 @@ const composeSignals = (signals, timeout) => {
         aborted = true;
         unsubscribe();
         const err = reason instanceof Error ? reason : this.reason;
+        // Treat the default DOMException(AbortError) (from abort() with no argument) as no reason
+        const isDefaultAbort = err instanceof DOMException && err.name === 'AbortError';
         controller.abort(
           err instanceof AxiosError
             ? err
-            : new CanceledError(err instanceof Error ? err.message : err)
+            : new CanceledError(
+                isDefaultAbort ? null : (err instanceof Error ? err.message : err),
+                null,
+                null,
+                isDefaultAbort ? undefined : (err instanceof Error ? undefined : err)
+              )
         );
       }
     };

--- a/lib/helpers/composeSignals.js
+++ b/lib/helpers/composeSignals.js
@@ -16,7 +16,7 @@ const composeSignals = (signals, timeout) => {
         unsubscribe();
         const err = reason instanceof Error ? reason : this.reason;
         // Treat the default AbortError (from abort() with no argument) as no reason
-        const isDefaultAbort = err instanceof Error && err.name === 'AbortError';
+        const isDefaultAbort = err == null || (err instanceof Error && err.name === 'AbortError');
         controller.abort(
           err instanceof AxiosError
             ? err


### PR DESCRIPTION
### Description

Fixes an issue where abort reasons provided via AbortController.abort(reason) are not propagated and instead always result in a generic CanceledError.

Closes #7434

### Problem

When using AbortController with Axios, the abort reason passed to controller.abort(reason) is ignored.

**Example:**

controller.abort('TimeoutError');

**Expected:**

The thrown error should contain the provided reason ('TimeoutError')

**Actual:**

Axios always throws a generic CanceledError without the provided reason

This makes it impossible to distinguish between different cancellation scenarios (e.g., timeout vs user cancel).

### Root Cause

In both adapters (xhr.js and http.js), Axios handles an AbortEvent when the signal is triggered.

The existing logic checks cancel.type, which is always 'abort', and creates a new CanceledError without preserving the original abort reason. As a result, config.signal.reason is ignored.

### Solution

This PR updates abort handling to correctly propagate the abort reason:

If config.signal.reason is an Error → throw it directly
If it is a string → create a CanceledError with that message
For any other type → attach it as cause on the CanceledError

So now users can do:
```bash
controller.abort('TimeoutError');
// catch: e.message === 'TimeoutError' ✓

controller.abort(new Error('my reason'));
// catch: e.message === 'my reason' ✓

controller.abort({ code: 'TIMEOUT' });
// catch: e.cause === { code: 'TIMEOUT' } ✓
```
### Benefits
Enables better error handling for different cancellation scenarios
Aligns Axios behavior with standard AbortController expectations
Improves developer experience for timeout and retry logic
### Testing
Verified that abort reasons are preserved across different types (string, Error, object)
Confirmed backward compatibility with existing cancellation handling

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Propagates abort reasons from `AbortController.abort(reason)` across `http`, `xhr`, `fetch`, and composed signals so Axios throws the provided error/message or attaches it as `cause` instead of always emitting a generic `CanceledError`. Fixes #7434 and keeps `abort()` with no argument as a generic cancel.

## Description

- Summary of changes
  - `lib/adapters/http.js`, `lib/adapters/xhr.js`: prefer `signal.reason`; ignore default `AbortError`; if `Error`, rethrow; if string, use as message; else wrap in `CanceledError` with `cause`; fallback to generic cancel.
  - `lib/adapters/fetch.js`: on `AbortError`, read `composedSignal.reason`; rethrow `AxiosError`/`CanceledError` reasons; otherwise create `CanceledError` with message/cause; treat default `AbortError` as generic.
  - `lib/helpers/composeSignals.js`: forward non-default reasons and rethrow `AxiosError` reasons; map default `AbortError` to generic cancel.
  - `lib/cancel/CanceledError.js`: constructor accepts optional `cause` and assigns `this.cause`.

- Reasoning
  - Meets #7434 by preserving abort reasons so apps can distinguish timeout vs user cancel and aligns with standard `AbortController` behavior.

- Additional context
  - Backward compatible: `controller.abort()` (no argument) still yields generic `CanceledError('canceled')`.

## Docs

- Cancellation now preserves `signal.reason`:
  - `abort(new Error('timeout'))` → throws `Error('timeout')`
  - `abort('TimeoutError')` → throws `CanceledError` with message `TimeoutError`
  - `abort({ code: 'TIMEOUT' })` → throws `CanceledError` with `cause: { code: 'TIMEOUT' }`
  - `abort()` → generic `CanceledError('canceled')`
- In the `fetch` adapter, existing `AxiosError`/`CanceledError` reasons are rethrown as-is.

## Testing

- No tests added.
- Recommended tests:
  - `http`, `xhr`, `fetch`: abort with `Error`, string, object, and no reason; assert message/cause and generic fallback.
  - `composeSignals`: forwards non-default reasons and treats default `AbortError` as generic.

<sup>Written for commit a9d1090c42201c086874d11d7205779a368e57bd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

