### PR TITLE
fix: prevent authentication bypass via prototype pollution

### DIFF
--- a/lib/core/mergeConfig.js
+++ b/lib/core/mergeConfig.js
@@ -56,9 +56,9 @@ export default function mergeConfig(config1, config2) {
 
   // eslint-disable-next-line consistent-return
   function mergeDirectKeys(a, b, prop) {
-    if (prop in config2) {
+    if (utils.hasOwnProp(config2, prop)) {
       return getMergedValue(a, b);
-    } else if (prop in config1) {
+    } else if (utils.hasOwnProp(config1, prop)) {
       return getMergedValue(undefined, a);
     }
   }

--- a/tests/unit/prototypePollution.test.js
+++ b/tests/unit/prototypePollution.test.js
@@ -20,6 +20,7 @@ describe('Prototype Pollution Protection', () => {
     delete Object.prototype.lookup;
     delete Object.prototype.family;
     delete Object.prototype.http2Options;
+    delete Object.prototype.validateStatus;
   });
 
   describe('utils.merge', () => {
@@ -273,6 +274,43 @@ describe('Prototype Pollution Protection', () => {
       assert.strictEqual(result, 'plain text');
       delete Object.prototype.responseType;
     });
+  });
+
+  // GHSA-w9j2-pvgh-6h63: mergeDirectKeys must not inherit validateStatus from
+  // Object.prototype (was using the `in` operator which traverses the chain).
+  describe('GHSA-w9j2-pvgh-6h63 validateStatus merge', () => {
+    it('should not inherit a polluted validateStatus during mergeConfig', () => {
+      Object.prototype.validateStatus = () => true;
+
+      const merged = mergeConfig(defaults, { url: '/x' });
+
+      assert.strictEqual(merged.validateStatus, defaults.validateStatus);
+    });
+
+    it('should keep 4xx/5xx responses rejected when Object.prototype.validateStatus is polluted', async () => {
+      Object.prototype.validateStatus = () => true;
+
+      const server = http.createServer((req, res) => {
+        res.writeHead(401, { 'Content-Type': 'application/json' });
+        res.end('{"error":"unauthorized"}');
+      });
+
+      await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+      const { port } = server.address();
+
+      try {
+        let threw = false;
+        try {
+          await axios.get(`http://127.0.0.1:${port}/`);
+        } catch (err) {
+          threw = true;
+          assert.strictEqual(err.response.status, 401);
+        }
+        assert.strictEqual(threw, true);
+      } finally {
+        await new Promise((resolve) => server.close(resolve));
+      }
+    }, 10000);
   });
 
   // GHSA-3w6x-2g7m-8v23: end-to-end check that a polluted parseReviver does not


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevents authentication bypass via prototype pollution by replacing `in` checks in `mergeConfig` with `utils.hasOwnProp`, so `validateStatus` cannot be inherited from `Object.prototype`. Adds targeted tests to ensure 4xx/5xx responses are still rejected under polluted `Object.prototype.validateStatus` (AXI-207, GHSA-w9j2-pvgh-6h63).

**Description**
- Summary of changes: Swapped `in` for `utils.hasOwnProp` in `mergeConfig` direct key merging; added focused tests for `validateStatus` inheritance and behavior.
- Reasoning: `in` traverses the prototype chain, letting a polluted `validateStatus` override config and accept all responses.
- Additional context: Addresses AXI-207 and aligns with GHSA-w9j2-pvgh-6h63.

**Docs**
- Suggest updating `/docs/` to state `mergeConfig` only merges own properties and note protection against prototype pollution (e.g., `validateStatus` cannot be inherited).

**Testing**
- Added tests in `tests/unit/prototypePollution.test.js`:
  - Ensures merged `validateStatus` comes from defaults when `Object.prototype.validateStatus` is set.
  - End-to-end check that 4xx/5xx responses remain rejected even if `Object.prototype.validateStatus` is polluted.
  - Test teardown now cleans up `Object.prototype.validateStatus` to avoid cross-test leakage.
- No other tests changed; coverage is sufficient for the fix.

**Semantic version impact**
- Patch: security bug fix; no API changes or behavior changes for valid inputs.

<sup>Written for commit 2f1f96a8cb492441b4cfb6dc29327b7c5b830f68. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

