### PR TITLE
fix: update the implementation to rather parse out the values than throw

### DIFF
--- a/lib/core/AxiosHeaders.js
+++ b/lib/core/AxiosHeaders.js
@@ -5,41 +5,17 @@ import parseHeaders from '../helpers/parseHeaders.js';
 
 const $internals = Symbol('internals');
 
-const isValidHeaderValue = (value) => !/[\r\n]/.test(value);
-
-function assertValidHeaderValue(value, header) {
-  if (value === false || value == null) {
-    return;
-  }
-
-  if (utils.isArray(value)) {
-    value.forEach((v) => assertValidHeaderValue(v, header));
-    return;
-  }
-
-  if (!isValidHeaderValue(String(value))) {
-    throw new Error(`Invalid character in header content ["${header}"]`);
-  }
-}
+const INVALID_HEADER_VALUE_CHARS_RE = /[^\x09\x20-\x7E\x80-\xFF]/g;
+const LEADING_OR_TRAILING_SP_OR_HTAB_RE = /^[\x09\x20]+|[\x09\x20]+$/g;
 
 function normalizeHeader(header) {
   return header && String(header).trim().toLowerCase();
 }
 
-function stripTrailingCRLF(str) {
-  let end = str.length;
-
-  while (end > 0) {
-    const charCode = str.charCodeAt(end - 1);
-
-    if (charCode !== 10 && charCode !== 13) {
-      break;
-    }
-
-    end -= 1;
-  }
-
-  return end === str.length ? str : str.slice(0, end);
+function sanitizeHeaderValue(str) {
+  return str
+    .replace(INVALID_HEADER_VALUE_CHARS_RE, '')
+    .replace(LEADING_OR_TRAILING_SP_OR_HTAB_RE, '');
 }
 
 function normalizeValue(value) {
@@ -47,7 +23,7 @@ function normalizeValue(value) {
     return value;
   }
 
-  return utils.isArray(value) ? value.map(normalizeValue) : stripTrailingCRLF(String(value));
+  return utils.isArray(value) ? value.map(normalizeValue) : sanitizeHeaderValue(String(value));
 }
 
 function parseTokens(str) {
@@ -129,7 +105,6 @@ class AxiosHeaders {
         _rewrite === true ||
         (_rewrite === undefined && self[key] !== false)
       ) {
-        assertValidHeaderValue(_value, _header);
         self[key || _header] = normalizeValue(_value);
       }
     }

--- a/lib/core/AxiosHeaders.js
+++ b/lib/core/AxiosHeaders.js
@@ -6,16 +6,40 @@ import parseHeaders from '../helpers/parseHeaders.js';
 const $internals = Symbol('internals');
 
 const INVALID_HEADER_VALUE_CHARS_RE = /[^\x09\x20-\x7E\x80-\xFF]/g;
-const LEADING_OR_TRAILING_SP_OR_HTAB_RE = /^[\x09\x20]+|[\x09\x20]+$/g;
+
+function trimSPorHTAB(str) {
+  let start = 0;
+  let end = str.length;
+
+  while (start < end) {
+    const code = str.charCodeAt(start);
+
+    if (code !== 0x09 && code !== 0x20) {
+      break;
+    }
+
+    start += 1;
+  }
+
+  while (end > start) {
+    const code = str.charCodeAt(end - 1);
+
+    if (code !== 0x09 && code !== 0x20) {
+      break;
+    }
+
+    end -= 1;
+  }
+
+  return start === 0 && end === str.length ? str : str.slice(start, end);
+}
 
 function normalizeHeader(header) {
   return header && String(header).trim().toLowerCase();
 }
 
 function sanitizeHeaderValue(str) {
-  return str
-    .replace(INVALID_HEADER_VALUE_CHARS_RE, '')
-    .replace(LEADING_OR_TRAILING_SP_OR_HTAB_RE, '');
+  return trimSPorHTAB(str.replace(INVALID_HEADER_VALUE_CHARS_RE, ''));
 }
 
 function normalizeValue(value) {

--- a/lib/helpers/shouldBypassProxy.js
+++ b/lib/helpers/shouldBypassProxy.js
@@ -1,3 +1,7 @@
+const LOOPBACK_ADDRESSES = new Set(['localhost', '127.0.0.1', '::1']);
+
+const isLoopback = (host) => LOOPBACK_ADDRESSES.has(host);
+
 const DEFAULT_PORTS = {
   http: 80,
   https: 443,
@@ -101,6 +105,6 @@ export default function shouldBypassProxy(location) {
       return hostname.endsWith(entryHost);
     }
 
-    return hostname === entryHost;
+    return hostname === entryHost || (isLoopback(hostname) && isLoopback(entryHost));
   });
 }

--- a/tests/browser/adapter.browser.test.js
+++ b/tests/browser/adapter.browser.test.js
@@ -179,15 +179,19 @@ describe('adapter (vitest browser)', () => {
     await responsePromise;
   });
 
-  it('should reject request headers containing CRLF characters', async () => {
-    await expect(
-      axios('/foo', {
-        headers: {
-          'x-test': 'ok\r\nInjected: yes',
-        },
-      })
-    ).rejects.toThrow(/Invalid character in header content/);
+  it('should sanitize request headers containing CRLF characters', async () => {
+    const responsePromise = axios('/foo', {
+      headers: {
+        'x-test': '\tok\r\nInjected: yes ',
+      },
+    });
 
-    expect(requests.length).toBe(0);
+    const request = await waitForRequest();
+
+    expect(request.requestHeaders['x-test']).toBe('okInjected: yes');
+    expect(request.requestHeaders.Injected).toBeUndefined();
+
+    request.respondWith();
+    await responsePromise;
   });
 });

--- a/tests/unit/adapters/fetch.test.js
+++ b/tests/unit/adapters/fetch.test.js
@@ -26,15 +26,34 @@ const fetchAxios = axios.create({
 });
 
 describe.runIf(typeof fetch === 'function')('supports fetch with nodejs', () => {
-  it('should reject request headers containing CRLF characters', async () => {
-    await assert.rejects(
-      fetchAxios.get(`${LOCAL_SERVER_URL}/`, {
-        headers: {
-          'x-test': 'ok\r\nInjected: yes',
-        },
-      }),
-      /(invalid.*header|header.*invalid)/i
+  it('should sanitize request headers containing CRLF characters', async () => {
+    const server = await startHTTPServer(
+      (req, res) => {
+        res.setHeader('Content-Type', 'application/json');
+        res.end(
+          JSON.stringify({
+            xTest: req.headers['x-test'],
+            injected: req.headers.injected ?? null,
+          })
+        );
+      },
+      {
+        port: SERVER_PORT,
+      }
     );
+
+    try {
+      const { data } = await fetchAxios.get(`${LOCAL_SERVER_URL}/`, {
+        headers: {
+          'x-test': '\tok\r\nInjected: yes ',
+        },
+      });
+
+      assert.strictEqual(data.xTest, 'okInjected: yes');
+      assert.strictEqual(data.injected, null);
+    } finally {
+      await stopHTTPServer(server);
+    }
   });
 
   describe('responses', () => {

--- a/tests/unit/adapters/http.test.js
+++ b/tests/unit/adapters/http.test.js
@@ -126,15 +126,32 @@ describe('supports http with nodejs', () => {
     }
   });
 
-  it('should reject request headers containing CRLF characters', async () => {
-    await assert.rejects(
-      axios.get('http://localhost:1/', {
-        headers: {
-          'x-test': 'ok\r\nInjected: yes',
-        },
-      }),
-      /Invalid character in header content/
+  it('should sanitize request headers containing CRLF characters', async () => {
+    const server = await startHTTPServer(
+      (req, res) => {
+        res.setHeader('Content-Type', 'application/json');
+        res.end(
+          JSON.stringify({
+            xTest: req.headers['x-test'],
+            injected: req.headers.injected ?? null,
+          })
+        );
+      },
+      { port: SERVER_PORT }
     );
+
+    try {
+      const { data } = await axios.get(`http://localhost:${server.address().port}/`, {
+        headers: {
+          'x-test': '\tok\r\nInjected: yes ',
+        },
+      });
+
+      assert.strictEqual(data.xTest, 'okInjected: yes');
+      assert.strictEqual(data.injected, null);
+    } finally {
+      await stopHTTPServer(server);
+    }
   });
 
   it('should parse the timeout property', async () => {

--- a/tests/unit/axiosHeaders.test.js
+++ b/tests/unit/axiosHeaders.test.js
@@ -103,20 +103,20 @@ describe('AxiosHeaders', () => {
       }
     );
 
-    it('should throw on CRLF in header value', () => {
+    it('should sanitize invalid characters in header value', () => {
       const headers = new AxiosHeaders();
 
-      assert.throws(() => {
-        headers.set('x-test', 'safe\r\nInjected: true');
-      }, /Invalid character in header content/);
+      headers.set('x-test', '\t safe\r\nInjected: true \u0000');
+
+      assert.strictEqual(headers.get('x-test'), 'safeInjected: true');
     });
 
-    it('should throw on CRLF in any array header value', () => {
+    it('should sanitize invalid characters in any array header value', () => {
       const headers = new AxiosHeaders();
 
-      assert.throws(() => {
-        headers.set('set-cookie', ['safe=1', 'unsafe=1\nInjected: true']);
-      }, /Invalid character in header content/);
+      headers.set('set-cookie', ['safe=1', ' \tunsafe=1\nInjected: true\r\n ']);
+
+      assert.deepStrictEqual(headers.get('set-cookie'), ['safe=1', 'unsafe=1Injected: true']);
     });
   });
 

--- a/tests/unit/helpers/shouldBypassProxy.test.js
+++ b/tests/unit/helpers/shouldBypassProxy.test.js
@@ -42,6 +42,30 @@ describe('helpers::shouldBypassProxy', () => {
     expect(shouldBypassProxy('http://[::1]:8080/')).toBe(true);
   });
 
+  it('should bypass proxy for 127.0.0.1 when no_proxy contains localhost', () => {
+    setNoProxy('localhost');
+
+    expect(shouldBypassProxy('http://127.0.0.1:7777/')).toBe(true);
+  });
+
+  it('should bypass proxy for [::1] when no_proxy contains localhost', () => {
+    setNoProxy('localhost');
+
+    expect(shouldBypassProxy('http://[::1]:7777/')).toBe(true);
+  });
+
+  it('should bypass proxy for localhost when no_proxy contains 127.0.0.1', () => {
+    setNoProxy('127.0.0.1');
+
+    expect(shouldBypassProxy('http://localhost:7777/')).toBe(true);
+  });
+
+  it('should bypass proxy for localhost when no_proxy contains ::1', () => {
+    setNoProxy('::1');
+
+    expect(shouldBypassProxy('http://localhost:7777/')).toBe(true);
+  });
+
   it('should match wildcard and explicit ports', () => {
     setNoProxy('*.example.com,localhost:8080');
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Sanitizes request header values by stripping invalid bytes and trimming tabs/spaces instead of throwing, preventing header injection across browser and Node. Also hardens proxy bypass by treating `localhost`, `127.0.0.1`, and `::1` as equivalent loopbacks in `NO_PROXY` matching.

**Description**
- Replace validation with sanitization in `AxiosHeaders`; remove disallowed bytes, trim SP/HTAB, handle strings and arrays; no throws.
- Prevent creation of new headers from injected content.
- Harden `shouldBypassProxy`: treat `localhost`, `127.0.0.1`, and `::1` as equivalent loopbacks in `NO_PROXY` matching.

**Testing**
- Browser adapter: header `'\tok\r\nInjected: yes '` becomes `'okInjected: yes'`; no `Injected` header.
- Node `fetch` and `http` adapters: echo servers confirm same sanitized value and no extra headers.
- `AxiosHeaders` and `shouldBypassProxy` tests updated: expect sanitized string/array values; verify loopback equivalence across `localhost`/`127.0.0.1`/`::1`.

<sup>Written for commit 98799bf8db6ef76bfc8fb8ccc7a12fa5c081ba33. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

