### PR TITLE
chore(ci): use ephemeral release branch for v1.x

### DIFF
--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -285,7 +285,9 @@ jobs:
               npm version $TYPE
             fi
           fi
-          echo "::set-output name=newTag::$(node -p "require('./package.json').version")"
+          VERSION=$(node -p "require('./package.json').version")
+          echo "newTag=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "newBranch=release-v1x/version-$VERSION" >> "$GITHUB_OUTPUT"
       - name: Bump bower etc
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -295,7 +297,8 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         with:
-          branch: 'release'
+          branch: ${{ steps.bump-version.outputs.newBranch }}
+          base: v1.x
           commit-message: 'chore(release): prepare release ${{ steps.bump-version.outputs.newTag }}'
           body: 'This PR prepares the release ${{ steps.bump-version.outputs.newTag }}.'
           title: 'chore(release): prepare release ${{ steps.bump-version.outputs.newTag }}'


### PR DESCRIPTION
Aligns with v0.x release flow. Can delete long-lived `release` branch after merging.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch v1.x release flow to CI-created, per-version branches. Retires the long‑lived `release` branch and aligns with `v0.x`.

## Description
- Replaces deprecated `::set-output` with `$GITHUB_OUTPUT`; writes `newTag` and `newBranch` from `package.json` version.
- Creates `release-v1x/version-$VERSION` and opens PRs to `v1.x` via `peter-evans/create-pull-request`.
- Synced with the latest `v1.x` to avoid drift.

## Docs
- Update any docs/automation that reference the `release` branch and plan to delete it after merge.

## Testing
- No unit tests needed.
- Validate by running the workflow and confirming a PR from `release-v1x/version-$VERSION` to `v1.x` with the correct tag and branch name in outputs.

<sup>Written for commit d42757325cc7aa8cfff063a2e910cb779e0afb6c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

