### PR TITLE
ci: update branch name

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,4 +29,4 @@ jobs:
       - name: Build project
         run: npm run build
       - name: Publish to NPM
-        run: npm publish --provenance --access public --tag v0.x
+        run: npm publish --provenance --access public --tag v0x

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,4 +29,4 @@ jobs:
       - name: Build project
         run: npm run build
       - name: Publish to NPM
-        run: npm publish --provenance --access public --tag old-version
+        run: npm publish --provenance --access public --tag v0.x

--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -69,7 +69,7 @@ jobs:
           npm version ${{ inputs.version_type }} --no-git-tag-version
           VERSION=$(node -p "require('./package.json').version")
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "branch=release/version-$VERSION" >> "$GITHUB_OUTPUT"
+          echo "branch=release-v0x/version-$VERSION" >> "$GITHUB_OUTPUT"
       - name: Create pull request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Aligns the v0.x release flow: release branches use `release-v0x/version-$VERSION` and publishes use the NPM dist-tag `v0x`. This ensures release PRs and packages target the correct v0.x channel.

## Description
- Set release-branch workflow output to `release-v0x/version-$VERSION`.
- Updated `publish.yml` to publish with `--tag v0x` (valid NPM tag; replaces `v0.x`).
- CI-only change; no updates to Git tags or versioning.

## Testing
- No unit tests.
- Validate via workflow runs: PR branch is `release-v0x/version-<version>` and the published package has NPM tag `v0x`.

<sup>Written for commit 42f8d26fc28d853df4f4b499d5fc99015b1e3a04. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

