### PR TITLE
ci: gate v0.x publish with npm-publish environment

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: npm-publish
     steps:
       - name: Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Summary

- Add `environment: npm-publish` to the v0.x publish workflow

## Why

Ensures release publishes pass through GitHub Environment protections (required reviewers, deployment branch restrictions, etc.) before publishing to npm.

> ⚠️ Note  : Environment protections significantly raise the bar for unauthorized publishes but are not a complete defense against a fully compromised admin account. Please reach out if more information is required before merging.

## Maintainer setup required

1. Go to **Repository Settings > Environments > New environment**, create `npm-publish`
2. Configure protection rules (specific settings are up to your preference, but here's what I'd recommend):
   - Required reviewers: add at least two trusted maintainers
   - Prevent self-review: enable, so the person who pushes the release tag cannot approve their own publish
   - Deployment branches and tags: select "Selected branches and tags", then add two Tag rules: `v1.*.*` and `v0.*.*`
   - Allow administrators to bypass configured protection rules: disable, otherwise admins can bypass all of the above
3. On **npmjs.com**, update the package's trusted publisher config to include `npm-publish` in the environment field (must match the GitHub environment name exactly)

## Related

Companion PR: #10666 (v1.x). Both PRs should be merged together since the `npm-publish` environment name must be consistent across workflows.