### PR TITLE
fix: stream response bypassed max content length

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -795,6 +795,30 @@ export default isHttpAdapterSupported &&
         };
 
         if (responseType === 'stream') {
+          // Enforce maxContentLength on streamed responses; previously this
+          // was applied only to buffered responses. See GHSA-vf2m-468p-8v99.
+          if (config.maxContentLength > -1) {
+            const limit = config.maxContentLength;
+            const source = responseStream;
+            async function* enforceMaxContentLength() {
+              let totalResponseBytes = 0;
+              for await (const chunk of source) {
+                totalResponseBytes += chunk.length;
+                if (totalResponseBytes > limit) {
+                  throw new AxiosError(
+                    'maxContentLength size of ' + limit + ' exceeded',
+                    AxiosError.ERR_BAD_RESPONSE,
+                    config,
+                    lastRequest
+                  );
+                }
+                yield chunk;
+              }
+            }
+            responseStream = stream.Readable.from(enforceMaxContentLength(), {
+              objectMode: false,
+            });
+          }
           response.data = responseStream;
           settle(resolve, reject, response);
         } else {

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -967,7 +967,41 @@ export default isHttpAdapterSupported &&
           }
         });
 
-        data.pipe(req);
+        // Enforce maxBodyLength for streamed uploads on the native http/https
+        // transport (maxRedirects === 0); follow-redirects enforces it on the
+        // other path. See GHSA-5c9x-8gcm-mpgx.
+        let uploadStream = data;
+        if (config.maxBodyLength > -1 && config.maxRedirects === 0) {
+          const limit = config.maxBodyLength;
+          let bytesSent = 0;
+          uploadStream = stream.pipeline(
+            [
+              data,
+              new stream.Transform({
+                transform(chunk, _enc, cb) {
+                  bytesSent += chunk.length;
+                  if (bytesSent > limit) {
+                    return cb(
+                      new AxiosError(
+                        'Request body larger than maxBodyLength limit',
+                        AxiosError.ERR_BAD_REQUEST,
+                        config,
+                        req
+                      )
+                    );
+                  }
+                  cb(null, chunk);
+                },
+              }),
+            ],
+            utils.noop
+          );
+          uploadStream.on('error', (err) => {
+            if (!req.destroyed) req.destroy(err);
+          });
+        }
+
+        uploadStream.pipe(req);
       } else {
         data && req.write(data);
         req.end();

--- a/tests/unit/adapters/http.test.js
+++ b/tests/unit/adapters/http.test.js
@@ -988,6 +988,82 @@ describe('supports http with nodejs', () => {
     }
   });
 
+  it('should enforce maxBodyLength for streamed uploads with maxRedirects: 0 (GHSA-5c9x-8gcm-mpgx)', async () => {
+    let bytesReceived = 0;
+    const server = await startHTTPServer(
+      (req, res) => {
+        req.on('data', (chunk) => {
+          bytesReceived += chunk.length;
+        });
+        req.on('end', () => {
+          res.setHeader('Content-Type', 'application/json');
+          res.end(JSON.stringify({ received: bytesReceived }));
+        });
+      },
+      { port: SERVER_PORT }
+    );
+
+    try {
+      const size = 2 * 1024 * 1024;
+      const buf = Buffer.alloc(size, 0x61);
+      const source = stream.Readable.from([buf]);
+
+      await assert.rejects(
+        axios.post(`http://localhost:${server.address().port}/`, source, {
+          maxBodyLength: 1024,
+          maxRedirects: 0,
+          headers: { 'Content-Type': 'application/octet-stream' },
+        }),
+        (error) => {
+          assert.strictEqual(error.message, 'Request body larger than maxBodyLength limit');
+          return true;
+        }
+      );
+
+      assert.ok(
+        bytesReceived <= 1024 * 4,
+        `server should not receive full payload; got ${bytesReceived}`
+      );
+    } finally {
+      await stopHTTPServer(server);
+    }
+  });
+
+  it('should allow streamed uploads under maxBodyLength with maxRedirects: 0', async () => {
+    let bytesReceived = 0;
+    const server = await startHTTPServer(
+      (req, res) => {
+        req.on('data', (chunk) => {
+          bytesReceived += chunk.length;
+        });
+        req.on('end', () => {
+          res.setHeader('Content-Type', 'application/json');
+          res.end(JSON.stringify({ received: bytesReceived }));
+        });
+      },
+      { port: SERVER_PORT }
+    );
+
+    try {
+      const payload = Buffer.alloc(512, 0x62);
+      const source = stream.Readable.from([payload]);
+
+      const response = await axios.post(
+        `http://localhost:${server.address().port}/`,
+        source,
+        {
+          maxBodyLength: 1024,
+          maxRedirects: 0,
+          headers: { 'Content-Type': 'application/octet-stream' },
+        }
+      );
+
+      assert.strictEqual(response.data.received, payload.length);
+    } finally {
+      await stopHTTPServer(server);
+    }
+  });
+
   it('should properly support default max body length (follow-redirects as well)', async () => {
     // Taken from follow-redirects defaults.
     const followRedirectsMaxBodyDefaults = 10 * 1024 * 1024;

--- a/tests/unit/adapters/http.test.js
+++ b/tests/unit/adapters/http.test.js
@@ -988,6 +988,70 @@ describe('supports http with nodejs', () => {
     }
   });
 
+  it('should enforce maxContentLength for streamed responses (GHSA-vf2m-468p-8v99)', async () => {
+    const size = 2 * 1024 * 1024;
+    const body = Buffer.alloc(size, 0x63);
+    const server = await startHTTPServer(
+      (req, res) => {
+        res.setHeader('Content-Type', 'application/octet-stream');
+        res.end(body);
+      },
+      { port: SERVER_PORT }
+    );
+
+    try {
+      const response = await axios.get(`http://localhost:${server.address().port}/`, {
+        responseType: 'stream',
+        maxContentLength: 1024,
+      });
+
+      let bytesRead = 0;
+      const err = await new Promise((resolve) => {
+        response.data.on('data', (chunk) => { bytesRead += chunk.length; });
+        response.data.on('error', resolve);
+        response.data.on('end', () => resolve(null));
+      });
+
+      assert.ok(err, 'stream should emit an error');
+      assert.strictEqual(err.message, 'maxContentLength size of 1024 exceeded');
+      assert.ok(
+        bytesRead <= 1024 * 64,
+        `stream should not deliver full payload; got ${bytesRead}`
+      );
+    } finally {
+      await stopHTTPServer(server);
+    }
+  });
+
+  it('should allow streamed responses under maxContentLength', async () => {
+    const body = Buffer.alloc(512, 0x64);
+    const server = await startHTTPServer(
+      (req, res) => {
+        res.setHeader('Content-Type', 'application/octet-stream');
+        res.end(body);
+      },
+      { port: SERVER_PORT }
+    );
+
+    try {
+      const response = await axios.get(`http://localhost:${server.address().port}/`, {
+        responseType: 'stream',
+        maxContentLength: 1024,
+      });
+
+      const chunks = [];
+      await new Promise((resolve, reject) => {
+        response.data.on('data', (chunk) => chunks.push(chunk));
+        response.data.on('error', reject);
+        response.data.on('end', resolve);
+      });
+
+      assert.strictEqual(Buffer.concat(chunks).length, body.length);
+    } finally {
+      await stopHTTPServer(server);
+    }
+  });
+
   it('should enforce maxBodyLength for streamed uploads with maxRedirects: 0 (GHSA-5c9x-8gcm-mpgx)', async () => {
     let bytesReceived = 0;
     const server = await startHTTPServer(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes a limits bypass in the Node HTTP adapter by enforcing `maxContentLength` for streamed responses and `maxBodyLength` for streamed uploads when `maxRedirects: 0`. Prevents oversized payloads from being fully read or sent, addressing GHSA-vf2m-468p-8v99 and GHSA-5c9x-8gcm-mpgx.

## Description

- Enforce `maxContentLength` for `responseType: 'stream'` by wrapping the response stream; throw `AxiosError` when the limit is exceeded.
- Enforce `maxBodyLength` for streamed uploads on native `http/https` when `maxRedirects === 0` using a counting transform; fail early and destroy the request.
- Keep existing `follow-redirects` behavior otherwise; both paths now consistently enforce limits.

## Docs

- `maxContentLength` now applies to streamed responses.
- `maxBodyLength` is enforced for streamed uploads when `maxRedirects: 0` (native transport); other cases remain enforced by `follow-redirects`.
- Clients receive an error once limits are exceeded; streams stop early.

## Testing

- Added four unit tests covering over/under limit for streamed responses and for streamed uploads with `maxRedirects: 0`.
- No additional tests needed.

<sup>Written for commit 34ea6dde50c9fea13f324b9ff57edb5ca876d73b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

