### PR TITLE
chore: added a versioning flow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Publish package to NPM
 on:
   push:
     tags:
-      - 'v0.*.*'
+      - "v0.*.*"
 
 permissions:
   contents: read
@@ -22,10 +22,10 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 24.x
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: "https://registry.npmjs.org"
           package-manager-cache: false
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
       - name: Build project
         run: npm run build
       - name: Publish to NPM

--- a/.github/workflows/run-ci-v0.yml
+++ b/.github/workflows/run-ci-v0.yml
@@ -32,7 +32,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: npm
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
       - name: Build project
         run: npm run build
       - name: Run tests

--- a/.github/workflows/version-v0x.yml
+++ b/.github/workflows/version-v0x.yml
@@ -1,0 +1,95 @@
+name: Version package (v0.x)
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_type:
+        description: "Choose release type"
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+        default: patch
+
+jobs:
+  ci:
+    name: Test (Node ${{ matrix.node-version }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [12.x, 14.x, 16.x, 18.x, 20.x, 22.x, 24.x]
+      fail-fast: false
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: v0.x
+          persist-credentials: false
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+      - name: Build project
+        run: npm run build
+      - name: Run tests
+        run: npm run test
+
+  bump-version-and-create-pr:
+    name: Bump version and create PR v0.x
+    runs-on: ubuntu-latest
+    needs: ci
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: v0.x
+          persist-credentials: false
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: 24.x
+          cache: npm
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+      - name: Bump version
+        id: bump
+        run: |
+          npm version ${{ inputs.version_type }} --no-git-tag-version
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "branch=release/version-$VERSION" >> "$GITHUB_OUTPUT"
+      - name: Create release branch and commit
+        run: |
+          git checkout -b "${STEPS_BUMP_OUTPUTS_BRANCH}"
+          git add package.json package-lock.json
+          git commit -m "chore: bump version to v${STEPS_BUMP_OUTPUTS_VERSION}"
+          git push origin "${STEPS_BUMP_OUTPUTS_BRANCH}"
+        env:
+          STEPS_BUMP_OUTPUTS_BRANCH: ${{ steps.bump.outputs.branch }}
+          STEPS_BUMP_OUTPUTS_VERSION: ${{ steps.bump.outputs.version }}
+      - name: Create pull request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          STEPS_BUMP_OUTPUTS_VERSION: ${{ steps.bump.outputs.version }}
+        run: |
+          gh pr create \
+            --base v0.x \
+            --title "chore: release v${STEPS_BUMP_OUTPUTS_VERSION}" \
+            --body "Automated version bump to v${STEPS_BUMP_OUTPUTS_VERSION}." \
+            --label "type::automated-pr" \
+            --label "priority::high" \
+            --label "commit::chore"

--- a/.github/workflows/version-v0x.yml
+++ b/.github/workflows/version-v0x.yml
@@ -16,6 +16,8 @@ jobs:
   ci:
     name: Test (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     strategy:
       matrix:

--- a/.github/workflows/version-v0x.yml
+++ b/.github/workflows/version-v0x.yml
@@ -55,6 +55,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: v0.x
+          persist-credentials: false
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
@@ -62,10 +63,6 @@ jobs:
           cache: npm
       - name: Install dependencies
         run: npm ci --ignore-scripts
-      - name: Configure git
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
       - name: Bump version
         id: bump
         run: |
@@ -73,24 +70,16 @@ jobs:
           VERSION=$(node -p "require('./package.json').version")
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "branch=release/version-$VERSION" >> "$GITHUB_OUTPUT"
-      - name: Create release branch and commit
-        run: |
-          git checkout -b "${STEPS_BUMP_OUTPUTS_BRANCH}"
-          git add package.json package-lock.json
-          git commit -m "chore: bump version to v${STEPS_BUMP_OUTPUTS_VERSION}"
-          git push origin "${STEPS_BUMP_OUTPUTS_BRANCH}"
-        env:
-          STEPS_BUMP_OUTPUTS_BRANCH: ${{ steps.bump.outputs.branch }}
-          STEPS_BUMP_OUTPUTS_VERSION: ${{ steps.bump.outputs.version }}
       - name: Create pull request
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          STEPS_BUMP_OUTPUTS_VERSION: ${{ steps.bump.outputs.version }}
-        run: |
-          gh pr create \
-            --base v0.x \
-            --title "chore: release v${STEPS_BUMP_OUTPUTS_VERSION}" \
-            --body "Automated version bump to v${STEPS_BUMP_OUTPUTS_VERSION}." \
-            --label "type::automated-pr" \
-            --label "priority::high" \
-            --label "commit::chore"
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: bump version to v${{ steps.bump.outputs.version }}"
+          branch: ${{ steps.bump.outputs.branch }}
+          base: v0.x
+          title: "chore: release v${{ steps.bump.outputs.version }}"
+          body: "Automated version bump to v${{ steps.bump.outputs.version }}."
+          labels: |
+            type::automated-pr
+            priority::high
+            commit::chore

--- a/.github/workflows/version-v0x.yml
+++ b/.github/workflows/version-v0x.yml
@@ -55,7 +55,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: v0.x
-          persist-credentials: false
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ coverage/
 test/typescript/axios.js*
 sauce_connect.log
 .vscode/
+.claude/
+openspec/


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a manual versioning workflow for `v0.x` that bumps the version, runs CI on Node 12–24, and opens a labeled release PR. Also switches CI/publish to `npm ci --ignore-scripts`, updates `.gitignore`, and reverts a prior GH-release experiment in favor of a standard PR flow.

## Description

- Summary of changes
  - New workflow `version-v0x.yml` (manual dispatch) to bump `patch`/`minor`, create `release/version-<x.y.z>` branch, commit updated `package.json`/`package-lock.json`, and open a PR to `v0.x` after CI passes (Node 12–24). PR is labeled: `type::automated-pr`, `priority::high`, `commit::chore`.
  - Use `npm ci --ignore-scripts` in CI (`run-ci-v0.yml`) and publish (`publish.yml`); minor YAML quoting cleanup.
  - `.gitignore` adds `.claude/` and `openspec/`.

- Reasoning
  - Standardizes `v0.x` releases with a safe, PR-based flow and clearer triage via labels.
  - Disabling lifecycle scripts makes installs deterministic and fixes flaky content reads in tests.
  - Drops a previous GH-release idea and sticks to a simpler, standard workflow.

- Additional context
  - Publishing still triggers on `v0.*.*` tags via `publish.yml`.

## Docs

- To cut a `v0.x` release: Actions → “Version package (v0.x)” → choose `patch` or `minor` → review and merge “chore: release v<x.y.z>” PR into `v0.x` → tag and push `v0.x.y` to publish.
- CI uses explicit build/test steps; avoid npm lifecycle scripts in CI/publish.

## Testing

- No new unit tests; changes are workflow-only.
- The versioning workflow runs the full CI matrix before opening the release PR, exercising existing tests. No extra tests needed.

<sup>Written for commit 68fdd8a28d913009f615cbdaed973c09e4ae74db. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

