### PR TITLE
ci: prevent sponsor block workflow from running on forks

### DIFF
--- a/.github/workflows/update-sponsor-block.yml
+++ b/.github/workflows/update-sponsor-block.yml
@@ -14,6 +14,7 @@ permissions:
 
 jobs:
   sponsors:
+    if: github.repository == 'axios/axios'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
<!-- Instructions

If you would like to add a PR description you may do so or let our AI agent create one, after the creation
you may then edit the file if the AI agent got it wrong.

Please read and follow the instructions before creating and submitting a pull request:

- Create an issue explaining the feature. It could save you some effort in case we don't consider it should be included in axios.
- If you're fixing a bug, try to commit the failing test/s and the code fixing it in different commits.
- Ensure you're following our [contributing guide](https://github.com/axios/axios/blob/main/CONTRIBUTING.md).

**⚠️👆 Delete the instructions before submitting the pull request 👆⚠️**

Describe your pull request here. -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent the Sponsor Block GitHub Actions workflow from running on forks by gating the job to the main `axios/axios` repo. This avoids noisy failures and saves CI minutes.

**Description**
- Add job-level guard: `if: github.repository == 'axios/axios'` in `update-sponsor-block.yml`.
- Reason: forks don’t have required secrets/permissions, causing failed or unnecessary runs.
- Scope: CI-only; no runtime code changes.

**Testing**
- No unit tests added (workflow-only change).
- Expected behavior: on forks, the job is marked “skipped”; on `axios/axios`, it runs normally.
- Manual check: open a fork PR and confirm the workflow shows “skipped”.

<sup>Written for commit e60dd0948e9ae5d72623aa567f6c438bc7ce9c5b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

