### PR TITLE
test: migrate progressEventReducer test to vitest

### DIFF
--- a/tests/unit/helpers/progressEventReducer.test.js
+++ b/tests/unit/helpers/progressEventReducer.test.js
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import { describe, it, expect } from 'vitest';
 import { progressEventReducer } from '../../../lib/helpers/progressEventReducer.js';
 
 describe('helpers::progressEventReducer', () => {
@@ -13,15 +13,15 @@ describe('helpers::progressEventReducer', () => {
     onProgress({ lengthComputable: true, loaded: 180, total: 100 });
     flush();
 
-    assert.strictEqual(events.length, 3);
-    assert.strictEqual(events[0].bytes, 80);
-    assert.strictEqual(events[1].bytes, 0);
+    expect(events.length).toBe(3);
+    expect(events[0].bytes).toBe(80);
+    expect(events[1].bytes).toBe(0);
 
     const last = events[events.length - 1];
-    assert.strictEqual(last.loaded, 100);
-    assert.strictEqual(last.total, 100);
-    assert.strictEqual(last.progress, 1);
-    assert.strictEqual(last.upload, true);
-    assert.strictEqual(last.bytes, 20);
+    expect(last.loaded).toBe(100);
+    expect(last.total).toBe(100);
+    expect(last.progress).toBe(1);
+    expect(last.upload).toBe(true);
+    expect(last.bytes).toBe(20);
   });
 });


### PR DESCRIPTION
Remove last stray  Mocha`test/` file -> vitest `tests/`; removes old `test/` dir.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated the last `mocha` test to `vitest` and removed the old `test/` directory to standardize the test runner. This completes the move to `vitest`.

**Description**
- Switched to `vitest` (`describe`, `it`, `expect`) from Node `assert`.
- Renamed/moved test to `tests/unit/helpers/progressEventReducer.test.js`; removed legacy `test/` directory.
- Synced with `v1.x`; no logic changes.
- Update docs to reference `vitest` only; remove `mocha` mentions.

**Testing**
- Modified existing unit test; assertions equivalent and coverage unchanged.
- No new tests needed.

<sup>Written for commit e155b1c339f06d73716872a2ad2b72cb474dea00. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

