### PR TITLE
ci: add publishing workflow with OIDC and provenance attestations for v0.x

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,31 @@
+name: Publish package to NPM
+
+on:
+  push:
+    tags:
+      - 'v0.*.*'
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: 24.x
+          registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
+      - name: Install dependencies
+        run: npm ci
+      - name: Build project
+        run: npm run build
+      - name: Publish to NPM
+        run: npm publish --provenance --access public --tag old-version


### PR DESCRIPTION
## Summary

Adds `publish.yml` to enable OIDC Trusted Publishing and provenance attestations for v0.x releases.

The v0.x line has never had a CI publish workflow. Every release from v0.28.0 through v0.30.3 was published manually/locally using a npm token.

The workflow is identical to v1.x's `publish.yml` except for the tag pattern (`v0.*.*`) and `--tag old-version`.

## Prior attempts

There was a prior attempt in #7407 that was [deleted](https://github.com/axios/axios/commit/3ddccd3bf478c8aab863f2fdd4a52461849eab45) before it ever ran successfully. The main issues were renaming the workflow file (which breaks Trusted Publisher matching, since npm keys on `(repo, workflow_filename)`), using a tag pattern without the `v` prefix (doesn't match existing tags), and trying to do version bumping and git push-back inside the workflow. This PR avoids all of that by keeping the filename as `publish.yml`, using `v0.*.*` to match existing tag conventions, and doing publish-only with no version manipulation.

## Multi-branch OIDC

npm's Trusted Publisher config has no branch field; it matches on `(repository, workflow_filename, optional_environment)` only. The existing config (owner: `axios`, repo: `axios`, workflow: `publish.yml`) covers this workflow with no changes needed on npmjs.com.

Verified empirically with [`@shaanmajid/npm-multibranch-oidc-test`](https://www.npmjs.com/package/@shaanmajid/npm-multibranch-oidc-test) ([repo](https://github.com/shaanmajid/npm-multibranch-oidc-test)): both a v1.x and v0.x branch published via OIDC with provenance using a single Trusted Publisher entry.

## dist-tag

Publishes with `--tag old-version`. Current state:

```json
{ "latest": "1.14.0", "next": "1.7.0-beta.2", "old-version": "0.30.0" }
```

`old-version` points to 0.30.0 despite 0.30.1, 0.30.2, and 0.30.3 all existing on npm (published manually without `--tag old-version`). This will correct itself on the next v0.x release since the workflow uses `--tag old-version`.

## Maintainer checklist

These should already be done from #10619, but listing for completeness since I can't verify them externally:

### npmjs.com

- [ ] Trusted Publisher configured: org `axios`, repo `axios`, workflow `publish.yml`, environment blank
- [ ] Publishing access set to "Require two-factor authentication and disallow tokens (recommended)"
- [ ] All legacy access tokens revoked
- [ ] 2FA enabled on all accounts with publish access

### GitHub

- [ ] `NPM_TOKEN` secret deleted
- [ ] Repository ruleset restricting `v*.*.*` tag creation (Settings > Rules > Rulesets > New tag ruleset). There are currently no tag rulesets on this repo, so anyone with write access can push a tag and trigger a publish.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `publish.yml` GitHub Actions workflow to enable OIDC Trusted Publishing for v0.x releases. It triggers on `v0.*.*` tags and publishes to `npm` with `--tag old-version` and provenance, replacing manual token-based publishes.

## Description

- Summary of changes
  - Adds `.github/workflows/publish.yml` with `id-token: write`, Node 24, build, and `npm publish --provenance --access public --tag old-version`.
  - Triggers on tags matching `v0.*.*`.
  - Mirrors the v1.x workflow; only differences are tag pattern and dist-tag.

- Reasoning
  - Replaces manual, long-lived token publishing with OIDC Trusted Publishing.
  - Closes the v0.x supply-chain gap exploited in a prior compromise.
  - Keeps workflow publish-only (no version bumping or push-backs) to avoid trust and matching issues.

- Additional context
  - npm Trusted Publisher matches on `(repository, workflow_filename[, environment])`; using `publish.yml` ensures v0.x is covered without new npm config.
  - `old-version` dist-tag will update automatically on the next v0.x release.

## Docs

- Ensure Trusted Publisher exists for org `axios`, repo `axios`, workflow `publish.yml` (no environment).
- Set npm publishing to “require 2FA and disallow tokens”; revoke legacy tokens; ensure maintainers have 2FA.
- Remove `NPM_TOKEN` from repo secrets if present.
- Consider a tag ruleset restricting `v*.*.*` creation.

## Testing

- No unit tests (CI workflow only).
- Multi-branch OIDC behavior validated externally; final verification will occur on the next `v0.*.*` tag.
- Monitor first publish for:
  - npm provenance attached.
  - Dist-tags show the new v0.x version under `old-version`.

<sup>Written for commit 78f565353a5f3e483dd81d89acb68139e951341b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

