### PR TITLE
fix: fallback to GET when config.method is undefined in adapters (closes #6960)

### DIFF
--- a/lib/adapters/fetch.js
+++ b/lib/adapters/fetch.js
@@ -237,7 +237,7 @@ const factory = (env) => {
       const resolvedOptions = {
         ...fetchOptions,
         signal: composedSignal,
-        method: method.toUpperCase(),
+        method: (method || 'get').toUpperCase(),
         headers: headers.normalize().toJSON(),
         body: data,
         duplex: 'half',

--- a/lib/adapters/fetch.js
+++ b/lib/adapters/fetch.js
@@ -163,6 +163,8 @@ const factory = (env) => {
       fetchOptions,
     } = resolveConfig(config);
 
+    method = method || 'get';
+
     let _fetch = envFetch || fetch;
 
     responseType = responseType ? (responseType + '').toLowerCase() : 'text';
@@ -237,7 +239,7 @@ const factory = (env) => {
       const resolvedOptions = {
         ...fetchOptions,
         signal: composedSignal,
-        method: (method || 'get').toUpperCase(),
+        method: method.toUpperCase(),
         headers: headers.normalize().toJSON(),
         body: data,
         duplex: 'half',

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -335,7 +335,7 @@ export default isHttpAdapterSupported &&
     return wrapAsync(async function dispatchHttpRequest(resolve, reject, onDone) {
       let { data, lookup, family, httpVersion = 1, http2Options } = config;
       const { responseType, responseEncoding } = config;
-      const method = config.method.toUpperCase();
+      const method = (config.method || 'get').toUpperCase();
       let isDone;
       let rejected = false;
       let req;

--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -33,7 +33,7 @@ export default isXHRAdapterSupported &&
 
       let request = new XMLHttpRequest();
 
-      request.open(_config.method.toUpperCase(), _config.url, true);
+      request.open((_config.method || 'get').toUpperCase(), _config.url, true);
 
       // Set the request timeout in MS
       request.timeout = _config.timeout;

--- a/tests/unit/regression/method-undefined.test.js
+++ b/tests/unit/regression/method-undefined.test.js
@@ -1,0 +1,40 @@
+import { describe, it } from 'vitest';
+import assert from 'assert';
+import axios from '../../../index.js';
+
+describe('issue #6960: config.method undefined after interceptor', () => {
+  it('should default to GET when interceptor removes config.method', async () => {
+    const instance = axios.create();
+    let capturedMethod;
+
+    instance.interceptors.request.use((config) => {
+      delete config.method;
+      return config;
+    });
+
+    instance.defaults.adapter = (config) => {
+      capturedMethod = (config.method || 'get').toUpperCase();
+      return Promise.resolve({ data: {}, status: 200, statusText: 'OK', headers: {}, config });
+    };
+
+    await instance.request({ url: '/test' });
+    assert.strictEqual(capturedMethod, 'GET');
+  });
+
+  it('should not throw TypeError in http adapter when method is undefined', async () => {
+    const instance = axios.create({ adapter: 'http' });
+
+    instance.interceptors.request.use((config) => {
+      delete config.method;
+      return config;
+    });
+
+    try {
+      await instance.request({ url: 'http://localhost:1/test' });
+    } catch (err) {
+      // Network errors are expected (no server), but TypeError is NOT acceptable
+      assert.notStrictEqual(err.name, 'TypeError',
+        'Should not throw TypeError when config.method is undefined');
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `(config.method || 'get')` fallback before `.toUpperCase()` in all 3 adapters
- Prevents `TypeError: undefined is not an object (evaluating 'config.method.toUpperCase')` 
- Includes regression test

## Root Cause
`Axios._request()` normalizes `config.method` at line 145, but request interceptors run **after** this normalization and can delete or nullify `config.method`. The adapters then crash when calling `.toUpperCase()` on `undefined`.

## Changes
| File | Change |
|------|--------|
| `lib/adapters/xhr.js:36` | `_config.method.toUpperCase()` → `(_config.method \|\| 'get').toUpperCase()` |
| `lib/adapters/http.js:338` | `config.method.toUpperCase()` → `(config.method \|\| 'get').toUpperCase()` |
| `lib/adapters/fetch.js:240` | `method.toUpperCase()` → `(method \|\| 'get').toUpperCase()` |
| `tests/unit/regression/method-undefined.test.js` | New regression test (2 cases) |

The `'get'` default matches the same fallback already used in `Axios.js:145`.

## Test plan
- [x] Regression test passes: `npx vitest run tests/unit/regression/method-undefined.test.js` (2/2)
- [ ] Full test suite passes
- [ ] Manual verification with interceptor that deletes config.method

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents crashes when `config.method` is unset by defaulting to `GET` across adapters and fixes `fetch` preprocessing to avoid unnecessary upload handling. Adds a regression test to guard against future breakage (closes #6960).

## Description

- Changes
  - XHR/HTTP: use `(config.method || 'get').toUpperCase()` before use.
  - Fetch: set `method = method || 'get'` immediately after destructuring so upload guards see the correct method.
- Reasoning
  - Interceptors can remove `config.method` after normalization, making `.toUpperCase()` throw and causing incorrect fetch upload preprocessing.
- Context
  - No public API changes; matches existing `axios` defaults.

## Testing

- Added `tests/unit/regression/method-undefined.test.js` (2 cases):
  - Defaults to `GET` when an interceptor removes `config.method`.
  - `http` adapter does not throw `TypeError` when `method` is `undefined`.

<sup>Written for commit 7bc149c91ea28a74cb39929dc008e3427de00d6b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

