### PR TITLE
chore: added additional testing for prototype pollution

### DIFF
--- a/tests/unit/prototypePollution.test.js
+++ b/tests/unit/prototypePollution.test.js
@@ -275,6 +275,49 @@ describe('Prototype Pollution Protection', () => {
     });
   });
 
+  // GHSA-3w6x-2g7m-8v23: end-to-end check that a polluted parseReviver does not
+  // tamper with JSON response bodies through the full axios.get pipeline.
+  describe('GHSA-3w6x-2g7m-8v23 parseReviver end-to-end', () => {
+    it('should not let Object.prototype.parseReviver tamper with JSON responses', async () => {
+      let reviverCalled = false;
+      const stolen = {};
+      Object.prototype.parseReviver = function polluted(key, value) {
+        reviverCalled = true;
+        if (key && typeof value !== 'object') stolen[key] = value;
+        if (key === 'isAdmin') return true;
+        if (key === 'role') return 'admin';
+        if (key === 'balance') return 999999;
+        return value;
+      };
+
+      const payload = {
+        user: 'john',
+        role: 'viewer',
+        isAdmin: false,
+        balance: 100,
+        apiKey: 'sk-secret-internal-key',
+      };
+
+      const server = http.createServer((req, res) => {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(payload));
+      });
+
+      await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+      const { port } = server.address();
+
+      try {
+        const res = await axios.get(`http://127.0.0.1:${port}/`);
+
+        assert.strictEqual(reviverCalled, false);
+        assert.deepStrictEqual(res.data, payload);
+        assert.deepStrictEqual(stolen, {});
+      } finally {
+        await new Promise((resolve) => server.close(resolve));
+      }
+    }, 10000);
+  });
+
   // GHSA-pf86-5x62-jrwf gadget 2: http adapter must not read config.transport
   // (or related keys) from Object.prototype.
   describe('http adapter prototype reads', () => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds an end-to-end test to ensure a prototype-polluted `Object.prototype.parseReviver` cannot tamper with JSON responses in `axios.get`. Strengthens coverage for AXI-210 (invisible JSON response tampering via prototype pollution).

**Description**
- Adds an E2E test in `tests/unit/prototypePollution.test.js` that:
  - Pollutes `Object.prototype.parseReviver`
  - Serves a JSON payload over a local HTTP server
  - Asserts the reviver is never called, the response equals the original payload, and no keys are exfiltrated
- Validates the fix path for GHSA-3w6x-2g7m-8v23 through the full `axios.get` pipeline

**Docs**
- Suggest adding a short security note in `/docs/` (e.g., `security.md`) describing that response parsing is hardened against prototype-polluted revivers, referencing AXI-210 and GHSA-3w6x-2g7m-8v23

**Testing**
- Added: one E2E unit test under `tests/unit/prototypePollution.test.js`
- No other tests changed

**Semantic version impact**
- None (tests-only change; no API or behavior changes)

<sup>Written for commit 3a57ac0a28458ee73a19fcd990da19a171353846. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

