### PR TITLE
chore: added missing versions from the changelo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,171 @@
 # Changelog
 
+## v1.15.0 — April 7, 2026
+
+This release delivers two critical security patches targeting header injection and SSRF via proxy bypass, adds official runtime support for Deno and Bun, and includes significant CI security hardening.
+
+## 🔒 Security Fixes
+
+* **Header Injection (CRLF):** Rejects any header value containing `\r` or `\n` characters to block CRLF injection chains that could be used to exfiltrate cloud metadata (IMDS). Behavior change: headers with CR/LF now throw `"Invalid character in header content"`. (__#10660__)
+
+* **SSRF via `no_proxy` Bypass:** Introduces a `shouldBypassProxy` helper that normalises hostnames (strips trailing dots, handles bracketed IPv6) before evaluating `no_proxy`/`NO_PROXY` rules, closing a gap that could cause loopback or internal hosts to be inadvertently proxied. (__#10661__)
+
+## 🚀 New Features
+
+* **Deno & Bun Runtime Support:** Added full smoke test suites for Deno and Bun, with CI workflows that run both runtimes before any release is cut. (__#10652__)
+
+## 🐛 Bug Fixes
+
+* **Node.js v22 Compatibility:** Replaced deprecated `url.parse()` calls with the WHATWG `URL`/`URLSearchParams` API across examples, sandbox, and tests, eliminating `DEP0169` deprecation warnings on Node.js v22+. (__#10625__)
+
+## 🔧 Maintenance & Chores
+
+* **CI Security Hardening:** Added [zizmor](https://github.com/zizmorcore/zizmor) GitHub Actions security scanner; switched npm publish to OIDC Trusted Publishing (removing the long-lived `NODE_AUTH_TOKEN`); pinned all action references to full commit SHAs; narrowed workflow permissions to least privilege; gated the publish step behind a dedicated `npm-publish` environment; and blocked the sponsor-block workflow from running on forks. (__#10618__, __#10619__, __#10627__, __#10637__, __#10641__, __#10666__)
+
+* **Docs:** Clarified HTTP/2 support and the unsupported `httpVersion` option; added documentation for header case preservation; improved the `beforeRedirect` example to prevent accidental credential leakage. (__#10644__, __#10654__, __#10624__)
+
+* **Dependencies:** Bumped `picomatch`, `handlebars`, `serialize-javascript`, `vite` (×3), `denoland/setup-deno`, and 4 additional dev dependencies to latest versions. (__#10564__, __#10565__, __#10567__, __#10568__, __#10572__, __#10574__, __#10663__, __#10664__, __#10665__, __#10669__, __#10670__)
+
+## 🌟 New Contributors
+
+We are thrilled to welcome our new contributors. Thank you for helping improve axios:
+
+* **@Kilros0817** (__#10625__)
+* **@shaanmajid** (__#10616__, __#10617__, __#10618__, __#10619__, __#10637__, __#10641__, __#10666__)
+* **@ashstrc** (__#10624__, __#10644__)
+* **@Abhi3975** (__#10589__)
+* **@raashish1601** (__#10573__)
+
+[Full Changelog](https://github.com/axios/axios/compare/v1.14.0...v1.15.0)
+
+---
+
+## v1.14.0 — March 27, 2026
+
+This release fixes a security vulnerability in the `formidable` dependency, resolves a CommonJS compatibility regression, hardens proxy and HTTP/2 handling, and modernises the build and test toolchain.
+
+## 🔒 Security Fixes
+
+* **Formidable Vulnerability:** Upgraded `formidable` from v2 to v3 to address a reported arbitrary-file vulnerability. Updated test server and assertions to align with the v3 API. (__#7533__)
+
+## 🐛 Bug Fixes
+
+* **CommonJS Compatibility:** Restored `require('axios')` in Node.js by correcting the `main` field in `package.json` to point to the built CJS bundle. (__#7532__)
+
+* **Fetch Adapter:** Cancel the `ReadableStream` body after the request stream capability probe to prevent resource leaks. (__#7515__)
+
+* **Proxy:** Upgraded `proxy-from-env` to v2 and switched to the named `getProxyForUrl` export, fixing proxy detection from environment variables and resolving CJS bundling errors. (__#7499__)
+
+* **HTTP/2:** Close detached HTTP/2 sessions on timeout to free resources when no new requests arrive. (__#7457__)
+
+* **Headers:** Trim trailing CRLF characters from normalised header values. (__#7456__)
+
+## 🔧 Maintenance & Chores
+
+* **Toolchain Modernisation:** Migrated test suite to Vitest, updated ESLint to v10, upgraded Rollup and `@rollup/plugin-babel`, migrated to Husky 9, upgraded TypeScript to latest, and modernised the Express test harness. (__#7484__, __#7489__, __#7498__, __#7505__, __#7506__, __#7507__, __#7508__, __#7509__, __#7510__, __#7516__, __#7522__)
+
+* **Dependencies:** Bumped `multer` to v2, `minimatch`, `tar`, `pacote`, `@babel/preset-env`, and additional dev dependencies. (__#7453__, __#7480__, __#7491__, __#7504__, __#7517__, __#7531__)
+
+## 🌟 New Contributors
+
+We are thrilled to welcome our new contributors. Thank you for helping improve axios:
+
+* **@penkzhou** (__#7515__)
+* **@aviu16** (__#7456__)
+* **@fedotov** (__#7457__)
+
+[Full Changelog](https://github.com/axios/axios/compare/v1.13.6...v1.14.0)
+
+---
+
+## v1.13.6 — February 27, 2026
+
+This release adds React Native Blob support, fixes several enumeration and export regressions, and patches FormData detection for WeChat Mini Program environments.
+
+## 🚀 New Features
+
+* **React Native Blob Support:** Axios now correctly handles native Blob objects in React Native environments. (__#5764__)
+
+## 🐛 Bug Fixes
+
+* **AxiosError:** Fixed `AxiosError.from` not copying the `status` field from the source error. (__#7403__)
+
+* **AxiosError:** Made the `message` property enumerable so it appears in `JSON.stringify` output and `Object.keys`. (__#7392__)
+
+* **FormData Detection:** Corrected safe FormData detection for WeChat Mini Program environments. (__#7324__)
+
+* **React Native / Browserify Export:** Fixed broken module export that caused import failures in React Native and Browserify. (__#7386__)
+
+## 🔧 Maintenance & Chores
+
+* **Dependencies:** Migrated `@rollup/plugin-babel` from v5 to v6 and bumped the development dependencies group. (__#7424__, __#7432__)
+
+## 🌟 New Contributors
+
+We are thrilled to welcome our new contributors. Thank you for helping improve axios:
+
+* **@moh3n9595** (__#5764__)
+* **@skrtheboss** (__#7403__)
+* **@ybbus** (__#7392__)
+* **@Shiwaangee** (__#7324__)
+* **@Gudahtt** (__#7386__)
+
+[Full Changelog](https://github.com/axios/axios/compare/v1.13.5...v1.13.6)
+
+---
+
+## v1.13.5 — February 8, 2026
+
+This release patches a prototype pollution denial-of-service vulnerability, fixes a missing `status` field regression in `AxiosError`, adds interceptor ordering control, and introduces URL validation for `isAbsoluteURL`.
+
+## 🔒 Security Fixes
+
+* **Prototype Pollution (DoS):** Hardened `mergeConfig` to ignore `__proto__`, `constructor`, and `prototype` keys, preventing denial-of-service via prototype pollution when merging user-supplied config. (__#7369__)
+
+## 🚀 New Features
+
+* **`isAbsoluteURL` Validation:** Added input validation to `isAbsoluteURL` to handle malformed or unexpected input gracefully. (__#7326__)
+
+## 🐛 Bug Fixes
+
+* **AxiosError `status`:** Restored the `status` field on `AxiosError` instances, which was missing in v1.13.3 and later. (__#7368__)
+
+* **Interceptor Ordering:** Added a `useLegacyInterceptorOrder` option to restore pre-v1.13 interceptor execution order for applications relying on the previous behaviour. ([569f028](https://github.com/axios/axios/commit/569f028a5878faaec8d7d138ba686aac407bda4c))
+
+## 🔧 Maintenance & Chores
+
+* **CI:** Fixed run conditions and updated workflow YAMLs. (__#7372__, __#7373__)
+
+* **Dependencies:** Bumped `karma-sourcemap-loader` and minor package versions. (__#7356__, __#7360__)
+
+## 🌟 New Contributors
+
+We are thrilled to welcome our new contributors. Thank you for helping improve axios:
+
+* **@asmitha-16** (__#7326__)
+
+[Full Changelog](https://github.com/axios/axios/compare/v1.13.4...v1.13.5)
+
+---
+
+## v1.13.4 — January 27, 2026
+
+Patch release fixing regressions introduced in v1.13.3, including TypeScript export compatibility and CI/build stability.
+
+## 🐛 Bug Fixes
+
+* **v1.13.3 Regressions:** Fixed multiple issues introduced by the v1.13.3 release, including broken merge configs. (__#7352__)
+
+* **TypeScript Exports:** Corrected TypeScript export declarations to restore proper type resolution. (__#4884__)
+
+## 🔧 Maintenance & Chores
+
+* **CI & Build:** Refactored CI pipeline and build configuration for stability. (__#7340__)
+
+[Full Changelog](https://github.com/axios/axios/compare/v1.13.3...v1.13.4)
+
+---
+
 ## [1.13.3](https://github.com/axios/axios/compare/v1.13.2...v1.13.3) (2026-01-20)
 
 ### Bug Fixes


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds the missing release entries to CHANGELOG for v1.15.0, v1.14.0, v1.13.6, v1.13.5, and v1.13.4 to restore a complete release history. No code changes; documentation only.

**Description**
- Summary of changes: Added full notes for the above versions, including highlights and links.
- Reasoning: Keep release history accurate and visible, covering security fixes, runtime support, and key bug fixes.
- Additional context: Docs-only update; no functional impact.

**Docs**
- Changelog now includes: security patches (header injection, SSRF, prototype pollution), new runtime support (Deno, Bun), notable fixes (CommonJS require, React Native Blob), and maintenance updates for each version.

**Testing**
- No tests added or required; content-only changes.

<sup>Written for commit 97608cd4602ad177ed042c7382814708271d1b33. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

