### PR TITLE
fix(types): make response headers case insensative

### DIFF
--- a/index.d.cts
+++ b/index.d.cts
@@ -39,6 +39,8 @@ type CommonResponseHeadersList =
   | 'Cache-Control'
   | 'Content-Encoding';
 
+type CommonResponseHeaderKey = CommonResponseHeadersList | Lowercase<CommonResponseHeadersList>;
+
 type BrowserProgressEvent = any;
 
 declare class AxiosHeaders {
@@ -307,7 +309,7 @@ declare namespace axios {
   type AxiosHeaderValue = AxiosHeaders | string | string[] | number | boolean | null;
 
   type RawCommonResponseHeaders = {
-    [Key in CommonResponseHeadersList]: AxiosHeaderValue;
+    [Key in CommonResponseHeaderKey]: AxiosHeaderValue;
   } & {
     'set-cookie': string[];
   };
@@ -345,13 +347,35 @@ declare namespace axios {
     protocol?: string;
   }
 
-  type UppercaseMethod = "GET" | "DELETE" | "HEAD" | "OPTIONS" | "POST" | "PUT" | "PATCH" | "PURGE" | "LINK" | "UNLINK";
+  type UppercaseMethod =
+    | 'GET'
+    | 'DELETE'
+    | 'HEAD'
+    | 'OPTIONS'
+    | 'POST'
+    | 'PUT'
+    | 'PATCH'
+    | 'PURGE'
+    | 'LINK'
+    | 'UNLINK';
 
   type Method = (UppercaseMethod | Lowercase<UppercaseMethod>) & {};
 
   type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata';
 
-  type UppercaseResponseEncoding = "ASCII" | "ANSI" | "BINARY" | "BASE64" | "BASE64URL" | "HEX" | "LATIN1" | "UCS-2" | "UCS2" | "UTF-8" | "UTF8" | "UTF16LE";
+  type UppercaseResponseEncoding =
+    | 'ASCII'
+    | 'ANSI'
+    | 'BINARY'
+    | 'BASE64'
+    | 'BASE64URL'
+    | 'HEX'
+    | 'LATIN1'
+    | 'UCS-2'
+    | 'UCS2'
+    | 'UTF-8'
+    | 'UTF8'
+    | 'UTF16LE';
 
   type responseEncoding = (UppercaseResponseEncoding | Lowercase<UppercaseResponseEncoding>) & {};
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,13 +1,7 @@
 // TypeScript Version: 4.7
 type StringLiteralsOrString<Literals extends string> = Literals | (string & {});
 
-export type AxiosHeaderValue =
-  | AxiosHeaders
-  | string
-  | string[]
-  | number
-  | boolean
-  | null;
+export type AxiosHeaderValue = AxiosHeaders | string | string[] | number | boolean | null;
 
 interface RawAxiosHeaders {
   [key: string]: AxiosHeaderValue;
@@ -24,11 +18,7 @@ type AxiosHeaderMatcher =
   | RegExp
   | ((this: AxiosHeaders, value: string, name: string) => boolean);
 
-type AxiosHeaderParser = (
-  this: AxiosHeaders,
-  value: AxiosHeaderValue,
-  header: string,
-) => any;
+type AxiosHeaderParser = (this: AxiosHeaders, value: AxiosHeaderValue, header: string) => any;
 
 export class AxiosHeaders {
   constructor(headers?: RawAxiosHeaders | AxiosHeaders | string);
@@ -38,12 +28,9 @@ export class AxiosHeaders {
   set(
     headerName?: string,
     value?: AxiosHeaderValue,
-    rewrite?: boolean | AxiosHeaderMatcher,
+    rewrite?: boolean | AxiosHeaderMatcher
   ): AxiosHeaders;
-  set(
-    headers?: RawAxiosHeaders | AxiosHeaders | string,
-    rewrite?: boolean,
-  ): AxiosHeaders;
+  set(headers?: RawAxiosHeaders | AxiosHeaders | string, rewrite?: boolean): AxiosHeaders;
 
   get(headerName: string, parser: RegExp): RegExpExecArray | null;
   get(headerName: string, matcher?: true | AxiosHeaderParser): AxiosHeaderValue;
@@ -57,9 +44,7 @@ export class AxiosHeaders {
   normalize(format: boolean): AxiosHeaders;
 
   concat(
-    ...targets: Array<
-      AxiosHeaders | RawAxiosHeaders | string | undefined | null
-    >
+    ...targets: Array<AxiosHeaders | RawAxiosHeaders | string | undefined | null>
   ): AxiosHeaders;
 
   toJSON(asStrings?: boolean): RawAxiosHeaders;
@@ -69,55 +54,35 @@ export class AxiosHeaders {
   static accessor(header: string | string[]): AxiosHeaders;
 
   static concat(
-    ...targets: Array<
-      AxiosHeaders | RawAxiosHeaders | string | undefined | null
-    >
+    ...targets: Array<AxiosHeaders | RawAxiosHeaders | string | undefined | null>
   ): AxiosHeaders;
 
-  setContentType(
-    value: ContentType,
-    rewrite?: boolean | AxiosHeaderMatcher,
-  ): AxiosHeaders;
+  setContentType(value: ContentType, rewrite?: boolean | AxiosHeaderMatcher): AxiosHeaders;
   getContentType(parser?: RegExp): RegExpExecArray | null;
   getContentType(matcher?: AxiosHeaderMatcher): AxiosHeaderValue;
   hasContentType(matcher?: AxiosHeaderMatcher): boolean;
 
-  setContentLength(
-    value: AxiosHeaderValue,
-    rewrite?: boolean | AxiosHeaderMatcher,
-  ): AxiosHeaders;
+  setContentLength(value: AxiosHeaderValue, rewrite?: boolean | AxiosHeaderMatcher): AxiosHeaders;
   getContentLength(parser?: RegExp): RegExpExecArray | null;
   getContentLength(matcher?: AxiosHeaderMatcher): AxiosHeaderValue;
   hasContentLength(matcher?: AxiosHeaderMatcher): boolean;
 
-  setAccept(
-    value: AxiosHeaderValue,
-    rewrite?: boolean | AxiosHeaderMatcher,
-  ): AxiosHeaders;
+  setAccept(value: AxiosHeaderValue, rewrite?: boolean | AxiosHeaderMatcher): AxiosHeaders;
   getAccept(parser?: RegExp): RegExpExecArray | null;
   getAccept(matcher?: AxiosHeaderMatcher): AxiosHeaderValue;
   hasAccept(matcher?: AxiosHeaderMatcher): boolean;
 
-  setUserAgent(
-    value: AxiosHeaderValue,
-    rewrite?: boolean | AxiosHeaderMatcher,
-  ): AxiosHeaders;
+  setUserAgent(value: AxiosHeaderValue, rewrite?: boolean | AxiosHeaderMatcher): AxiosHeaders;
   getUserAgent(parser?: RegExp): RegExpExecArray | null;
   getUserAgent(matcher?: AxiosHeaderMatcher): AxiosHeaderValue;
   hasUserAgent(matcher?: AxiosHeaderMatcher): boolean;
 
-  setContentEncoding(
-    value: AxiosHeaderValue,
-    rewrite?: boolean | AxiosHeaderMatcher,
-  ): AxiosHeaders;
+  setContentEncoding(value: AxiosHeaderValue, rewrite?: boolean | AxiosHeaderMatcher): AxiosHeaders;
   getContentEncoding(parser?: RegExp): RegExpExecArray | null;
   getContentEncoding(matcher?: AxiosHeaderMatcher): AxiosHeaderValue;
   hasContentEncoding(matcher?: AxiosHeaderMatcher): boolean;
 
-  setAuthorization(
-    value: AxiosHeaderValue,
-    rewrite?: boolean | AxiosHeaderMatcher,
-  ): AxiosHeaders;
+  setAuthorization(value: AxiosHeaderValue, rewrite?: boolean | AxiosHeaderMatcher): AxiosHeaders;
   getAuthorization(parser?: RegExp): RegExpExecArray | null;
   getAuthorization(matcher?: AxiosHeaderMatcher): AxiosHeaderValue;
   hasAuthorization(matcher?: AxiosHeaderMatcher): boolean;
@@ -128,57 +93,53 @@ export class AxiosHeaders {
 }
 
 type CommonRequestHeadersList =
-  | "Accept"
-  | "Content-Length"
-  | "User-Agent"
-  | "Content-Encoding"
-  | "Authorization"
-  | "Location";
+  | 'Accept'
+  | 'Content-Length'
+  | 'User-Agent'
+  | 'Content-Encoding'
+  | 'Authorization'
+  | 'Location';
 
 type ContentType =
   | AxiosHeaderValue
-  | "text/html"
-  | "text/plain"
-  | "multipart/form-data"
-  | "application/json"
-  | "application/x-www-form-urlencoded"
-  | "application/octet-stream";
+  | 'text/html'
+  | 'text/plain'
+  | 'multipart/form-data'
+  | 'application/json'
+  | 'application/x-www-form-urlencoded'
+  | 'application/octet-stream';
 
 export type RawAxiosRequestHeaders = Partial<
   RawAxiosHeaders & {
     [Key in CommonRequestHeadersList]: AxiosHeaderValue;
   } & {
-    "Content-Type": ContentType;
+    'Content-Type': ContentType;
   }
 >;
 
 export type AxiosRequestHeaders = RawAxiosRequestHeaders & AxiosHeaders;
 
 type CommonResponseHeadersList =
-  | "Server"
-  | "Content-Type"
-  | "Content-Length"
-  | "Cache-Control"
-  | "Content-Encoding";
+  | 'Server'
+  | 'Content-Type'
+  | 'Content-Length'
+  | 'Cache-Control'
+  | 'Content-Encoding';
+
+type CommonResponseHeaderKey = CommonResponseHeadersList | Lowercase<CommonResponseHeadersList>;
 
 type RawCommonResponseHeaders = {
-  [Key in CommonResponseHeadersList]: AxiosHeaderValue;
+  [Key in CommonResponseHeaderKey]: AxiosHeaderValue;
 } & {
-  "set-cookie": string[];
+  'set-cookie': string[];
 };
 
-export type RawAxiosResponseHeaders = Partial<
-  RawAxiosHeaders & RawCommonResponseHeaders
->;
+export type RawAxiosResponseHeaders = Partial<RawAxiosHeaders & RawCommonResponseHeaders>;
 
 export type AxiosResponseHeaders = RawAxiosResponseHeaders & AxiosHeaders;
 
 export interface AxiosRequestTransformer {
-  (
-    this: InternalAxiosRequestConfig,
-    data: any,
-    headers: AxiosRequestHeaders,
-  ): any;
+  (this: InternalAxiosRequestConfig, data: any, headers: AxiosRequestHeaders): any;
 }
 
 export interface AxiosResponseTransformer {
@@ -186,7 +147,7 @@ export interface AxiosResponseTransformer {
     this: InternalAxiosRequestConfig,
     data: any,
     headers: AxiosResponseHeaders,
-    status?: number,
+    status?: number
   ): any;
 }
 
@@ -272,22 +233,47 @@ export enum HttpStatusCode {
   NetworkAuthenticationRequired = 511,
 }
 
-type UppercaseMethod = "GET" | "DELETE" | "HEAD" | "OPTIONS" | "POST" | "PUT" | "PATCH" | "PURGE" | "LINK" | "UNLINK";
+type UppercaseMethod =
+  | 'GET'
+  | 'DELETE'
+  | 'HEAD'
+  | 'OPTIONS'
+  | 'POST'
+  | 'PUT'
+  | 'PATCH'
+  | 'PURGE'
+  | 'LINK'
+  | 'UNLINK';
 
 export type Method = (UppercaseMethod | Lowercase<UppercaseMethod>) & {};
 
 export type ResponseType =
-  | "arraybuffer"
-  | "blob"
-  | "document"
-  | "json"
-  | "text"
-  | "stream"
-  | "formdata";
+  | 'arraybuffer'
+  | 'blob'
+  | 'document'
+  | 'json'
+  | 'text'
+  | 'stream'
+  | 'formdata';
 
-type UppercaseResponseEncoding = "ASCII" | "ANSI" | "BINARY" | "BASE64" | "BASE64URL" | "HEX" | "LATIN1" | "UCS-2" | "UCS2" | "UTF-8" | "UTF8" | "UTF16LE";
+type UppercaseResponseEncoding =
+  | 'ASCII'
+  | 'ANSI'
+  | 'BINARY'
+  | 'BASE64'
+  | 'BASE64URL'
+  | 'HEX'
+  | 'LATIN1'
+  | 'UCS-2'
+  | 'UCS2'
+  | 'UTF-8'
+  | 'UTF8'
+  | 'UTF16LE';
 
-export type responseEncoding = (UppercaseResponseEncoding | Lowercase<UppercaseResponseEncoding>) & {};
+export type responseEncoding = (
+  | UppercaseResponseEncoding
+  | Lowercase<UppercaseResponseEncoding>
+) & {};
 
 export interface TransitionalOptions {
   silentJSONParsing?: boolean;
@@ -315,7 +301,7 @@ export interface SerializerVisitor {
     value: any,
     key: string | number,
     path: null | Array<string | number>,
-    helpers: FormDataVisitorHelpers,
+    helpers: FormDataVisitorHelpers
   ): boolean;
 }
 
@@ -363,7 +349,7 @@ export interface AxiosProgressEvent {
 
 type Milliseconds = number;
 
-type AxiosAdapterName = StringLiteralsOrString<"xhr" | "http" | "fetch">;
+type AxiosAdapterName = StringLiteralsOrString<'xhr' | 'http' | 'fetch'>;
 
 type AxiosAdapterConfig = AxiosAdapter | AxiosAdapterName;
 
@@ -408,7 +394,7 @@ export interface AxiosRequestConfig<D = any> {
     responseDetails: {
       headers: Record<string, string>;
       statusCode: HttpStatusCode;
-    },
+    }
   ) => void;
   socketPath?: string | null;
   transport?: any;
@@ -422,24 +408,11 @@ export interface AxiosRequestConfig<D = any> {
   insecureHTTPParser?: boolean;
   env?: {
     FormData?: new (...args: any[]) => object;
-    fetch?: (
-      input: URL | Request | string,
-      init?: RequestInit,
-    ) => Promise<Response>;
-    Request?: new (
-      input: URL | Request | string,
-      init?: RequestInit,
-    ) => Request;
+    fetch?: (input: URL | Request | string, init?: RequestInit) => Promise<Response>;
+    Request?: new (input: URL | Request | string, init?: RequestInit) => Request;
     Response?: new (
-      body?:
-        | ArrayBuffer
-        | ArrayBufferView
-        | Blob
-        | FormData
-        | URLSearchParams
-        | string
-        | null,
-      init?: ResponseInit,
+      body?: ArrayBuffer | ArrayBufferView | Blob | FormData | URLSearchParams | string | null,
+      init?: ResponseInit
     ) => Response;
   };
   formSerializer?: FormSerializerOptions;
@@ -451,26 +424,18 @@ export interface AxiosRequestConfig<D = any> {
         cb: (
           err: Error | null,
           address: LookupAddress | LookupAddress[],
-          family?: AddressFamily,
-        ) => void,
+          family?: AddressFamily
+        ) => void
       ) => void)
     | ((
         hostname: string,
-        options: object,
+        options: object
       ) => Promise<
-        | [
-            address: LookupAddressEntry | LookupAddressEntry[],
-            family?: AddressFamily,
-          ]
-        | LookupAddress
+        [address: LookupAddressEntry | LookupAddressEntry[], family?: AddressFamily] | LookupAddress
       >);
-  withXSRFToken?:
-    | boolean
-    | ((config: InternalAxiosRequestConfig) => boolean | undefined);
+  withXSRFToken?: boolean | ((config: InternalAxiosRequestConfig) => boolean | undefined);
   parseReviver?: (this: any, key: string, value: any) => any;
-  fetchOptions?:
-    | Omit<RequestInit, "body" | "headers" | "method" | "signal">
-    | Record<string, any>;
+  fetchOptions?: Omit<RequestInit, 'body' | 'headers' | 'method' | 'signal'> | Record<string, any>;
   httpVersion?: 1 | 2;
   http2Options?: Record<string, any> & {
     sessionTimeout?: number;
@@ -480,9 +445,7 @@ export interface AxiosRequestConfig<D = any> {
 // Alias
 export type RawAxiosRequestConfig<D = any> = AxiosRequestConfig<D>;
 
-export interface InternalAxiosRequestConfig<
-  D = any,
-> extends AxiosRequestConfig<D> {
+export interface InternalAxiosRequestConfig<D = any> extends AxiosRequestConfig<D> {
   headers: AxiosRequestHeaders;
 }
 
@@ -500,17 +463,11 @@ export interface HeadersDefaults {
   unlink?: RawAxiosRequestHeaders;
 }
 
-export interface AxiosDefaults<D = any> extends Omit<
-  AxiosRequestConfig<D>,
-  "headers"
-> {
+export interface AxiosDefaults<D = any> extends Omit<AxiosRequestConfig<D>, 'headers'> {
   headers: HeadersDefaults;
 }
 
-export interface CreateAxiosDefaults<D = any> extends Omit<
-  AxiosRequestConfig<D>,
-  "headers"
-> {
+export interface CreateAxiosDefaults<D = any> extends Omit<AxiosRequestConfig<D>, 'headers'> {
   headers?: RawAxiosRequestHeaders | AxiosHeaders | Partial<HeadersDefaults>;
 }
 
@@ -529,7 +486,7 @@ export class AxiosError<T = unknown, D = any> extends Error {
     code?: string,
     config?: InternalAxiosRequestConfig<D>,
     request?: any,
-    response?: AxiosResponse<T, D>,
+    response?: AxiosResponse<T, D>
   );
 
   config?: InternalAxiosRequestConfig<D>;
@@ -547,24 +504,24 @@ export class AxiosError<T = unknown, D = any> extends Error {
     config?: InternalAxiosRequestConfig<D>,
     request?: any,
     response?: AxiosResponse<T, D>,
-    customProps?: object,
+    customProps?: object
   ): AxiosError<T, D>;
-  static readonly ERR_FR_TOO_MANY_REDIRECTS = "ERR_FR_TOO_MANY_REDIRECTS";
-  static readonly ERR_BAD_OPTION_VALUE = "ERR_BAD_OPTION_VALUE";
-  static readonly ERR_BAD_OPTION = "ERR_BAD_OPTION";
-  static readonly ERR_NETWORK = "ERR_NETWORK";
-  static readonly ERR_DEPRECATED = "ERR_DEPRECATED";
-  static readonly ERR_BAD_RESPONSE = "ERR_BAD_RESPONSE";
-  static readonly ERR_BAD_REQUEST = "ERR_BAD_REQUEST";
-  static readonly ERR_NOT_SUPPORT = "ERR_NOT_SUPPORT";
-  static readonly ERR_INVALID_URL = "ERR_INVALID_URL";
-  static readonly ERR_CANCELED = "ERR_CANCELED";
-  static readonly ECONNABORTED = "ECONNABORTED";
-  static readonly ETIMEDOUT = "ETIMEDOUT";
+  static readonly ERR_FR_TOO_MANY_REDIRECTS = 'ERR_FR_TOO_MANY_REDIRECTS';
+  static readonly ERR_BAD_OPTION_VALUE = 'ERR_BAD_OPTION_VALUE';
+  static readonly ERR_BAD_OPTION = 'ERR_BAD_OPTION';
+  static readonly ERR_NETWORK = 'ERR_NETWORK';
+  static readonly ERR_DEPRECATED = 'ERR_DEPRECATED';
+  static readonly ERR_BAD_RESPONSE = 'ERR_BAD_RESPONSE';
+  static readonly ERR_BAD_REQUEST = 'ERR_BAD_REQUEST';
+  static readonly ERR_NOT_SUPPORT = 'ERR_NOT_SUPPORT';
+  static readonly ERR_INVALID_URL = 'ERR_INVALID_URL';
+  static readonly ERR_CANCELED = 'ERR_CANCELED';
+  static readonly ECONNABORTED = 'ECONNABORTED';
+  static readonly ETIMEDOUT = 'ETIMEDOUT';
 }
 
 export class CanceledError<T> extends AxiosError<T> {
-  readonly name: "CanceledError";
+  readonly name: 'CanceledError';
 }
 
 export type AxiosPromise<T = any> = Promise<AxiosResponse<T>>;
@@ -608,12 +565,12 @@ type AxiosInterceptorRejected = (error: any) => any;
 type AxiosRequestInterceptorUse<T> = (
   onFulfilled?: AxiosInterceptorFulfilled<T> | null,
   onRejected?: AxiosInterceptorRejected | null,
-  options?: AxiosInterceptorOptions,
+  options?: AxiosInterceptorOptions
 ) => number;
 
 type AxiosResponseInterceptorUse<T> = (
   onFulfilled?: AxiosInterceptorFulfilled<T> | null,
-  onRejected?: AxiosInterceptorRejected | null,
+  onRejected?: AxiosInterceptorRejected | null
 ) => number;
 
 interface AxiosInterceptorHandler<T> {
@@ -624,9 +581,7 @@ interface AxiosInterceptorHandler<T> {
 }
 
 export interface AxiosInterceptorManager<V> {
-  use: V extends AxiosResponse
-    ? AxiosResponseInterceptorUse<V>
-    : AxiosRequestInterceptorUse<V>;
+  use: V extends AxiosResponse ? AxiosResponseInterceptorUse<V> : AxiosRequestInterceptorUse<V>;
   eject(id: number): void;
   clear(): void;
   handlers?: Array<AxiosInterceptorHandler<V>>;
@@ -640,68 +595,61 @@ export class Axios {
     response: AxiosInterceptorManager<AxiosResponse>;
   };
   getUri(config?: AxiosRequestConfig): string;
-  request<T = any, R = AxiosResponse<T>, D = any>(
-    config: AxiosRequestConfig<D>,
-  ): Promise<R>;
+  request<T = any, R = AxiosResponse<T>, D = any>(config: AxiosRequestConfig<D>): Promise<R>;
   get<T = any, R = AxiosResponse<T>, D = any>(
     url: string,
-    config?: AxiosRequestConfig<D>,
+    config?: AxiosRequestConfig<D>
   ): Promise<R>;
   delete<T = any, R = AxiosResponse<T>, D = any>(
     url: string,
-    config?: AxiosRequestConfig<D>,
+    config?: AxiosRequestConfig<D>
   ): Promise<R>;
   head<T = any, R = AxiosResponse<T>, D = any>(
     url: string,
-    config?: AxiosRequestConfig<D>,
+    config?: AxiosRequestConfig<D>
   ): Promise<R>;
   options<T = any, R = AxiosResponse<T>, D = any>(
     url: string,
-    config?: AxiosRequestConfig<D>,
+    config?: AxiosRequestConfig<D>
   ): Promise<R>;
   post<T = any, R = AxiosResponse<T>, D = any>(
     url: string,
     data?: D,
-    config?: AxiosRequestConfig<D>,
+    config?: AxiosRequestConfig<D>
   ): Promise<R>;
   put<T = any, R = AxiosResponse<T>, D = any>(
     url: string,
     data?: D,
-    config?: AxiosRequestConfig<D>,
+    config?: AxiosRequestConfig<D>
   ): Promise<R>;
   patch<T = any, R = AxiosResponse<T>, D = any>(
     url: string,
     data?: D,
-    config?: AxiosRequestConfig<D>,
+    config?: AxiosRequestConfig<D>
   ): Promise<R>;
   postForm<T = any, R = AxiosResponse<T>, D = any>(
     url: string,
     data?: D,
-    config?: AxiosRequestConfig<D>,
+    config?: AxiosRequestConfig<D>
   ): Promise<R>;
   putForm<T = any, R = AxiosResponse<T>, D = any>(
     url: string,
     data?: D,
-    config?: AxiosRequestConfig<D>,
+    config?: AxiosRequestConfig<D>
   ): Promise<R>;
   patchForm<T = any, R = AxiosResponse<T>, D = any>(
     url: string,
     data?: D,
-    config?: AxiosRequestConfig<D>,
+    config?: AxiosRequestConfig<D>
   ): Promise<R>;
 }
 
 export interface AxiosInstance extends Axios {
-  <T = any, R = AxiosResponse<T>, D = any>(
-    config: AxiosRequestConfig<D>,
-  ): Promise<R>;
-  <T = any, R = AxiosResponse<T>, D = any>(
-    url: string,
-    config?: AxiosRequestConfig<D>,
-  ): Promise<R>;
+  <T = any, R = AxiosResponse<T>, D = any>(config: AxiosRequestConfig<D>): Promise<R>;
+  <T = any, R = AxiosResponse<T>, D = any>(url: string, config?: AxiosRequestConfig<D>): Promise<R>;
 
   create(config?: CreateAxiosDefaults): AxiosInstance;
-  defaults: Omit<AxiosDefaults, "headers"> & {
+  defaults: Omit<AxiosDefaults, 'headers'> & {
     headers: HeadersDefaults & {
       [key: string]: AxiosHeaderValue;
     };
@@ -719,22 +667,18 @@ export interface GenericHTMLFormElement {
 }
 
 export function getAdapter(
-  adapters: AxiosAdapterConfig | AxiosAdapterConfig[] | undefined,
+  adapters: AxiosAdapterConfig | AxiosAdapterConfig[] | undefined
 ): AxiosAdapter;
 
 export function toFormData(
   sourceObj: object,
   targetFormData?: GenericFormData,
-  options?: FormSerializerOptions,
+  options?: FormSerializerOptions
 ): GenericFormData;
 
-export function formToJSON(
-  form: GenericFormData | GenericHTMLFormElement,
-): object;
+export function formToJSON(form: GenericFormData | GenericHTMLFormElement): object;
 
-export function isAxiosError<T = any, D = any>(
-  payload: any,
-): payload is AxiosError<T, D>;
+export function isAxiosError<T = any, D = any>(payload: any): payload is AxiosError<T, D>;
 
 export function spread<T, R>(callback: (...args: T[]) => R): (array: T[]) => R;
 
@@ -744,7 +688,7 @@ export function all<T>(values: Array<T | Promise<T>>): Promise<T[]>;
 
 export function mergeConfig<D = any>(
   config1: AxiosRequestConfig<D>,
-  config2: AxiosRequestConfig<D>,
+  config2: AxiosRequestConfig<D>
 ): AxiosRequestConfig<D>;
 
 export interface AxiosStatic extends AxiosInstance {


### PR DESCRIPTION
Closes: https://github.com/axios/axios/issues/6677

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `axios` response header types case-insensitive so both uppercase and lowercase common header keys work without TS errors. Addresses issue #6677 and aligns with `AxiosHeaders` behavior.

## Description

- Summary of changes
  - Added `CommonResponseHeaderKey = CommonResponseHeadersList | Lowercase<CommonResponseHeadersList>`.
  - Updated `RawCommonResponseHeaders` to use `CommonResponseHeaderKey`.
  - Applied the change in both `index.d.ts` and `index.d.cts`.
  - Merged `v1.x` formatting updates (quote normalization, condensed signatures); no runtime changes.
- Reasoning
  - Match HTTP’s case-insensitive headers and fix TS access for keys like `response.headers['content-type']`.
- Additional context
  - Resolves #6677.

## Docs

- Clarify that common response headers can be accessed in either case (e.g., `Content-Type` or `content-type`).
- No migration needed.

## Testing

- No tests added.
- Recommend dtslint/TS checks to validate both `response.headers['Content-Type']` and `response.headers['content-type']` are accepted.

<sup>Written for commit a2bc503c91fe1a530ef75ef27d91e5045cda7044. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

