### PR TITLE
fix: short-circuits on any truthy non-boolean in withXSRFToken

### DIFF
--- a/lib/helpers/resolveConfig.js
+++ b/lib/helpers/resolveConfig.js
@@ -54,10 +54,18 @@ export default (config) => {
   // Specifically not if we're in a web worker, or react-native.
 
   if (platform.hasStandardBrowserEnv) {
-    withXSRFToken && utils.isFunction(withXSRFToken) && (withXSRFToken = withXSRFToken(newConfig));
+    if (utils.isFunction(withXSRFToken)) {
+      withXSRFToken = withXSRFToken(newConfig);
+    }
 
-    if (withXSRFToken || (withXSRFToken !== false && isURLSameOrigin(newConfig.url))) {
-      // Add xsrf header
+    // Strict boolean check — prevents proto-pollution gadgets (e.g. Object.prototype.withXSRFToken = 1)
+    // and misconfigurations (e.g. "false") from short-circuiting the same-origin check and leaking
+    // the XSRF token cross-origin. See GHSA-xx6v-rp6x-q39c.
+    const shouldSendXSRF =
+      withXSRFToken === true ||
+      (withXSRFToken == null && isURLSameOrigin(newConfig.url));
+
+    if (shouldSendXSRF) {
       const xsrfValue = xsrfHeaderName && xsrfCookieName && cookies.read(xsrfCookieName);
 
       if (xsrfValue) {

--- a/tests/browser/xsrf.browser.test.js
+++ b/tests/browser/xsrf.browser.test.js
@@ -179,4 +179,60 @@ describe('xsrf (vitest browser)', () => {
       expect(request.requestHeaders[axios.defaults.xsrfHeaderName]).toBe(token);
     });
   });
+
+  // GHSA-xx6v-rp6x-q39c: non-boolean truthy withXSRFToken must not short-circuit
+  // the same-origin check and leak the XSRF token cross-origin.
+  describe('GHSA-xx6v-rp6x-q39c non-boolean withXSRFToken', () => {
+    afterEach(() => {
+      delete Object.prototype.withXSRFToken;
+    });
+
+    const leakCases = [
+      ['number 1', 1],
+      ['string "false"', 'false'],
+      ['empty object', {}],
+      ['empty array', []],
+    ];
+
+    leakCases.forEach(([label, value]) => {
+      it(`should not send xsrf header cross-origin when withXSRFToken = ${label}`, async () => {
+        setXsrfCookie('12345');
+
+        const request = await sendRequest('http://example.com/', {
+          withXSRFToken: value,
+        });
+
+        expect(request.requestHeaders[axios.defaults.xsrfHeaderName]).toBeUndefined();
+      });
+    });
+
+    it('should not send xsrf header cross-origin when Object.prototype.withXSRFToken is polluted', async () => {
+      Object.prototype.withXSRFToken = 1;
+      setXsrfCookie('12345');
+
+      const request = await sendRequest('http://example.com/');
+
+      expect(request.requestHeaders[axios.defaults.xsrfHeaderName]).toBeUndefined();
+    });
+
+    it('should still send xsrf header cross-origin when withXSRFToken === true (strict)', async () => {
+      const token = '12345';
+      setXsrfCookie(token);
+
+      const request = await sendRequest('http://example.com/', {
+        withXSRFToken: true,
+      });
+
+      expect(request.requestHeaders[axios.defaults.xsrfHeaderName]).toBe(token);
+    });
+
+    it('should still send xsrf header same-origin when withXSRFToken is undefined', async () => {
+      const token = '12345';
+      setXsrfCookie(token);
+
+      const request = await sendRequest('/foo');
+
+      expect(request.requestHeaders[axios.defaults.xsrfHeaderName]).toBe(token);
+    });
+  });
 });


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes XSRF token leakage by requiring `withXSRFToken === true` for cross-origin requests; otherwise the token only sends for same-origin. Adds browser tests to block truthy non-boolean values and prototype pollution (AXI-205).

## Description

- Summary of changes
  - In `lib/helpers/resolveConfig.js`, compute a strict `shouldSendXSRF` boolean.
  - Send XSRF header only when `withXSRFToken === true`, or when `withXSRFToken` is null/undefined and the URL is same-origin.
- Reasoning
  - Prevent cross-origin leakage via truthy non-boolean values and `Object.prototype` pollution (GHSA-xx6v-rp6x-q39c).
- Additional context
  - Aligns with AXI-205.
  - Synced with latest `v1.x` (no functional changes).

## Docs

Please update `/docs/` to clarify `withXSRFToken`:
- Only `true` forces sending the token cross-origin.
- Non-boolean values are ignored.
- Default (undefined) sends only on same-origin.

## Testing

- Added browser tests in `tests/browser/xsrf.browser.test.js` to:
  - Block cross-origin sends for truthy non-booleans and polluted `Object.prototype`.
  - Keep behavior for `withXSRFToken === true` cross-origin and default same-origin.
- No other test changes needed.

## Semantic version impact

Patch: security bug fix with no API changes.

<sup>Written for commit bf3a288261b803bc317606dff8201a66b0984630. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

