### PR TITLE
docs: bun deno changes

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -3,8 +3,8 @@
 layout: home
 
 hero:
-  name: "axios docs"
-  text: "axios is a simple HTTP client for the browser and Node.js"
+  name: 'axios docs'
+  text: 'axios is a simple HTTP client for the browser and Node.js'
   image:
     dark: /logo.svg
     light: /logo-light.svg
@@ -43,6 +43,20 @@ onMounted(() => {
       gap: 10,
       snap: true,
       pagination: false,
+      breakpoints: {
+        1200: {
+          perPage: 4,
+        },
+        960: {
+          perPage: 3,
+        },
+        640: {
+          perPage: 2,
+        },
+        480: {
+          perPage: 1,
+        },
+      },
     }
   ).mount();
 });
@@ -116,12 +130,15 @@ const capitalizeFirstLetter = (word) => {
   border: 1px solid var(--vp-c-gutter) !important;
   text-align: center;
   background-color: var(--card-background-color) !important;
-  width: 11.5rem;
+  width: 100%;
+  max-width: 11.5rem;
   scroll-snap-align: center;
   box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
   flex-shrink: 0 !important;
   margin-bottom: 0.5rem !important;
   margin-top: 0.5rem !important;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .imgWrapper {

--- a/docs/pages/getting-started/features.md
+++ b/docs/pages/getting-started/features.md
@@ -20,6 +20,8 @@ axios supports all modern and select older browsers, including Chrome, Firefox, 
 
 axios also supports a wide range Node.js versions with tested compatibility as far back as v12.x, making it a good choice in environments where upgrading to the latest Node.js version might not be possible or practical.
 
+In addition to Node.js, axios has Bun and Deno smoke tests that validate key runtime behavior and improve confidence in cross-runtime compatibility.
+
 ## Additional features
 
 - Supports the Promise API

--- a/docs/pages/getting-started/first-steps.md
+++ b/docs/pages/getting-started/first-steps.md
@@ -33,7 +33,7 @@ bun add axios
 #### Using deno
 
 ```bash
-deno install axios
+deno install npm:axios
 ```
 
 #### Using jsDelivr

--- a/docs/pages/getting-started/first-steps.md
+++ b/docs/pages/getting-started/first-steps.md
@@ -27,7 +27,13 @@ yarn add axios
 #### Using bun
 
 ```bash
-bun install axios
+bun add axios
+```
+
+#### Using deno
+
+```bash
+deno install axios
 ```
 
 #### Using jsDelivr


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updates the docs to reflect Bun and Deno support and make the homepage carousel responsive. Clarifies install commands and notes cross-runtime smoke tests.

**Description**
- Summary of changes
  - Homepage: added carousel breakpoints (1200/960/640/480); cards are now 100% width with max-width and centered.
  - Getting Started: Bun install uses `bun add axios`; added Deno section with `deno install npm:axios`; features note Bun/Deno smoke tests.
- Reasoning
  - Better mobile UX and clearer cross-runtime setup.
- Additional context
  - Please confirm the Deno command; many projects use `deno add npm:axios` or import via `npm:axios`.

**Testing**
- No tests changed; docs-only update.
- Manual checks
  - Build docs and verify carousel behavior per breakpoints and card centering.
  - Confirm `bun add axios` works.
  - Verify the Deno install/import flow on a recent Deno version.

<sup>Written for commit 2556b7810a63683f9b58c06d6ae381704a2f4ffb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

