### PR TITLE
fix: improve regex in AxiosURLSearchParams

### DIFF
--- a/lib/helpers/AxiosURLSearchParams.js
+++ b/lib/helpers/AxiosURLSearchParams.js
@@ -9,10 +9,9 @@ function encode(str) {
     '(': '%28',
     ')': '%29',
     '~': '%7E',
-    '%20': '+',
-    '%00': '\x00'
+    '%20': '+'
   };
-  return encodeURIComponent(str).replace(/[!'\(\)~]|%20|%00/g, function replacer(match) {
+  return encodeURIComponent(str).replace(/[!'\(\)~]|%20/g, function replacer(match) {
     return charMap[match];
   });
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes URL param encoding by removing the unsafe "%00" → null-byte substitution in `AxiosURLSearchParams.encode`. This preserves "%00" as-is and prevents null byte injection; other encoding behavior is unchanged.

**Description**
- Removed the `%00` entry from the char map and its regex match in `AxiosURLSearchParams.encode`.
- Keeps `%20` → `+` and existing character replacements intact.
- Prevents null-byte insertion and aligns with standard URL encoding expectations.

**Testing**
- No tests updated in this PR.
- Recommended: add a unit test to assert `encode('\x00')` returns `%00`, and confirm spaces still encode to `+`.

<sup>Written for commit 977aa2d7adf165704f369a3a7313cddc1fa180c3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

