### PR TITLE
fix: form data recursion

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,7 +342,8 @@ These are the available config options for making requests. Only the `url` is re
 
   // `paramsSerializer` is an optional config in charge of serializing `params`
   paramsSerializer: {
-    indexes: null // array indexes format (null - no brackets, false - empty brackets, true - brackets with indexes)
+    indexes: null, // array indexes format (null - no brackets, false - empty brackets, true - brackets with indexes)
+    maxDepth: 100 // maximum recursion depth for nested params (default: 100, Infinity disables the limit)
   },
 
   // `data` is the data to be sent as the request body
@@ -522,6 +523,7 @@ These are the available config options for making requests. Only the `url` is re
       dots: boolean; // use dots instead of brackets format
       metaTokens: boolean; // keep special endings like {} in parameter key
       indexes: boolean; // array indexes format null - no brackets, false - empty brackets, true - brackets with indexes
+      maxDepth: number; // maximum recursion depth for nested objects (default: 100, Infinity disables the limit)
   }
 }
 ```
@@ -1010,6 +1012,13 @@ The back-end body-parser could potentially use this meta-information to automati
     - `null` - don't add brackets (`arr: 1`, `arr: 2`, `arr: 3`)
     - `false`(default) - add empty brackets (`arr[]: 1`, `arr[]: 2`, `arr[]: 3`)
     - `true` - add brackets with indexes  (`arr[0]: 1`, `arr[1]: 2`, `arr[2]: 3`)
+
+- `maxDepth: number = 100` - maximum recursion depth when serializing nested objects. Throws an `AxiosError` with
+code `ERR_FORM_DATA_DEPTH_EXCEEDED` if the limit is exceeded. Set to `Infinity` to disable the limit.
+
+> **Security note:** If your server-side code forwards client-supplied objects to axios as request `data` or `params`,
+> keep `maxDepth` at a reasonable value (the default of 100 is sufficient for most use cases) to prevent
+> denial-of-service via deeply nested payloads.
 
 Let's say we have an object like this one:
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -231,6 +231,7 @@ export class AxiosError<T = unknown, D = any> extends Error {
   static readonly ERR_BAD_REQUEST = "ERR_BAD_REQUEST";
   static readonly ERR_NOT_SUPPORT = "ERR_NOT_SUPPORT";
   static readonly ERR_INVALID_URL = "ERR_INVALID_URL";
+  static readonly ERR_FORM_DATA_DEPTH_EXCEEDED = "ERR_FORM_DATA_DEPTH_EXCEEDED";
   static readonly ERR_CANCELED = "ERR_CANCELED";
   static readonly ECONNABORTED = "ECONNABORTED";
   static readonly ETIMEDOUT = "ETIMEDOUT";

--- a/lib/core/AxiosError.js
+++ b/lib/core/AxiosError.js
@@ -66,7 +66,8 @@ var descriptors = {};
   'ERR_BAD_REQUEST',
   'ERR_CANCELED',
   'ERR_NOT_SUPPORT',
-  'ERR_INVALID_URL'
+  'ERR_INVALID_URL',
+  'ERR_FORM_DATA_DEPTH_EXCEEDED'
 // eslint-disable-next-line func-names
 ].forEach(function(code) {
   descriptors[code] = {value: code};

--- a/lib/helpers/toFormData.js
+++ b/lib/helpers/toFormData.js
@@ -69,6 +69,7 @@ function toFormData(obj, formData, options) {
   var dots = options.dots;
   var indexes = options.indexes;
   var _Blob = options.Blob || typeof Blob !== 'undefined' && Blob;
+  var maxDepth = options.maxDepth === undefined ? 100 : options.maxDepth;
   var useBlob = _Blob && isSpecCompliant(formData);
 
   if (!utils.isFunction(visitor)) {
@@ -145,8 +146,17 @@ function toFormData(obj, formData, options) {
     isVisitable: isVisitable
   });
 
-  function build(value, path) {
+  function build(value, path, depth) {
     if (utils.isUndefined(value)) return;
+
+    depth = depth || 0;
+
+    if (depth > maxDepth) {
+      throw new AxiosError(
+        'Object is too deeply nested (' + depth + ' levels). Max depth: ' + maxDepth,
+        AxiosError.ERR_FORM_DATA_DEPTH_EXCEEDED
+      );
+    }
 
     if (stack.indexOf(value) !== -1) {
       throw Error('Circular reference detected in ' + path.join('.'));
@@ -160,7 +170,7 @@ function toFormData(obj, formData, options) {
       );
 
       if (result === true) {
-        build(el, path ? path.concat(key) : [key]);
+        build(el, path ? path.concat(key) : [key], depth + 1);
       }
     });
 

--- a/test/specs/helpers/toFormData.spec.js
+++ b/test/specs/helpers/toFormData.spec.js
@@ -1,4 +1,6 @@
 var toFormData = require('../../../lib/helpers/toFormData');
+var AxiosError = require('../../../lib/core/AxiosError');
+var AxiosURLSearchParams = require('../../../lib/helpers/AxiosURLSearchParams');
 
 describe('toFormData', function () {
   it('should convert nested data object to FormData with dots option enabled', function () {
@@ -121,6 +123,100 @@ describe('toFormData', function () {
 
     expect(Array.from(form.keys()).length).toEqual(1);
     expect(form.getAll('obj{}')).toEqual([str]);
+  });
+
+  // --- Depth limit tests ---
+
+  function nest(depth) {
+    var o = { leaf: 1 };
+    for (var i = 0; i < depth; i++) o = { a: o };
+    return o;
+  }
+
+  describe('maxDepth option', function () {
+    it('should throw AxiosError when payload exceeds default depth limit (100)', function () {
+      try {
+        toFormData(nest(101), new FormData());
+        throw new Error('Should have thrown');
+      } catch (err) {
+        expect(err instanceof AxiosError).toBe(true);
+        expect(err.code).toEqual('ERR_FORM_DATA_DEPTH_EXCEEDED');
+        expect(err instanceof RangeError).toBe(false);
+      }
+    });
+
+    it('should succeed when payload is exactly at the default depth limit (100)', function () {
+      var formData = toFormData(nest(100), new FormData());
+      expect(formData instanceof FormData).toBe(true);
+    });
+
+    it('should succeed for a shallow payload (no regression)', function () {
+      var formData = toFormData(nest(5), new FormData());
+      expect(formData instanceof FormData).toBe(true);
+    });
+
+    it('should allow deeper payloads when maxDepth is raised', function () {
+      var formData = toFormData(nest(150), new FormData(), { maxDepth: 200 });
+      expect(formData instanceof FormData).toBe(true);
+    });
+
+    it('should reject shallower payloads when maxDepth is lowered', function () {
+      try {
+        toFormData(nest(10), new FormData(), { maxDepth: 5 });
+        throw new Error('Should have thrown');
+      } catch (err) {
+        expect(err instanceof AxiosError).toBe(true);
+        expect(err.code).toEqual('ERR_FORM_DATA_DEPTH_EXCEEDED');
+      }
+    });
+
+    it('should not throw for depth guard when maxDepth is Infinity', function () {
+      var formData = toFormData(nest(500), new FormData(), { maxDepth: Infinity });
+      expect(formData instanceof FormData).toBe(true);
+    });
+
+    it('should still detect circular references when depth guard is active', function () {
+      var data = { foo: 'bar' };
+      data.self = data;
+      try {
+        toFormData(data, new FormData());
+        throw new Error('Should have thrown');
+      } catch (err) {
+        expect(err.message).toContain('Circular reference detected');
+      }
+    });
+
+    it('depth limit error is catchable as AxiosError with correct code', function () {
+      var caught;
+      try {
+        toFormData(nest(101), new FormData());
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught instanceof AxiosError).toBe(true);
+      expect(caught.code).toEqual('ERR_FORM_DATA_DEPTH_EXCEEDED');
+      expect(caught instanceof RangeError).toBe(false);
+    });
+  });
+
+  describe('maxDepth — params serialization via AxiosURLSearchParams', function () {
+    it('should throw AxiosError for deeply nested params object (default limit)', function () {
+      try {
+        // eslint-disable-next-line no-new
+        new AxiosURLSearchParams(nest(101));
+        throw new Error('Should have thrown');
+      } catch (err) {
+        expect(err instanceof AxiosError).toBe(true);
+        expect(err.code).toEqual('ERR_FORM_DATA_DEPTH_EXCEEDED');
+      }
+    });
+
+    it('should build query string for deep params when maxDepth is raised', function () {
+      var params = new AxiosURLSearchParams(nest(150), { maxDepth: 200 });
+      var qs = params.toString();
+      expect(typeof qs).toEqual('string');
+      expect(qs.length > 0).toBe(true);
+    });
   });
 });
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes unbounded recursion in form and params serialization by adding a configurable maxDepth (default 100) and throwing a typed AxiosError when exceeded. Updates docs and types; ports the v1 fix to v0.x.

**Description**
- Add `maxDepth` to `toFormData` and params serialization (default 100; `Infinity` disables).
- Throw `AxiosError` with code `ERR_FORM_DATA_DEPTH_EXCEEDED` when limit is exceeded; added to error constants and `index.d.ts`.
- Preserve circular reference detection behavior.
- Update README with option docs and a security note to prevent DoS via deeply nested payloads.

**Testing**
- Add tests for default limit, exact limit, raised/lowered limits, and `Infinity`.
- Verify error type/code (`ERR_FORM_DATA_DEPTH_EXCEEDED`) and non-interference with circular reference detection.
- Add tests for deep params via `AxiosURLSearchParams` honoring `maxDepth`.

<sup>Written for commit 865aa1dd45d56a014bb5ee6612660449860951ba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

