### PR TITLE
fix(dispatchRequest): attach response to AxiosError on JSON parse failure

### DIFF
--- a/lib/core/dispatchRequest.js
+++ b/lib/core/dispatchRequest.js
@@ -49,8 +49,15 @@ export default function dispatchRequest(config) {
     function onAdapterResolution(response) {
       throwIfCancellationRequested(config);
 
-      // Transform response data
-      response.data = transformData.call(config, config.transformResponse, response);
+      // Expose the current response on config so that transformResponse can
+      // attach it to any AxiosError it throws (e.g. on JSON parse failure).
+      // We clean it up afterwards to avoid polluting the config object.
+      config.response = response;
+      try {
+        response.data = transformData.call(config, config.transformResponse, response);
+      } finally {
+        delete config.response;
+      }
 
       response.headers = AxiosHeaders.from(response.headers);
 
@@ -62,11 +69,16 @@ export default function dispatchRequest(config) {
 
         // Transform response data
         if (reason && reason.response) {
-          reason.response.data = transformData.call(
-            config,
-            config.transformResponse,
-            reason.response
-          );
+          config.response = reason.response;
+          try {
+            reason.response.data = transformData.call(
+              config,
+              config.transformResponse,
+              reason.response
+            );
+          } finally {
+            delete config.response;
+          }
           reason.response.headers = AxiosHeaders.from(reason.response.headers);
         }
       }

--- a/tests/unit/transformResponse.test.js
+++ b/tests/unit/transformResponse.test.js
@@ -1,6 +1,7 @@
 import { describe, it } from 'vitest';
 import defaults from '../../lib/defaults/index.js';
 import transformData from '../../lib/core/transformData.js';
+import AxiosError from '../../lib/core/AxiosError.js';
 import assert from 'assert';
 
 describe('transformResponse', () => {
@@ -33,6 +34,68 @@ describe('transformResponse', () => {
         defaults.transformResponse
       );
       assert.strictEqual(result, data);
+    });
+  });
+
+  describe('malformed JSON with responseType: json', () => {
+    it('throws AxiosError with ERR_BAD_RESPONSE code', () => {
+      const response = { status: 200, headers: {}, data: '{bad json' };
+      const config = {
+        responseType: 'json',
+        transitional: { silentJSONParsing: false, forcedJSONParsing: true },
+        response,
+      };
+
+      assert.throws(
+        () => transformData.call(config, defaults.transformResponse, response),
+        (e) => e instanceof AxiosError && e.code === AxiosError.ERR_BAD_RESPONSE
+      );
+    });
+
+    it('attaches response to AxiosError so error.status and error.response are available', () => {
+      // Regression test for https://github.com/axios/axios/issues/7224
+      // When JSON.parse fails in strict mode, the thrown AxiosError must carry
+      // the original response so callers can inspect error.status and
+      // error.response without having to re-examine the raw response.
+      const response = { status: 200, headers: {}, data: '{bad json' };
+      const config = {
+        responseType: 'json',
+        transitional: { silentJSONParsing: false, forcedJSONParsing: true },
+        response,
+      };
+
+      let thrown;
+      try {
+        transformData.call(config, defaults.transformResponse, response);
+      } catch (e) {
+        thrown = e;
+      }
+
+      assert.ok(thrown instanceof AxiosError, 'must be AxiosError');
+      assert.strictEqual(thrown.status, 200, 'error.status must equal response status');
+      assert.strictEqual(thrown.response, response, 'error.response must be the original response');
+    });
+
+    it('does not leave config.response set after transformResponse completes', () => {
+      // The fix temporarily assigns config.response; it must be cleaned up
+      // afterwards to avoid polluting the config object.
+      const response = { status: 200, headers: {}, data: '{bad json' };
+      const config = {
+        responseType: 'json',
+        transitional: { silentJSONParsing: false, forcedJSONParsing: true },
+      };
+
+      try {
+        transformData.call(config, defaults.transformResponse, response);
+      } catch (_) {
+        // expected
+      }
+
+      assert.strictEqual(
+        Object.prototype.hasOwnProperty.call(config, 'response'),
+        false,
+        'config.response must not be left on the config object'
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes #7224.

When `JSON.parse` fails in strict mode (`responseType: 'json'` or `silentJSONParsing: false`), the thrown `AxiosError` had `error.response` and `error.status` both as `undefined`, making it impossible for callers to inspect the HTTP response status without re-examining the raw response.

## Root cause

`transformResponse` runs inside `transformData.call(config, ...)` where `this` is the config object. `AxiosError.from` uses `this.response` to populate the error — but `config.response` is never set in `dispatchRequest`, so it is always `undefined`.

## Fix

In `dispatchRequest`, temporarily assign `config.response = response` before calling `transformData`, then clean it up in a `finally` block. This makes `this.response` available inside `transformResponse` when building the `AxiosError`.

## Changes

- `lib/core/dispatchRequest.js`: set/clean `config.response` around `transformData` calls for both resolution and rejection paths
- `tests/unit/transformResponse.test.js`: 3 new tests — ERR_BAD_RESPONSE code, response/status attached, config.response cleaned up after

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing `error.response` and `error.status` on JSON parse failures by exposing the response during transform, restoring consistent `AxiosError` behavior.

**Description**
- Summary of changes: In `dispatchRequest`, temporarily set `config.response = response` around `transformData` calls, then delete it in `finally`.
- Reasoning: `AxiosError.from` reads `this.response` inside `transformResponse`; without it, JSON parse failures in strict mode lacked response details.
- Additional context: Touches `lib/core/dispatchRequest.js`; adds unit tests for strict JSON parsing failure. No docs changes.

**Testing**
- Added 3 unit tests in `tests/unit/transformResponse.test.js`:
  - Throws `AxiosError` with `ERR_BAD_RESPONSE`.
  - Ensures `error.response` and `error.status` are populated.
  - Verifies `config.response` is cleaned up after transform.

<sup>Written for commit f2c8fb4b2f1be1b5d7c6da5633c2d5267dad94aa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

