### PR TITLE
fix(types): constrain AxiosHeaders index signature from any to AxiosHeaderValue (closes #7487)

### DIFF
--- a/index.d.cts
+++ b/index.d.cts
@@ -46,7 +46,7 @@ type BrowserProgressEvent = any;
 declare class AxiosHeaders {
   constructor(headers?: RawAxiosHeaders | AxiosHeaders | string);
 
-  [key: string]: any;
+  [key: string]: axios.AxiosHeaderValue | ((...args: any[]) => any);
 
   set(
     headerName?: string,

--- a/index.d.ts
+++ b/index.d.ts
@@ -23,7 +23,7 @@ type AxiosHeaderParser = (this: AxiosHeaders, value: AxiosHeaderValue, header: s
 export class AxiosHeaders {
   constructor(headers?: RawAxiosHeaders | AxiosHeaders | string);
 
-  [key: string]: any;
+  [key: string]: AxiosHeaderValue | ((...args: any[]) => any);
 
   set(
     headerName?: string,


### PR DESCRIPTION
## Summary
- Changes `[key: string]: any` to `[key: string]: AxiosHeaderValue | ((...args: any[]) => any)` in AxiosHeaders class
- Updated in both `index.d.ts` and `index.d.cts`
- Prevents invalid assignments (Promise, plain objects, etc.) while keeping class methods compatible

## Before / After

```typescript
// BEFORE: silently accepted (runtime bug)
config.headers.someCustomHeader = Promise.resolve('foo'); // no error

// AFTER: TypeScript catches it at compile time
config.headers.someCustomHeader = Promise.resolve('foo'); // TS error!

// Valid assignments still work fine
config.headers.someCustomHeader = 'Bearer token';  // OK
config.headers.someCustomHeader = 123;              // OK
config.headers.someCustomHeader = true;             // OK
```

## Context
Issue #7487 reported that the `[key: string]: any` index signature on `AxiosHeaders` defeats TypeScript's type safety, allowing invalid values like Promises to be silently assigned to headers.

The `((...args: any[]) => any)` part of the union is required because TypeScript index signatures must be compatible with all class members, including methods.

## Test plan
- [ ] `npx tsc --noEmit index.d.ts` passes with zero errors
- [ ] `@ts-expect-error` on `headers['X'] = Promise.resolve('foo')` is consumed (error detected)
- [ ] `@ts-expect-error` on `headers['X'] = { obj: true }` is consumed (error detected)
- [ ] Valid assignments (`string`, `number`, `boolean`, `null`) compile without error
- [ ] All existing tests pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightens the `AxiosHeaders` index signature from `any` to `AxiosHeaderValue | ((...args: any[]) => any)` to catch invalid header assignments at compile time. Fixes the type-safety issue reported in #7487 without changing runtime behavior.

**Description**
- Summary of changes
  - Replaced `[key: string]: any` with `[key: string]: AxiosHeaderValue | ((...args: any[]) => any)` in `index.d.ts` and `index.d.cts`.
- Reasoning
  - Prevents assigning invalid types (e.g., `Promise`, plain objects) to headers while keeping method compatibility required by TypeScript index signatures.
- Additional context
  - Type-only change for TypeScript users; valid primitives (`string`, `number`, `boolean`, `null`) remain allowed.

**Docs**
- Update type docs/examples to reflect accepted header value types and that non-primitive values (e.g., `Promise`, objects) are rejected by TypeScript.

**Testing**
- No runtime tests needed; typings change only.
- Add/adjust TS type tests:
  - Errors: `headers['X'] = Promise.resolve('foo')`, `headers['X'] = { foo: true }`.
  - OK: `headers['X'] = 'Bearer token' | 123 | true | null`.
- Verify `tsc --noEmit` passes.

<sup>Written for commit 5078f174a6d5ae990459592f2b7de6b025be0521. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

