### PR TITLE
fix: support multiselect in form data

### DIFF
--- a/lib/helpers/formDataToJSON.js
+++ b/lib/helpers/formDataToJSON.js
@@ -58,7 +58,9 @@ function formDataToJSON(formData) {
 
     if (isLast) {
       if (utils.hasOwnProp(target, name)) {
-        target[name] = [target[name], value];
+        target[name] = utils.isArray(target[name])
+          ? target[name].concat(value)
+          : [target[name], value];
       } else {
         target[name] = value;
       }

--- a/tests/unit/helpers/formDataToJSON.test.js
+++ b/tests/unit/helpers/formDataToJSON.test.js
@@ -27,6 +27,32 @@ describe('formDataToJSON', () => {
     });
   });
 
+  it('should keep repeatable values flat for 3+ entries', () => {
+    const formData = new FormData();
+
+    formData.append('select3', '301');
+    formData.append('select3', '302');
+    formData.append('select3', '303');
+
+    expect(formDataToJSON(formData)).toEqual({
+      select3: ['301', '302', '303'],
+    });
+  });
+
+  it('should keep nested repeatable values flat for 3+ entries', () => {
+    const formData = new FormData();
+
+    formData.append('foo[bar]', '1');
+    formData.append('foo[bar]', '2');
+    formData.append('foo[bar]', '3');
+
+    expect(formDataToJSON(formData)).toEqual({
+      foo: {
+        bar: ['1', '2', '3'],
+      },
+    });
+  });
+
   it('should convert props with empty brackets to arrays', () => {
     const formData = new FormData();
 


### PR DESCRIPTION
Closes https://github.com/axios/axios/issues/7365

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `formDataToJSON` so repeated `FormData` fields (e.g., multi-selects) serialize into flat arrays instead of creating nested arrays. Works for both top-level and nested keys.

## Description
- Change: when a key already has an array value, append via `concat` instead of wrapping again.
- Reason: repeated values with 3+ entries were producing nested arrays like `[[a, b], c]`.
- Context: supports multi-select inputs and nested paths like `foo[bar]`, while preserving existing array-bracket behavior.

## Testing
- Added two unit tests in `tests/unit/helpers/formDataToJSON.test.js`:
  - Repeated top-level key (3 values) stays flat.
  - Repeated nested key `foo[bar]` (3 values) stays flat.

<sup>Written for commit 6909861286bd1b5f23ae70bfe0eef42fbabde041. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

