### PR TITLE
fix(types): replace ProgressEvent with AxiosProgressEvent to avoid DOM dependency (closes #6516)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -84,6 +84,18 @@ export interface TransitionalOptions {
   clarifyTimeoutError?: boolean;
 }
 
+export interface AxiosProgressEvent {
+  loaded: number;
+  total?: number;
+  progress?: number;
+  bytes: number;
+  rate?: number;
+  estimated?: number;
+  upload?: boolean;
+  download?: boolean;
+  event?: any;
+}
+
 export interface GenericAbortSignal {
   aborted: boolean;
   onabort: ((...args: any) => any) | null;
@@ -151,8 +163,8 @@ export interface AxiosRequestConfig<D = any> {
   responseEncoding?: responseEncoding | string;
   xsrfCookieName?: string;
   xsrfHeaderName?: string;
-  onUploadProgress?: (progressEvent: ProgressEvent) => void;
-  onDownloadProgress?: (progressEvent: ProgressEvent) => void;
+  onUploadProgress?: (progressEvent: AxiosProgressEvent) => void;
+  onDownloadProgress?: (progressEvent: AxiosProgressEvent) => void;
   maxContentLength?: number;
   validateStatus?: ((status: number) => boolean) | null;
   maxBodyLength?: number;


### PR DESCRIPTION
## Summary
- Defines a custom `AxiosProgressEvent` interface in `index.d.ts`
- Replaces `ProgressEvent` (DOM type) with `AxiosProgressEvent` in `onUploadProgress` and `onDownloadProgress` callbacks
- Aligns v0.x typings with the approach already used in v1.x

## Problem
TypeScript projects targeting Node.js without `"dom"` in their `tsconfig.json` `lib` array get:
```
error TS2304: Cannot find name 'ProgressEvent'.
```

## Solution
Define `AxiosProgressEvent` with the relevant progress properties (`loaded`, `total`, `progress`, `bytes`, `rate`, `estimated`, `upload`, `download`, `event`) instead of depending on the browser's `ProgressEvent` type.

## Test plan
- [ ] `npx tsc --noEmit --strict --lib es2017 test.ts` compiles without errors (no DOM lib needed)
- [ ] `AxiosProgressEvent` provides meaningful type information for progress callbacks
- [ ] No breaking changes for existing users (superset of commonly used properties)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces DOM `ProgressEvent` with a new `AxiosProgressEvent` type in `index.d.ts` to remove the DOM lib requirement for Node.js TypeScript projects. Aligns v0.x typings with v1.x and fixes TS2304 when `dom` is not in `lib`.

**Description**
- Summary of changes
  - Added `AxiosProgressEvent` interface with progress fields.
  - Updated `onUploadProgress` and `onDownloadProgress` to use `AxiosProgressEvent`.
  - No runtime changes; types only.
- Reasoning
  - Node.js TS projects without `"dom"` failed with `TS2304: Cannot find name 'ProgressEvent'`.
  - Avoids a DOM dependency and keeps v0.x consistent with v1.x.
- Additional context
  - Fields include: `loaded`, `total?`, `progress?`, `bytes`, `rate?`, `estimated?`, `upload?`, `download?`, `event?`.
  - Closes #6516.

**Docs**
- No user-facing docs needed.
- Optional: add a short note in typing guidance that progress callbacks use `AxiosProgressEvent`.

**Testing**
- No tests added. Consider adding a lightweight type test.
- Manual check:
  - `npx tsc --noEmit --strict --lib es2017 test.ts` compiles without `"dom"`.
  - Existing projects should see no breaking changes in progress callback usage.

<sup>Written for commit 1e6f370013798853acf9aee734912e4882c0e88e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

