### PR TITLE
fix: improve regex in AxiosURLSearchParams

### DIFF
--- a/lib/helpers/AxiosURLSearchParams.js
+++ b/lib/helpers/AxiosURLSearchParams.js
@@ -18,9 +18,8 @@ function encode(str) {
     ')': '%29',
     '~': '%7E',
     '%20': '+',
-    '%00': '\x00',
   };
-  return encodeURIComponent(str).replace(/[!'()~]|%20|%00/g, function replacer(match) {
+  return encodeURIComponent(str).replace(/[!'()~]|%20/g, function replacer(match) {
     return charMap[match];
   });
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix URL param encoding by removing the `%00` replacement in `AxiosURLSearchParams` to avoid inserting null bytes. The regex now skips `%00`, leaving it percent-encoded.

## Description

- Summary of changes
  - Removed `%00` from the char map and from the regex in `encode`.
  - Keeps `%20` → `+` and replacements for `! ' ( ) ~`.

- Reasoning
  - `encodeURIComponent` returns `%00` for a null byte.
  - Replacing it with `\x00` injected a raw null, which is invalid and can break consumers.

- Additional context
  - Matches standard URL encoding expectations by keeping `%00` as-is.

## Docs

No docs changes needed. Behavior now matches expected form-encoding.

## Testing

No tests were updated in this PR.
- Recommended: add tests to assert:
  - Encoding `"\x00"` yields `%00` (not a raw null).
  - Spaces still encode to `+`.
  - Existing replacements for `! ' ( ) ~` remain correct.

<sup>Written for commit 1c03ffe2047e526f5810eceafdb9fbd02944b802. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

