### PR TITLE
docs: fix for platinum sponsors

### DIFF
--- a/docs/data/sponsors.json
+++ b/docs/data/sponsors.json
@@ -78,7 +78,7 @@
       "slug": "fjt",
       "website": "https://fujita.dev/?utm_source=axios_docs_website&utm_medium=website&utm_campaign=axios_open_collective_sponsorship",
       "twitter": "https://twitter.com/Yuhei_FUJITA?utm_source=axios_docs_website&utm_medium=website&utm_campaign=axios_open_collective_sponsorship",
-      "active": true
+      "active": false
     },
     {
       "name": "DLTx Labs Pty Ltd",
@@ -138,7 +138,7 @@
       "slug": "andylockran",
       "website": "https://andylockran.dev/?utm_source=axios_docs_website&utm_medium=website&utm_campaign=axios_open_collective_sponsorship",
       "twitter": "https://twitter.com/andylockran?utm_source=axios_docs_website&utm_medium=website&utm_campaign=axios_open_collective_sponsorship",
-      "active": true
+      "active": false
     },
     {
       "name": "kei sakamoto",
@@ -218,7 +218,7 @@
       "slug": "raiderio_wow",
       "website": "https://raider.io/?utm_source=axios_docs_website&utm_medium=website&utm_campaign=axios_open_collective_sponsorship",
       "twitter": "https://twitter.com/RaiderIO_WoW?utm_source=axios_docs_website&utm_medium=website&utm_campaign=axios_open_collective_sponsorship",
-      "active": true
+      "active": false
     },
     {
       "name": "Midtown Rulers",
@@ -268,7 +268,7 @@
       "slug": "mfbtech",
       "website": "https://mfbtech.com/?utm_source=axios_docs_website&utm_medium=website&utm_campaign=axios_open_collective_sponsorship",
       "twitter": "https://twitter.com/mfb_tech?utm_source=axios_docs_website&utm_medium=website&utm_campaign=axios_open_collective_sponsorship",
-      "active": true
+      "active": false
     },
     {
       "name": "Tomasz",
@@ -1335,6 +1335,16 @@
       "active": false
     },
     {
+      "name": "FBPostLikes",
+      "imageUrl": "https://images.opencollective.com/pankaj-jangir/c5dee33/avatar.png",
+      "description": null,
+      "tier": "silver",
+      "slug": "pankaj-jangir",
+      "website": "https://www.fbpostlikes.com/?utm_source=axios_docs_website&utm_medium=website&utm_campaign=axios_open_collective_sponsorship",
+      "twitter": null,
+      "active": true
+    },
+    {
       "name": "iedcdubai",
       "imageUrl": "https://images.opencollective.com/iedcdubai-ae/62ea64d/avatar.png",
       "description": null,
@@ -1585,6 +1595,16 @@
       "active": true
     },
     {
+      "name": "super clone watches",
+      "imageUrl": "https://images.opencollective.com/super-clone-prestige/e681745/logo.png",
+      "description": "Information technology",
+      "tier": "silver",
+      "slug": "super-clone-prestige",
+      "website": "https://finance.yahoo.com/news/best-website-super-clone-watches-073500706.html?utm_source=axios_docs_website&utm_medium=website&utm_campaign=axios_open_collective_sponsorship",
+      "twitter": null,
+      "active": true
+    },
+    {
       "name": "Kasino Kurko: Uudet nettikasinot",
       "imageUrl": "https://images.opencollective.com/kurko-uudetnettikasinot/a293576/logo.png",
       "description": "KasinoKurko on Suomen uusien kasinoiden asiantuntija.",
@@ -1681,6 +1701,16 @@
       "tier": "silver",
       "slug": "chilecasinoonline",
       "website": "https://chilecasinoonline.cl/?utm_source=axios_docs_website&utm_medium=website&utm_campaign=axios_open_collective_sponsorship",
+      "twitter": null,
+      "active": true
+    },
+    {
+      "name": "buzzvoice.com",
+      "imageUrl": "https://images.opencollective.com/buzzvoicecom/c7477dd/logo.png",
+      "description": "Buzzvoice is your one-stop shop for all your social media marketing needs. With Buzzvoice, you can buy followers, comments, likes, video views and more!",
+      "tier": "silver",
+      "slug": "buzzvoicecom",
+      "website": "https://buzzvoice.com/?utm_source=axios_docs_website&utm_medium=website&utm_campaign=axios_open_collective_sponsorship",
       "twitter": null,
       "active": true
     },
@@ -1823,6 +1853,18 @@
       "tier": "gold",
       "slug": "buzzoid-buy-instagram-followers",
       "website": "https://buzzoid.com/buy-instagram-followers/?utm_source=axios_docs_website&utm_medium=website&utm_campaign=axios_open_collective_sponsorship",
+      "twitter": null,
+      "active": true
+    }
+  ],
+  "platinum": [
+    {
+      "name": "Hopper Security",
+      "imageUrl": "https://images.opencollective.com/hopper-security/c4f7de2/avatar.png",
+      "description": null,
+      "tier": "platinum",
+      "slug": "hopper-security",
+      "website": null,
       "twitter": null,
       "active": true
     }

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,10 +61,11 @@ onMounted(() => {
   ).mount();
 });
 
+const activePlatinumSponsors = allSponsors.platinum.filter((sponsor) => sponsor.active);
 const activeGoldSponsors = allSponsors.gold.filter((sponsor) => sponsor.active);
 const activeSilverSponsors = allSponsors.silver.filter((sponsor) => sponsor.active);
 
-const sponsors = [...activeGoldSponsors, ...activeSilverSponsors];
+const sponsors = [...activePlatinumSponsors, ...activeGoldSponsors, ...activeSilverSponsors];
 
 const capitalizeFirstLetter = (word) => {
   return String(word).charAt(0).toUpperCase() + String(word).slice(1);
@@ -176,6 +177,23 @@ const capitalizeFirstLetter = (word) => {
   flex-direction: column;
   flex-grow: 1;
   justify-content: space-between;
+}
+
+.tagSponsorPlatinum {
+  display: inline-flex;
+  padding-top: 0.25rem;
+  padding-bottom: 0.25rem;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  align-items: center;
+  border-radius: 9999px;
+  box-shadow: var(--tw-ring-inset) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  --tw-ring-inset: inset;
+  font-size: 0.75rem;
+  line-height: 1rem;
+  font-weight: 500;
+  color: #000;
+  background-color: #E5E7EB;
 }
 
 .tagSponsorGold {

--- a/docs/pages/misc/sponsors.md
+++ b/docs/pages/misc/sponsors.md
@@ -5,7 +5,7 @@ layout: page
 <script setup>
 import allSponsors from '../../data/sponsors.json';
 
-const sponsors = [...allSponsors.gold, ...allSponsors.silver, ...allSponsors.bronze, ...allSponsors.backer];
+const sponsors = [...allSponsors.platinum, ...allSponsors.gold, ...allSponsors.silver, ...allSponsors.bronze, ...allSponsors.backer];
 
 const capitalizeFirstLetter = (word) => {
   return String(word).charAt(0).toUpperCase() + String(word).slice(1);
@@ -79,6 +79,23 @@ const capitalizeFirstLetter = (word) => {
   text-wrap-style: pretty;
   display: -webkit-box;
   text-align: center;
+}
+
+.tagSponsorPlatinum {
+  display: inline-flex;
+  padding-top: 0.25rem;
+  padding-bottom: 0.25rem;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  align-items: center;
+  border-radius: 9999px;
+  box-shadow: var(--tw-ring-inset) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  --tw-ring-inset: inset;
+  font-size: 0.75rem;
+  line-height: 1rem;
+  font-weight: 500;
+  color: #000;
+  background-color: #E5E7EB;
 }
 
 .tagSponsorGold {

--- a/docs/scripts/process-sponsors.js
+++ b/docs/scripts/process-sponsors.js
@@ -271,6 +271,10 @@ const mainProcess = async () => {
       );
 
       if (!isSponsorInAllSponsors) {
+        if (!sponsorsByTier[sponsor.tier]) {
+          sponsorsByTier[sponsor.tier] ||= [];
+        }
+
         sponsorsByTier[sponsor.tier].push({
           ...sponsor,
           active: true,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a Platinum sponsor tier to the docs, shows it first, and makes the sponsor script handle new tiers safely. Also refreshes sponsor data and adds a Platinum badge.

**Description**
- Added `platinum` tier to `docs/data/sponsors.json`; added a new platinum sponsor, new silver sponsors, and marked some sponsors inactive.
- Updated `docs/index.md` to show active platinum, gold, then silver; added `.tagSponsorPlatinum` style in `docs/index.md` and `docs/pages/misc/sponsors.md`.
- Updated `docs/pages/misc/sponsors.md` to include the platinum tier at the top.
- Made `docs/scripts/process-sponsors.js` initialize missing tier arrays so unknown tiers (e.g., `platinum`) are appended correctly.
- Reasoning: Platinum sponsors were not rendered and new tiers could be dropped by the script; this fixes display, ordering, and data ingestion.

**Testing**
- No automated tests added.
- Manual checks:
  - Build docs and confirm platinum sponsors render before gold/silver with the new badge.
  - Confirm the homepage shows only active sponsors.
  - Run `docs/scripts/process-sponsors.js` and verify it adds sponsors for new tiers without errors.

<sup>Written for commit e473febe4633d2df39b6be6a6bb5ec82f8d7d471. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

