### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @jasonsaayman


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a root CODEOWNERS rule to assign all files to `@jasonsaayman`, enabling automatic review requests and clear default ownership.

## Description
- Adds `.github/CODEOWNERS` with `* @jasonsaayman`.
- Sets a single default owner for all paths to streamline reviews.

## Docs
- No user-facing docs needed.
- Future owners can add path-specific rules in the same file.

## Testing
- No tests added; none needed for a GitHub metadata configuration change.

<sup>Written for commit 419269646917d6167ea63a5bc356f5586add7f01. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

