### PR TITLE
fix(fetch): cancel request.body instead of source stream

### DIFF
--- a/lib/adapters/fetch.js
+++ b/lib/adapters/fetch.js
@@ -66,18 +66,20 @@ const factory = (env) => {
     test(() => {
       let duplexAccessed = false;
 
-      const body = new ReadableStream();
-
-      const hasContentType = new Request(platform.origin, {
-        body,
+      const request = new Request(platform.origin, {
+        body: new ReadableStream(),
         method: 'POST',
         get duplex() {
           duplexAccessed = true;
           return 'half';
         },
-      }).headers.has('Content-Type');
+      });
 
-      body.cancel();
+      const hasContentType = request.headers.has('Content-Type');
+
+      if (request.body != null) {
+        request.body.cancel();
+      }
 
       return duplexAccessed && !hasContentType;
     });


### PR DESCRIPTION
The `Request` constructor extracts and locks the `ReadableStream` passed as body, so calling `cancel()` on the original reference rejects with a [`TypeError` per spec](https://streams.spec.whatwg.org/#rs-cancel). This PR cancels the transferred stream via `request.body` instead, which achieves the same goal without producing an unhandled rejection.

Related https://github.com/axios/axios/pull/7515
Fixes https://github.com/expo/expo/issues/44382

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cancel the transferred request body (`request.body`) in the `fetch` adapter’s request stream probe to avoid TypeErrors from cancelling the original source stream. This removes unhandled rejections while keeping the probe behavior the same.

## Description

- Summary of changes
  - In `lib/adapters/fetch.js`, create the `Request` with a new `ReadableStream`, then cancel `request.body` (if present) instead of the original stream.
  - Keeps `duplex` access check and `Content-Type` header probe unchanged.
- Reasoning
  - The `Request` constructor locks the passed stream; cancelling the original throws a TypeError.
  - Cancelling `request.body` achieves the same effect without errors.
- Additional context
  - Improves compatibility in environments like Expo.
  - Related: axios#7515. Fixes: expo/expo#44382.

## Docs

- No user-facing or API changes. No docs updates needed.

## Testing

- No tests added or modified.
- Suggested: add a regression test to ensure the probe does not produce unhandled rejections and still returns the expected result when the body is locked by `Request`.

<sup>Written for commit eec1e4278752cb2634b3b96fda202bcb6d1ebd26. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

