### PR TITLE
ci: add zizmor and harden v0.x CI

### DIFF
--- a/.github/workflows/run-ci-v0.yml
+++ b/.github/workflows/run-ci-v0.yml
@@ -23,11 +23,11 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          persist-credentials: true
+          persist-credentials: false
       - name: Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
@@ -38,5 +38,5 @@ jobs:
       - name: Run tests
         run: npm run test
       - name: Dependency Review
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
         if: matrix.node-version == '24.x'

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,23 @@
+name: GitHub Actions Security Analysis with zizmor
+
+on:
+  push:
+    branches: [v0.x]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2


### PR DESCRIPTION
## Summary

v0.x counterpart to #10618 and #10627. Adds zizmor and hardens the existing CI workflow, matching the v1.x setup.

`run-ci-v0.yml`: SHA-pins all actions and sets `persist-credentials: false` (was `true`). SHAs can be verified with [pinact](https://github.com/suzuki-shunsuke/pinact) or [zizmor](https://github.com/zizmorcore/zizmor).

`zizmor.yml`: new workflow, copied from v1.x. Runs on pushes to v0.x and on PRs, uploads SARIF to code scanning.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `zizmor` security scanning and hardens v0.x CI by pinning actions and disabling credential persistence. Aligns the v0.x pipeline with v1.x to improve supply-chain security.

- **Description**
  - Added `.github/workflows/zizmor.yml` to scan GitHub Actions on pushes to `v0.x` and all PRs; uploads SARIF to code scanning. Uses top-level `permissions: {}` and grants `security-events: write` only.
  - Hardened `.github/workflows/run-ci-v0.yml`: SHA-pinned `actions/checkout`, `actions/setup-node`, and `actions/dependency-review-action`; set `persist-credentials: false`.
  - Synced with the latest `v0.x` to keep CI config in step.

- **Testing**
  - CI-only changes; validated via workflow runs.
  - Pins can be verified with `pinact` or `zizmor`; no additional tests needed.

<sup>Written for commit f9e132befb71fbad3552c3ed974c618cb2630847. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

