### PR TITLE
fix: backport security issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,11 +330,18 @@ These are the available config options for making requests. Only the `url` is re
 
   // `params` are the URL parameters to be sent with the request
   // Must be a plain object or a URLSearchParams object
+  // Null bytes in param values stay percent-encoded as `%00` in the resulting query string
+  // (GHSA-xhjh-pmcv-23jw) — Axios does not reverse `encodeURIComponent` output for `%00`,
+  // so null-byte injection cannot be smuggled through the serializer.
   params: {
     ID: 12345
   },
 
   // `paramsSerializer` is an optional config in charge of serializing `params`
+  // Nested objects are walked with a bounded recursion depth (GHSA-62hf-57xw-28j9):
+  // once `maxDepth` is exceeded the serializer throws `ERR_FORM_DATA_DEPTH_EXCEEDED`
+  // instead of overflowing the call stack. The same cap applies to `toFormData` when
+  // `Content-Type: multipart/form-data` triggers automatic FormData serialization.
   paramsSerializer: {
     indexes: null, // array indexes format (null - no brackets, false - empty brackets, true - brackets with indexes)
     maxDepth: 100 // maximum recursion depth for nested params (default: 100, Infinity disables the limit)
@@ -395,6 +402,9 @@ These are the available config options for making requests. Only the `url` is re
   xsrfHeaderName: 'X-XSRF-TOKEN', // default
 
   // `undefined` (default) - set XSRF header only for the same origin requests
+  // Only an explicit `true` (own property on the config) will add the XSRF header for
+  // cross-origin requests. Values inherited from `Object.prototype` are ignored
+  // (GHSA-xx6v-rp6x-q39c), so a polluted prototype cannot silently enable the token.
   withXSRFToken: boolean | undefined | ((config: AxiosRequestConfig) => boolean | undefined),
 
   // `onUploadProgress` allows handling of progress events for uploads
@@ -410,9 +420,13 @@ These are the available config options for making requests. Only the `url` is re
   },
 
   // `maxContentLength` defines the max size of the http response content in bytes allowed in node.js
+  // Also enforced on streamed responses (`responseType: 'stream'`): bytes are counted as they
+  // arrive and the stream is aborted with an error once the cap is exceeded (GHSA-vf2m-468p-8v99).
   maxContentLength: 2000,
 
   // `maxBodyLength` (Node only option) defines the max size of the http request content in bytes allowed
+  // Also enforced on stream uploads: uploaded bytes are tracked and the request is aborted
+  // once the cap is exceeded, even when the native http transport is used directly.
   maxBodyLength: 2000,
 
   // `validateStatus` defines whether to resolve or reject the promise for a given
@@ -598,6 +612,8 @@ instance.defaults.headers.common['Authorization'] = AUTH_TOKEN;
 ### Config order of precedence
 
 Config will be merged with an order of precedence. The order is library defaults found in [lib/defaults.js](https://github.com/axios/axios/blob/master/lib/defaults/index.js#L28), then `defaults` property of the instance, and finally `config` argument for the request. The latter will take precedence over the former. Here's an example.
+
+> Note: the merged config object is created with a null prototype (`Object.create(null)`) and only own properties of the inputs are copied across. A polluted `Object.prototype` cannot leak values (for example `transport`, `adapter`, or `transformRequest`) into the outgoing config through inheritance, and keys such as `__proto__`, `constructor`, and `prototype` are dropped during the merge.
 
 ```js
 // Create an instance using the config defaults provided by the library

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -350,8 +350,47 @@ module.exports = function httpAdapter(config) {
       };
 
       if (responseType === 'stream') {
-        response.data = responseStream;
-        settle(resolve, reject, response);
+        // Enforce maxContentLength on streamed responses too (GHSA-vf2m-468p-8v99).
+        // Previously the stream path bypassed the size guard because the check only
+        // ran on the buffering branch.
+        if (config.maxContentLength > -1) {
+          var maxContentLength = config.maxContentLength;
+          var streamedBytes = 0;
+          var limiter = new stream.Transform({
+            transform: function transformChunk(chunk, encoding, callback) {
+              streamedBytes += chunk.length;
+              if (streamedBytes > maxContentLength) {
+                callback(new AxiosError(
+                  'maxContentLength size of ' + maxContentLength + ' exceeded',
+                  AxiosError.ERR_BAD_RESPONSE,
+                  config,
+                  lastRequest
+                ));
+                return;
+              }
+              callback(null, chunk);
+            }
+          });
+          limiter.on('error', function handleLimiterError() {
+            rejected = true;
+            responseStream.destroy();
+          });
+          responseStream.on('error', function forwardError(err) {
+            limiter.destroy(err);
+          });
+          response.data = limiter;
+          settle(resolve, reject, response);
+          // Defer piping via setImmediate so the caller's `.then` (a microtask)
+          // has run and attached any `error`/`data` listeners before chunks flow
+          // through the transform. `process.nextTick` would drain before those
+          // microtasks and lose the error event.
+          setImmediate(function startPipe() {
+            responseStream.pipe(limiter);
+          });
+        } else {
+          response.data = responseStream;
+          settle(resolve, reject, response);
+        }
       } else {
         var responseBuffer = [];
         var totalResponseBytes = 0;
@@ -476,7 +515,42 @@ module.exports = function httpAdapter(config) {
     if (utils.isStream(data)) {
       data.on('error', function handleStreamError(err) {
         reject(AxiosError.from(err, config, null, req));
-      }).pipe(req);
+      });
+
+      // follow-redirects enforces options.maxBodyLength for stream uploads, but the
+      // native http/https transport (used when maxRedirects === 0) does not.
+      // Count bytes ourselves so the limit is always honored (GHSA-5c9x-8gcm-mpgx).
+      var nativeTransport = transport === http || transport === https;
+      if (nativeTransport && config.maxBodyLength > -1) {
+        var maxBodyLength = config.maxBodyLength;
+        var uploadedBytes = 0;
+        var bodyLimiter = new stream.Transform({
+          transform: function transformChunk(chunk, encoding, callback) {
+            uploadedBytes += chunk.length;
+            if (uploadedBytes > maxBodyLength) {
+              callback(new AxiosError(
+                'Request body larger than maxBodyLength limit',
+                AxiosError.ERR_BAD_REQUEST,
+                config,
+                req
+              ));
+              return;
+            }
+            callback(null, chunk);
+          }
+        });
+        bodyLimiter.on('error', function handleLimiterError(err) {
+          if (rejected) return;
+          rejected = true;
+          try { data.unpipe(bodyLimiter); } catch (e) { /* noop */ }
+          try { bodyLimiter.unpipe(req); } catch (e) { /* noop */ }
+          req.destroy();
+          reject(err);
+        });
+        data.pipe(bodyLimiter).pipe(req);
+      } else {
+        data.pipe(req);
+      }
     } else {
       req.end(data);
     }

--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -18,7 +18,8 @@ module.exports = function xhrAdapter(config) {
     var requestData = config.data;
     var requestHeaders = config.headers;
     var responseType = config.responseType;
-    var withXSRFToken = config.withXSRFToken;
+    // Guard against prototype pollution (GHSA-xx6v-rp6x-q39c): only honor own properties.
+    var withXSRFToken = utils.hasOwnProperty(config, 'withXSRFToken') ? config.withXSRFToken : undefined;
     var onCanceled;
     function done() {
       if (config.cancelToken) {
@@ -146,8 +147,11 @@ module.exports = function xhrAdapter(config) {
     // Specifically not if we're in a web worker, or react-native.
     if (utils.isStandardBrowserEnv()) {
       // Add xsrf header
-      withXSRFToken && utils.isFunction(withXSRFToken) && (withXSRFToken = withXSRFToken(config));
-      if (withXSRFToken || (withXSRFToken !== false && isURLSameOrigin(fullPath))) {
+      if (utils.isFunction(withXSRFToken)) {
+        withXSRFToken = withXSRFToken(config);
+      }
+      // Strict boolean check (GHSA-xx6v-rp6x-q39c): only `true` short-circuits the same-origin guard.
+      if (withXSRFToken === true || (withXSRFToken !== false && isURLSameOrigin(fullPath))) {
         // Add xsrf header
         var xsrfValue = config.xsrfHeaderName && config.xsrfCookieName && cookies.read(config.xsrfCookieName);
         if (xsrfValue) {

--- a/lib/core/mergeConfig.js
+++ b/lib/core/mergeConfig.js
@@ -13,7 +13,9 @@ var utils = require('../utils');
 module.exports = function mergeConfig(config1, config2) {
   // eslint-disable-next-line no-param-reassign
   config2 = config2 || {};
-  var config = {};
+  // Use a null-prototype object so a polluted Object.prototype cannot leak
+  // values (e.g. transport, adapter) into the returned config via inheritance.
+  var config = Object.create(null);
 
   function getOwn(source, prop) {
     return utils.hasOwnProperty(source, prop) ? source[prop] : undefined;

--- a/lib/helpers/AxiosURLSearchParams.js
+++ b/lib/helpers/AxiosURLSearchParams.js
@@ -3,6 +3,8 @@
 var toFormData = require('./toFormData');
 
 function encode(str) {
+  // Do not map `%00` back to a raw null byte (GHSA-xhjh-pmcv-23jw): that reversed
+  // the safe percent-encoding from encodeURIComponent and enabled null byte injection.
   var charMap = {
     '!': '%21',
     "'": '%27',

--- a/lib/helpers/toFormData.js
+++ b/lib/helpers/toFormData.js
@@ -146,7 +146,15 @@ function toFormData(obj, formData, options) {
     isVisitable: isVisitable
   });
 
+<<<<<<< HEAD
   function build(value, path, depth) {
+=======
+  // Bound recursion depth (GHSA-62hf-57xw-28j9) so deeply nested attacker-controlled
+  // payloads cannot overflow the call stack and crash the process.
+  var MAX_DEPTH = 100;
+
+  function build(value, path) {
+>>>>>>> 49f4c42 (chore backport all security fixes from v0.x)
     if (utils.isUndefined(value)) return;
 
     depth = depth || 0;
@@ -160,6 +168,13 @@ function toFormData(obj, formData, options) {
 
     if (stack.indexOf(value) !== -1) {
       throw Error('Circular reference detected in ' + path.join('.'));
+    }
+
+    if (stack.length >= MAX_DEPTH) {
+      throw new AxiosError(
+        'Maximum object depth of ' + MAX_DEPTH + ' exceeded',
+        AxiosError.ERR_BAD_REQUEST
+      );
     }
 
     stack.push(value);

--- a/lib/helpers/toFormData.js
+++ b/lib/helpers/toFormData.js
@@ -1,24 +1,27 @@
-'use strict';
+"use strict";
 
-var utils = require('../utils');
-var AxiosError = require('../core/AxiosError');
-var envFormData = require('../env/classes/FormData');
+var utils = require("../utils");
+var AxiosError = require("../core/AxiosError");
+var envFormData = require("../env/classes/FormData");
 
 function isVisitable(thing) {
   return utils.isPlainObject(thing) || utils.isArray(thing);
 }
 
 function removeBrackets(key) {
-  return utils.endsWith(key, '[]') ? key.slice(0, -2) : key;
+  return utils.endsWith(key, "[]") ? key.slice(0, -2) : key;
 }
 
 function renderKey(path, key, dots) {
   if (!path) return key;
-  return path.concat(key).map(function each(token, i) {
-    // eslint-disable-next-line no-param-reassign
-    token = removeBrackets(token);
-    return !dots && i ? '[' + token + ']' : token;
-  }).join(dots ? '.' : '');
+  return path
+    .concat(key)
+    .map(function each(token, i) {
+      // eslint-disable-next-line no-param-reassign
+      token = removeBrackets(token);
+      return !dots && i ? "[" + token + "]" : token;
+    })
+    .join(dots ? "." : "");
 }
 
 function isFlatArray(arr) {
@@ -30,7 +33,12 @@ var predicates = utils.toFlatObject(utils, {}, null, function filter(prop) {
 });
 
 function isSpecCompliant(thing) {
-  return thing && utils.isFunction(thing.append) && thing[Symbol.toStringTag] === 'FormData' && thing[Symbol.iterator];
+  return (
+    thing &&
+    utils.isFunction(thing.append) &&
+    thing[Symbol.toStringTag] === "FormData" &&
+    thing[Symbol.iterator]
+  );
 }
 
 /**
@@ -47,48 +55,55 @@ function isSpecCompliant(thing) {
 
 function toFormData(obj, formData, options) {
   if (!utils.isObject(obj)) {
-    throw new TypeError('target must be an object');
+    throw new TypeError("target must be an object");
   }
 
   // eslint-disable-next-line no-param-reassign
   formData = formData || new (envFormData || FormData)();
 
   // eslint-disable-next-line no-param-reassign
-  options = utils.toFlatObject(options, {
-    metaTokens: true,
-    dots: false,
-    indexes: false
-  }, false, function defined(option, source) {
-    // eslint-disable-next-line no-eq-null,eqeqeq
-    return !utils.isUndefined(source[option]);
-  });
+  options = utils.toFlatObject(
+    options,
+    {
+      metaTokens: true,
+      dots: false,
+      indexes: false,
+    },
+    false,
+    function defined(option, source) {
+      // eslint-disable-next-line no-eq-null,eqeqeq
+      return !utils.isUndefined(source[option]);
+    },
+  );
 
   var metaTokens = options.metaTokens;
   // eslint-disable-next-line no-use-before-define
   var visitor = options.visitor || defaultVisitor;
   var dots = options.dots;
   var indexes = options.indexes;
-  var _Blob = options.Blob || typeof Blob !== 'undefined' && Blob;
+  var _Blob = options.Blob || (typeof Blob !== "undefined" && Blob);
   var maxDepth = options.maxDepth === undefined ? 100 : options.maxDepth;
   var useBlob = _Blob && isSpecCompliant(formData);
 
   if (!utils.isFunction(visitor)) {
-    throw new TypeError('visitor must be a function');
+    throw new TypeError("visitor must be a function");
   }
 
   function convertValue(value) {
-    if (value === null) return '';
+    if (value === null) return "";
 
     if (utils.isDate(value)) {
       return value.toISOString();
     }
 
     if (!useBlob && utils.isBlob(value)) {
-      throw new AxiosError('Blob is not supported. Use a Buffer instead.');
+      throw new AxiosError("Blob is not supported. Use a Buffer instead.");
     }
 
     if (utils.isArrayBuffer(value) || utils.isTypedArray(value)) {
-      return useBlob && typeof Blob === 'function' ? new Blob([value]) : Buffer.from(value);
+      return useBlob && typeof Blob === "function"
+        ? new Blob([value])
+        : Buffer.from(value);
     }
 
     return value;
@@ -105,25 +120,31 @@ function toFormData(obj, formData, options) {
   function defaultVisitor(value, key, path) {
     var arr = value;
 
-    if (value && !path && typeof value === 'object') {
-      if (utils.endsWith(key, '{}')) {
+    if (value && !path && typeof value === "object") {
+      if (utils.endsWith(key, "{}")) {
         // eslint-disable-next-line no-param-reassign
         key = metaTokens ? key : key.slice(0, -2);
         // eslint-disable-next-line no-param-reassign
         value = JSON.stringify(value);
       } else if (
         (utils.isArray(value) && isFlatArray(value)) ||
-        (utils.isFileList(value) || utils.endsWith(key, '[]') && (arr = utils.toArray(value))
-        )) {
+        utils.isFileList(value) ||
+        (utils.endsWith(key, "[]") && (arr = utils.toArray(value)))
+      ) {
         // eslint-disable-next-line no-param-reassign
         key = removeBrackets(key);
 
         arr.forEach(function each(el, index) {
-          !(utils.isUndefined(el) || el === null) && formData.append(
-            // eslint-disable-next-line no-nested-ternary
-            indexes === true ? renderKey([key], index, dots) : (indexes === null ? key : key + '[]'),
-            convertValue(el)
-          );
+          !(utils.isUndefined(el) || el === null) &&
+            formData.append(
+              // eslint-disable-next-line no-nested-ternary
+              indexes === true
+                ? renderKey([key], index, dots)
+                : indexes === null
+                  ? key
+                  : key + "[]",
+              convertValue(el),
+            );
         });
         return false;
       }
@@ -143,46 +164,51 @@ function toFormData(obj, formData, options) {
   var exposedHelpers = Object.assign(predicates, {
     defaultVisitor: defaultVisitor,
     convertValue: convertValue,
-    isVisitable: isVisitable
+    isVisitable: isVisitable,
   });
 
-<<<<<<< HEAD
-  function build(value, path, depth) {
-=======
   // Bound recursion depth (GHSA-62hf-57xw-28j9) so deeply nested attacker-controlled
   // payloads cannot overflow the call stack and crash the process.
   var MAX_DEPTH = 100;
 
-  function build(value, path) {
->>>>>>> 49f4c42 (chore backport all security fixes from v0.x)
+  function build(value, path, depth) {
     if (utils.isUndefined(value)) return;
 
     depth = depth || 0;
 
     if (depth > maxDepth) {
       throw new AxiosError(
-        'Object is too deeply nested (' + depth + ' levels). Max depth: ' + maxDepth,
-        AxiosError.ERR_FORM_DATA_DEPTH_EXCEEDED
+        "Object is too deeply nested (" +
+          depth +
+          " levels). Max depth: " +
+          maxDepth,
+        AxiosError.ERR_FORM_DATA_DEPTH_EXCEEDED,
       );
     }
 
     if (stack.indexOf(value) !== -1) {
-      throw Error('Circular reference detected in ' + path.join('.'));
+      throw Error("Circular reference detected in " + path.join("."));
     }
 
     if (stack.length >= MAX_DEPTH) {
       throw new AxiosError(
-        'Maximum object depth of ' + MAX_DEPTH + ' exceeded',
-        AxiosError.ERR_BAD_REQUEST
+        "Maximum object depth of " + MAX_DEPTH + " exceeded",
+        AxiosError.ERR_BAD_REQUEST,
       );
     }
 
     stack.push(value);
 
     utils.forEach(value, function each(el, key) {
-      var result = !(utils.isUndefined(el) || el === null) && visitor.call(
-        formData, el, utils.isString(key) ? key.trim() : key, path, exposedHelpers
-      );
+      var result =
+        !(utils.isUndefined(el) || el === null) &&
+        visitor.call(
+          formData,
+          el,
+          utils.isString(key) ? key.trim() : key,
+          path,
+          exposedHelpers,
+        );
 
       if (result === true) {
         build(el, path ? path.concat(key) : [key], depth + 1);
@@ -193,10 +219,10 @@ function toFormData(obj, formData, options) {
   }
 
   if (!utils.isObject(obj)) {
-    throw new TypeError('data must be an object');
+    throw new TypeError("data must be an object");
   }
 
-  build(obj);
+  build(obj, null, 0);
 
   return formData;
 }

--- a/lib/helpers/toFormData.js
+++ b/lib/helpers/toFormData.js
@@ -1,27 +1,24 @@
-"use strict";
+'use strict';
 
-var utils = require("../utils");
-var AxiosError = require("../core/AxiosError");
-var envFormData = require("../env/classes/FormData");
+var utils = require('../utils');
+var AxiosError = require('../core/AxiosError');
+var envFormData = require('../env/classes/FormData');
 
 function isVisitable(thing) {
   return utils.isPlainObject(thing) || utils.isArray(thing);
 }
 
 function removeBrackets(key) {
-  return utils.endsWith(key, "[]") ? key.slice(0, -2) : key;
+  return utils.endsWith(key, '[]') ? key.slice(0, -2) : key;
 }
 
 function renderKey(path, key, dots) {
   if (!path) return key;
-  return path
-    .concat(key)
-    .map(function each(token, i) {
-      // eslint-disable-next-line no-param-reassign
-      token = removeBrackets(token);
-      return !dots && i ? "[" + token + "]" : token;
-    })
-    .join(dots ? "." : "");
+  return path.concat(key).map(function each(token, i) {
+    // eslint-disable-next-line no-param-reassign
+    token = removeBrackets(token);
+    return !dots && i ? '[' + token + ']' : token;
+  }).join(dots ? '.' : '');
 }
 
 function isFlatArray(arr) {
@@ -33,12 +30,7 @@ var predicates = utils.toFlatObject(utils, {}, null, function filter(prop) {
 });
 
 function isSpecCompliant(thing) {
-  return (
-    thing &&
-    utils.isFunction(thing.append) &&
-    thing[Symbol.toStringTag] === "FormData" &&
-    thing[Symbol.iterator]
-  );
+  return thing && utils.isFunction(thing.append) && thing[Symbol.toStringTag] === 'FormData' && thing[Symbol.iterator];
 }
 
 /**
@@ -55,55 +47,48 @@ function isSpecCompliant(thing) {
 
 function toFormData(obj, formData, options) {
   if (!utils.isObject(obj)) {
-    throw new TypeError("target must be an object");
+    throw new TypeError('target must be an object');
   }
 
   // eslint-disable-next-line no-param-reassign
   formData = formData || new (envFormData || FormData)();
 
   // eslint-disable-next-line no-param-reassign
-  options = utils.toFlatObject(
-    options,
-    {
-      metaTokens: true,
-      dots: false,
-      indexes: false,
-    },
-    false,
-    function defined(option, source) {
-      // eslint-disable-next-line no-eq-null,eqeqeq
-      return !utils.isUndefined(source[option]);
-    },
-  );
+  options = utils.toFlatObject(options, {
+    metaTokens: true,
+    dots: false,
+    indexes: false
+  }, false, function defined(option, source) {
+    // eslint-disable-next-line no-eq-null,eqeqeq
+    return !utils.isUndefined(source[option]);
+  });
 
   var metaTokens = options.metaTokens;
   // eslint-disable-next-line no-use-before-define
   var visitor = options.visitor || defaultVisitor;
   var dots = options.dots;
   var indexes = options.indexes;
-  var _Blob = options.Blob || (typeof Blob !== "undefined" && Blob);
+  var _Blob = options.Blob || typeof Blob !== 'undefined' && Blob;
   var maxDepth = options.maxDepth === undefined ? 100 : options.maxDepth;
   var useBlob = _Blob && isSpecCompliant(formData);
 
   if (!utils.isFunction(visitor)) {
-    throw new TypeError("visitor must be a function");
+    throw new TypeError('visitor must be a function');
   }
 
   function convertValue(value) {
-    if (value === null) return "";
+    if (value === null) return '';
 
     if (utils.isDate(value)) {
       return value.toISOString();
     }
 
     if (!useBlob && utils.isBlob(value)) {
-      throw new AxiosError("Blob is not supported. Use a Buffer instead.");
+      throw new AxiosError('Blob is not supported. Use a Buffer instead.');
     }
 
     if (utils.isArrayBuffer(value) || utils.isTypedArray(value)) {
-      return useBlob && typeof Blob === "function"
-        ? new Blob([value])
-        : Buffer.from(value);
+      return useBlob && typeof Blob === 'function' ? new Blob([value]) : Buffer.from(value);
     }
 
     return value;
@@ -120,31 +105,25 @@ function toFormData(obj, formData, options) {
   function defaultVisitor(value, key, path) {
     var arr = value;
 
-    if (value && !path && typeof value === "object") {
-      if (utils.endsWith(key, "{}")) {
+    if (value && !path && typeof value === 'object') {
+      if (utils.endsWith(key, '{}')) {
         // eslint-disable-next-line no-param-reassign
         key = metaTokens ? key : key.slice(0, -2);
         // eslint-disable-next-line no-param-reassign
         value = JSON.stringify(value);
       } else if (
         (utils.isArray(value) && isFlatArray(value)) ||
-        utils.isFileList(value) ||
-        (utils.endsWith(key, "[]") && (arr = utils.toArray(value)))
-      ) {
+        (utils.isFileList(value) || utils.endsWith(key, '[]') && (arr = utils.toArray(value))
+        )) {
         // eslint-disable-next-line no-param-reassign
         key = removeBrackets(key);
 
         arr.forEach(function each(el, index) {
-          !(utils.isUndefined(el) || el === null) &&
-            formData.append(
-              // eslint-disable-next-line no-nested-ternary
-              indexes === true
-                ? renderKey([key], index, dots)
-                : indexes === null
-                  ? key
-                  : key + "[]",
-              convertValue(el),
-            );
+          !(utils.isUndefined(el) || el === null) && formData.append(
+            // eslint-disable-next-line no-nested-ternary
+            indexes === true ? renderKey([key], index, dots) : (indexes === null ? key : key + '[]'),
+            convertValue(el)
+          );
         });
         return false;
       }
@@ -164,51 +143,32 @@ function toFormData(obj, formData, options) {
   var exposedHelpers = Object.assign(predicates, {
     defaultVisitor: defaultVisitor,
     convertValue: convertValue,
-    isVisitable: isVisitable,
+    isVisitable: isVisitable
   });
-
-  // Bound recursion depth (GHSA-62hf-57xw-28j9) so deeply nested attacker-controlled
-  // payloads cannot overflow the call stack and crash the process.
-  var MAX_DEPTH = 100;
 
   function build(value, path, depth) {
     if (utils.isUndefined(value)) return;
 
+    // eslint-disable-next-line no-param-reassign
     depth = depth || 0;
 
     if (depth > maxDepth) {
       throw new AxiosError(
-        "Object is too deeply nested (" +
-          depth +
-          " levels). Max depth: " +
-          maxDepth,
-        AxiosError.ERR_FORM_DATA_DEPTH_EXCEEDED,
+        'Maximum object depth of ' + maxDepth + ' exceeded (got ' + depth + ' levels)',
+        AxiosError.ERR_FORM_DATA_DEPTH_EXCEEDED
       );
     }
 
     if (stack.indexOf(value) !== -1) {
-      throw Error("Circular reference detected in " + path.join("."));
-    }
-
-    if (stack.length >= MAX_DEPTH) {
-      throw new AxiosError(
-        "Maximum object depth of " + MAX_DEPTH + " exceeded",
-        AxiosError.ERR_BAD_REQUEST,
-      );
+      throw Error('Circular reference detected in ' + path.join('.'));
     }
 
     stack.push(value);
 
     utils.forEach(value, function each(el, key) {
-      var result =
-        !(utils.isUndefined(el) || el === null) &&
-        visitor.call(
-          formData,
-          el,
-          utils.isString(key) ? key.trim() : key,
-          path,
-          exposedHelpers,
-        );
+      var result = !(utils.isUndefined(el) || el === null) && visitor.call(
+        formData, el, utils.isString(key) ? key.trim() : key, path, exposedHelpers
+      );
 
       if (result === true) {
         build(el, path ? path.concat(key) : [key], depth + 1);
@@ -219,7 +179,7 @@ function toFormData(obj, formData, options) {
   }
 
   if (!utils.isObject(obj)) {
-    throw new TypeError("data must be an object");
+    throw new TypeError('data must be an object');
   }
 
   build(obj, null, 0);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -208,6 +208,9 @@ function isFormData(thing) {
   var pattern = '[object FormData]';
   if (!thing) return false;
   if (typeof FormData === 'function' && thing instanceof FormData) return true;
+  // Reject non-objects (strings, numbers, booleans) up front — Object.getPrototypeOf
+  // throws a TypeError on primitives in ES5 environments.
+  if (!isObject(thing)) return false;
   // Reject plain objects inheriting directly from Object.prototype so prototype-pollution gadgets can't spoof FormData (GHSA-6chq-wfr3-2hj9).
   var proto = Object.getPrototypeOf(thing);
   if (!proto || proto === Object.prototype) return false;

--- a/test/unit/adapters/http.js
+++ b/test/unit/adapters/http.js
@@ -2137,48 +2137,34 @@ describe("supports http with nodejs", function () {
 
     it("should not merge prototype-polluted getHeaders into outgoing request", function (done) {
       var receivedHeaders;
-      server = http
-        .createServer(function (req, res) {
-          receivedHeaders = req.headers;
-          res.end("{}");
-        })
-        .listen(4444, function () {
-          pollute();
-          var finish = function (requestError) {
-            cleanup();
-            try {
-              if (receivedHeaders) {
-                assert.strictEqual(receivedHeaders["x-injected"], undefined);
-                assert.notStrictEqual(
-                  receivedHeaders["authorization"],
-                  "Bearer ATTACKER_TOKEN",
-                );
-              } else {
-                assert.ok(
-                  requestError,
-                  "expected request to either reach server or error",
-                );
-              }
-              done();
-            } catch (e) {
-              done(e);
-            }
-          };
-          axios
-            .post(
-              "http://localhost:4444/",
-              { userId: 42 },
-              {
-                headers: { Authorization: "Bearer VALID_USER_TOKEN" },
-              },
-            )
-            .then(function () {
-              finish();
-            })
-            .catch(function (err) {
-              finish(err);
-            });
+      server = http.createServer(function (req, res) {
+        receivedHeaders = req.headers;
+        res.end('{}');
+      }).listen(4444, function () {
+        pollute();
+        var finish = function (requestError) {
+          cleanup();
+          try {
+            assert.ok(
+              receivedHeaders,
+              'request must reach server to prove polluted headers were not merged' +
+                (requestError ? ' (request errored: ' + requestError.message + ')' : '')
+            );
+            assert.strictEqual(receivedHeaders['x-injected'], undefined);
+            assert.notStrictEqual(receivedHeaders['authorization'], 'Bearer ATTACKER_TOKEN');
+            done();
+          } catch (e) {
+            done(e);
+          }
+        };
+        axios.post('http://localhost:4444/', { userId: 42 }, {
+          headers: { 'Authorization': 'Bearer VALID_USER_TOKEN' }
+        }).then(function () {
+          finish();
+        }).catch(function (err) {
+          finish(err);
         });
+      });
     });
   });
 });

--- a/test/unit/adapters/http.js
+++ b/test/unit/adapters/http.js
@@ -2104,6 +2104,129 @@ describe("supports http with nodejs", function () {
       });
   });
 
+  describe("maxContentLength with responseType stream (GHSA-vf2m-468p-8v99)", function () {
+    it("should reject when streamed response exceeds maxContentLength", function (done) {
+      var payload = Buffer.alloc(2048, "a");
+      server = http
+        .createServer(function (req, res) {
+          res.end(payload);
+        })
+        .listen(4444, function () {
+          axios
+            .get("http://localhost:4444/", {
+              responseType: "stream",
+              maxContentLength: 1024,
+            })
+            .then(function (response) {
+              var received = 0;
+              var errored = false;
+              response.data.on("data", function (chunk) {
+                received += chunk.length;
+              });
+              response.data.on("error", function (err) {
+                errored = true;
+                assert.ok(
+                  /maxContentLength/.test(err.message),
+                  "expected maxContentLength error, got " + err.message,
+                );
+                done();
+              });
+              response.data.on("end", function () {
+                if (!errored) {
+                  done(
+                    new Error(
+                      "stream ended without error; received " +
+                        received +
+                        " bytes",
+                    ),
+                  );
+                }
+              });
+            })
+            .catch(done);
+        });
+    });
+
+    it("should allow streamed responses under maxContentLength", function (done) {
+      var payload = Buffer.alloc(512, "b");
+      server = http
+        .createServer(function (req, res) {
+          res.end(payload);
+        })
+        .listen(4444, function () {
+          axios
+            .get("http://localhost:4444/", {
+              responseType: "stream",
+              maxContentLength: 1024,
+            })
+            .then(function (response) {
+              var chunks = [];
+              response.data.on("data", function (chunk) {
+                chunks.push(chunk);
+              });
+              response.data.on("end", function () {
+                var body = Buffer.concat(chunks);
+                assert.strictEqual(body.length, 512);
+                done();
+              });
+              response.data.on("error", done);
+            })
+            .catch(done);
+        });
+    });
+  });
+
+  describe("maxBodyLength with streamed upload and maxRedirects=0 (GHSA-5c9x-8gcm-mpgx)", function () {
+    it("should reject streamed upload exceeding maxBodyLength with native transport", function (done) {
+      var received = 0;
+      server = http
+        .createServer(function (req, res) {
+          req.on("data", function (chunk) {
+            received += chunk.length;
+          });
+          req.on("end", function () {
+            res.end(JSON.stringify({ received: received }));
+          });
+        })
+        .listen(4444, function () {
+          var stream = require("stream");
+          var Readable = stream.Readable;
+          var chunks = [];
+          for (var i = 0; i < 20; i++) chunks.push(Buffer.alloc(1024, "c"));
+          var body = Readable.from(chunks);
+          axios
+            .post("http://localhost:4444/", body, {
+              maxBodyLength: 1024,
+              maxRedirects: 0,
+            })
+            .then(function () {
+              done(
+                new Error(
+                  "expected maxBodyLength rejection, got success (received " +
+                    received +
+                    ")",
+                ),
+              );
+            })
+            .catch(function (err) {
+              try {
+                assert.ok(
+                  err instanceof AxiosError,
+                  "expected AxiosError, got " + err,
+                );
+                assert.ok(
+                  /maxBodyLength/.test(err.message),
+                  "expected maxBodyLength error, got " + err.message,
+                );
+                done();
+              } catch (e) {
+                done(e);
+              }
+            });
+        });
+    });
+  });
+
   describe("prototype pollution (GHSA-6chq-wfr3-2hj9)", function () {
     var pollutedKeys = ["getHeaders", "append", "pipe", "on", "once"];
     var toStringTagSym = Symbol.toStringTag;
@@ -2137,34 +2260,48 @@ describe("supports http with nodejs", function () {
 
     it("should not merge prototype-polluted getHeaders into outgoing request", function (done) {
       var receivedHeaders;
-      server = http.createServer(function (req, res) {
-        receivedHeaders = req.headers;
-        res.end('{}');
-      }).listen(4444, function () {
-        pollute();
-        var finish = function (requestError) {
-          cleanup();
-          try {
-            assert.ok(
-              receivedHeaders,
-              'request must reach server to prove polluted headers were not merged' +
-                (requestError ? ' (request errored: ' + requestError.message + ')' : '')
-            );
-            assert.strictEqual(receivedHeaders['x-injected'], undefined);
-            assert.notStrictEqual(receivedHeaders['authorization'], 'Bearer ATTACKER_TOKEN');
-            done();
-          } catch (e) {
-            done(e);
-          }
-        };
-        axios.post('http://localhost:4444/', { userId: 42 }, {
-          headers: { 'Authorization': 'Bearer VALID_USER_TOKEN' }
-        }).then(function () {
-          finish();
-        }).catch(function (err) {
-          finish(err);
+      server = http
+        .createServer(function (req, res) {
+          receivedHeaders = req.headers;
+          res.end("{}");
+        })
+        .listen(4444, function () {
+          pollute();
+          var finish = function (requestError) {
+            cleanup();
+            try {
+              assert.ok(
+                receivedHeaders,
+                "request must reach server to prove polluted headers were not merged" +
+                  (requestError
+                    ? " (request errored: " + requestError.message + ")"
+                    : ""),
+              );
+              assert.strictEqual(receivedHeaders["x-injected"], undefined);
+              assert.notStrictEqual(
+                receivedHeaders["authorization"],
+                "Bearer ATTACKER_TOKEN",
+              );
+              done();
+            } catch (e) {
+              done(e);
+            }
+          };
+          axios
+            .post(
+              "http://localhost:4444/",
+              { userId: 42 },
+              {
+                headers: { Authorization: "Bearer VALID_USER_TOKEN" },
+              },
+            )
+            .then(function () {
+              finish();
+            })
+            .catch(function (err) {
+              finish(err);
+            });
         });
-      });
     });
   });
 });

--- a/test/unit/adapters/http.js
+++ b/test/unit/adapters/http.js
@@ -1,26 +1,25 @@
-var axios = require('../../../index');
-var http = require('http');
-var https = require('https');
-var net = require('net');
-var url = require('url');
-var zlib = require('zlib');
-var assert = require('assert');
-var fs = require('fs');
-var path = require('path');
-var pkg = require('./../../../package.json');
+var axios = require("../../../index");
+var http = require("http");
+var https = require("https");
+var net = require("net");
+var url = require("url");
+var zlib = require("zlib");
+var assert = require("assert");
+var fs = require("fs");
+var path = require("path");
+var pkg = require("./../../../package.json");
 var server, proxy;
-var AxiosError = require('../../../lib/core/AxiosError');
-var FormData = require('form-data');
-var formidable = require('formidable');
-var express = require('express');
-var multer = require('multer');
-var bodyParser = require('body-parser');
-const isBlobSupported = typeof Blob !== 'undefined';
+var AxiosError = require("../../../lib/core/AxiosError");
+var FormData = require("form-data");
+var formidable = require("formidable");
+var express = require("express");
+var multer = require("multer");
+var bodyParser = require("body-parser");
+var isBlobSupported = typeof Blob !== "undefined";
 
-var noop = ()=> {};
+var noop = () => {};
 
-describe('supports http with nodejs', function () {
-
+describe("supports http with nodejs", function () {
   afterEach(function () {
     if (server) {
       server.close();
@@ -37,1472 +36,1867 @@ describe('supports http with nodejs', function () {
     delete process.env.NO_PROXY;
   });
 
-  it('should sanitize request headers containing invalid characters', function (done) {
-    server = http.createServer(function (req, res) {
-      res.setHeader('Content-Type', 'text/plain');
-      res.end(req.headers['x-test']);
-    }).listen(4444, function () {
-      axios.get('http://localhost:4444/', {
+  it("should sanitize request headers containing invalid characters", function (done) {
+    server = http
+      .createServer(function (req, res) {
+        res.setHeader("Content-Type", "text/plain");
+        res.end(req.headers["x-test"]);
+      })
+      .listen(4444, function () {
+        axios
+          .get("http://localhost:4444/", {
+            headers: {
+              "x-test": " ok\r\nInjected: yes\t",
+            },
+          })
+          .then(function (response) {
+            assert.equal(response.data, "okInjected: yes");
+            done();
+          })
+          .catch(done);
+      });
+  });
+
+  it("should preserve request error for unavailable host with invalid characters", function (done) {
+    axios
+      .get("http://localhost:1/", {
         headers: {
-          'x-test': ' ok\r\nInjected: yes\t'
+          "x-test": "ok\r\nInjected: yes",
+        },
+      })
+      .then(function () {
+        done(new Error("request should not succeed"));
+      })
+      .catch(function (error) {
+        assert.notEqual(
+          error.message,
+          'Invalid character in header content ["x-test"]',
+        );
+        done();
+      });
+  });
+
+  it("should throw an error if the timeout property is not parsable as a number", function (done) {
+    server = http
+      .createServer(function (req, res) {
+        setTimeout(function () {
+          res.end();
+        }, 1000);
+      })
+      .listen(4444, function () {
+        var success = false,
+          failure = false;
+        var error;
+
+        axios
+          .get("http://localhost:4444/", {
+            timeout: { strangeTimeout: 250 },
+          })
+          .then(function (res) {
+            success = true;
+          })
+          .catch(function (err) {
+            error = err;
+            failure = true;
+          });
+
+        setTimeout(function () {
+          assert.equal(success, false, "request should not succeed");
+          assert.equal(failure, true, "request should fail");
+          assert.equal(error.code, AxiosError.ERR_BAD_OPTION_VALUE);
+          assert.equal(
+            error.message,
+            "error trying to parse `config.timeout` to int",
+          );
+          done();
+        }, 300);
+      });
+  });
+
+  it("should parse the timeout property", function (done) {
+    server = http
+      .createServer(function (req, res) {
+        setTimeout(function () {
+          res.end();
+        }, 1000);
+      })
+      .listen(4444, function () {
+        var success = false,
+          failure = false;
+        var error;
+
+        axios
+          .get("http://localhost:4444/", {
+            timeout: "250",
+          })
+          .then(function (res) {
+            success = true;
+          })
+          .catch(function (err) {
+            error = err;
+            failure = true;
+          });
+
+        setTimeout(function () {
+          assert.equal(success, false, "request should not succeed");
+          assert.equal(failure, true, "request should fail");
+          assert.equal(error.code, "ECONNABORTED");
+          assert.equal(error.message, "timeout of 250ms exceeded");
+          done();
+        }, 300);
+      });
+  });
+
+  it("should respect the timeout property", function (done) {
+    server = http
+      .createServer(function (req, res) {
+        setTimeout(function () {
+          res.end();
+        }, 1000);
+      })
+      .listen(4444, function () {
+        var success = false,
+          failure = false;
+        var error;
+
+        axios
+          .get("http://localhost:4444/", {
+            timeout: 250,
+          })
+          .then(function (res) {
+            success = true;
+          })
+          .catch(function (err) {
+            error = err;
+            failure = true;
+          });
+
+        setTimeout(function () {
+          assert.equal(success, false, "request should not succeed");
+          assert.equal(failure, true, "request should fail");
+          assert.equal(error.code, "ECONNABORTED");
+          assert.equal(error.message, "timeout of 250ms exceeded");
+          done();
+        }, 300);
+      });
+  });
+
+  it("should respect the timeoutErrorMessage property", function (done) {
+    server = http
+      .createServer(function (req, res) {
+        setTimeout(function () {
+          res.end();
+        }, 1000);
+      })
+      .listen(4444, function () {
+        var success = false,
+          failure = false;
+        var error;
+
+        axios
+          .get("http://localhost:4444/", {
+            timeout: 250,
+            timeoutErrorMessage: "oops, timeout",
+          })
+          .then(function (res) {
+            success = true;
+          })
+          .catch(function (err) {
+            error = err;
+            failure = true;
+          });
+
+        setTimeout(function () {
+          assert.strictEqual(success, false, "request should not succeed");
+          assert.strictEqual(failure, true, "request should fail");
+          assert.strictEqual(error.code, "ECONNABORTED");
+          assert.strictEqual(error.message, "oops, timeout");
+          done();
+        }, 300);
+      });
+  });
+
+  it("should allow passing JSON", function (done) {
+    var data = {
+      firstName: "Fred",
+      lastName: "Flintstone",
+      emailAddr: "fred@example.com",
+    };
+
+    server = http
+      .createServer(function (req, res) {
+        res.setHeader("Content-Type", "application/json");
+        res.end(JSON.stringify(data));
+      })
+      .listen(4444, function () {
+        axios
+          .get("http://localhost:4444/")
+          .then(function (res) {
+            assert.deepEqual(res.data, data);
+            done();
+          })
+          .catch(done);
+      });
+  });
+
+  it("should allow passing JSON with BOM", function (done) {
+    var data = {
+      firstName: "Fred",
+      lastName: "Flintstone",
+      emailAddr: "fred@example.com",
+    };
+
+    server = http
+      .createServer(function (req, res) {
+        res.setHeader("Content-Type", "application/json");
+        var bomBuffer = Buffer.from([0xef, 0xbb, 0xbf]);
+        var jsonBuffer = Buffer.from(JSON.stringify(data));
+        res.end(Buffer.concat([bomBuffer, jsonBuffer]));
+      })
+      .listen(4444, function () {
+        axios
+          .get("http://localhost:4444/")
+          .then(function (res) {
+            assert.deepEqual(res.data, data);
+            done();
+          })
+          .catch(done);
+      });
+  });
+
+  it("should redirect", function (done) {
+    var str = "test response";
+
+    server = http
+      .createServer(function (req, res) {
+        var parsed = url.parse(req.url);
+
+        if (parsed.pathname === "/one") {
+          res.setHeader("Location", "/two");
+          res.statusCode = 302;
+          res.end();
+        } else {
+          res.end(str);
         }
-      }).then(function (response) {
-        assert.equal(response.data, 'okInjected: yes');
-        done();
-      }).catch(done);
-    });
-  });
-
-  it('should preserve request error for unavailable host with invalid characters', function (done) {
-    axios.get('http://localhost:1/', {
-      headers: {
-        'x-test': 'ok\r\nInjected: yes'
-      }
-    }).then(function () {
-      done(new Error('request should not succeed'));
-    }).catch(function (error) {
-      assert.notEqual(error.message, 'Invalid character in header content ["x-test"]');
-      done();
-    });
-  });
-
-  it('should throw an error if the timeout property is not parsable as a number', function (done) {
-
-    server = http.createServer(function (req, res) {
-      setTimeout(function () {
-        res.end();
-      }, 1000);
-    }).listen(4444, function () {
-      var success = false, failure = false;
-      var error;
-
-      axios.get('http://localhost:4444/', {
-        timeout: { strangeTimeout: 250 }
-      }).then(function (res) {
-        success = true;
-      }).catch(function (err) {
-        error = err;
-        failure = true;
+      })
+      .listen(4444, function () {
+        axios
+          .get("http://localhost:4444/one")
+          .then(function (res) {
+            assert.equal(res.data, str);
+            assert.equal(res.request.path, "/two");
+            done();
+          })
+          .catch(done);
       });
-
-      setTimeout(function () {
-        assert.equal(success, false, 'request should not succeed');
-        assert.equal(failure, true, 'request should fail');
-        assert.equal(error.code, AxiosError.ERR_BAD_OPTION_VALUE);
-        assert.equal(error.message, 'error trying to parse `config.timeout` to int');
-        done();
-      }, 300);
-    });
   });
 
-  it('should parse the timeout property', function (done) {
-
-    server = http.createServer(function (req, res) {
-      setTimeout(function () {
-        res.end();
-      }, 1000);
-    }).listen(4444, function () {
-      var success = false, failure = false;
-      var error;
-
-      axios.get('http://localhost:4444/', {
-        timeout: '250'
-      }).then(function (res) {
-        success = true;
-      }).catch(function (err) {
-        error = err;
-        failure = true;
-      });
-
-      setTimeout(function () {
-        assert.equal(success, false, 'request should not succeed');
-        assert.equal(failure, true, 'request should fail');
-        assert.equal(error.code, 'ECONNABORTED');
-        assert.equal(error.message, 'timeout of 250ms exceeded');
-        done();
-      }, 300);
-    });
-  });
-
-  it('should respect the timeout property', function (done) {
-
-    server = http.createServer(function (req, res) {
-      setTimeout(function () {
-        res.end();
-      }, 1000);
-    }).listen(4444, function () {
-      var success = false, failure = false;
-      var error;
-
-      axios.get('http://localhost:4444/', {
-        timeout: 250
-      }).then(function (res) {
-        success = true;
-      }).catch(function (err) {
-        error = err;
-        failure = true;
-      });
-
-      setTimeout(function () {
-        assert.equal(success, false, 'request should not succeed');
-        assert.equal(failure, true, 'request should fail');
-        assert.equal(error.code, 'ECONNABORTED');
-        assert.equal(error.message, 'timeout of 250ms exceeded');
-        done();
-      }, 300);
-    });
-  });
-
-  it('should respect the timeoutErrorMessage property', function (done) {
-
-    server = http.createServer(function (req, res) {
-      setTimeout(function () {
-        res.end();
-      }, 1000);
-    }).listen(4444, function () {
-      var success = false, failure = false;
-      var error;
-
-      axios.get('http://localhost:4444/', {
-        timeout: 250,
-        timeoutErrorMessage: 'oops, timeout',
-      }).then(function (res) {
-        success = true;
-      }).catch(function (err) {
-        error = err;
-        failure = true;
-      });
-
-      setTimeout(function () {
-        assert.strictEqual(success, false, 'request should not succeed');
-        assert.strictEqual(failure, true, 'request should fail');
-        assert.strictEqual(error.code, 'ECONNABORTED');
-        assert.strictEqual(error.message, 'oops, timeout');
-        done();
-      }, 300);
-    });
-  });
-
-  it('should allow passing JSON', function (done) {
-    var data = {
-      firstName: 'Fred',
-      lastName: 'Flintstone',
-      emailAddr: 'fred@example.com'
-    };
-
-    server = http.createServer(function (req, res) {
-      res.setHeader('Content-Type', 'application/json');
-      res.end(JSON.stringify(data));
-    }).listen(4444, function () {
-      axios.get('http://localhost:4444/').then(function (res) {
-        assert.deepEqual(res.data, data);
-        done();
-      }).catch(done);
-    });
-  });
-
-  it('should allow passing JSON with BOM', function (done) {
-    var data = {
-      firstName: 'Fred',
-      lastName: 'Flintstone',
-      emailAddr: 'fred@example.com'
-    };
-
-    server = http.createServer(function (req, res) {
-      res.setHeader('Content-Type', 'application/json');
-      var bomBuffer = Buffer.from([0xEF, 0xBB, 0xBF])
-      var jsonBuffer = Buffer.from(JSON.stringify(data));
-      res.end(Buffer.concat([bomBuffer, jsonBuffer]));
-    }).listen(4444, function () {
-      axios.get('http://localhost:4444/').then(function (res) {
-        assert.deepEqual(res.data, data);
-        done();
-      }).catch(done);;
-    });
-  });
-
-  it('should redirect', function (done) {
-    var str = 'test response';
-
-    server = http.createServer(function (req, res) {
-      var parsed = url.parse(req.url);
-
-      if (parsed.pathname === '/one') {
-        res.setHeader('Location', '/two');
+  it("should not redirect", function (done) {
+    server = http
+      .createServer(function (req, res) {
+        res.setHeader("Location", "/foo");
         res.statusCode = 302;
         res.end();
-      } else {
-        res.end(str);
-      }
-    }).listen(4444, function () {
-      axios.get('http://localhost:4444/one').then(function (res) {
-        assert.equal(res.data, str);
-        assert.equal(res.request.path, '/two');
-        done();
-      }).catch(done);
-    });
+      })
+      .listen(4444, function () {
+        axios
+          .get("http://localhost:4444/", {
+            maxRedirects: 0,
+            validateStatus: function () {
+              return true;
+            },
+          })
+          .then(function (res) {
+            assert.equal(res.status, 302);
+            assert.equal(res.headers["location"], "/foo");
+            done();
+          })
+          .catch(done);
+      });
   });
 
-  it('should not redirect', function (done) {
-    server = http.createServer(function (req, res) {
-      res.setHeader('Location', '/foo');
-      res.statusCode = 302;
-      res.end();
-    }).listen(4444, function () {
-      axios.get('http://localhost:4444/', {
-        maxRedirects: 0,
-        validateStatus: function () {
-          return true;
-        }
-      }).then(function (res) {
-        assert.equal(res.status, 302);
-        assert.equal(res.headers['location'], '/foo');
-        done();
-      }).catch(done);
-    });
-  });
-
-  it('should support max redirects', function (done) {
+  it("should support max redirects", function (done) {
     var i = 1;
-    server = http.createServer(function (req, res) {
-      res.setHeader('Location', '/' + i);
-      res.statusCode = 302;
-      res.end();
-      i++;
-    }).listen(4444, function () {
-      axios.get('http://localhost:4444/', {
-        maxRedirects: 3
-      }).catch(function (error) {
-        assert.equal(error.code, AxiosError.ERR_FR_TOO_MANY_REDIRECTS);
-        assert.equal(error.message, 'Maximum number of redirects exceeded');
-        done();
-      }).catch(done);
-    });
+    server = http
+      .createServer(function (req, res) {
+        res.setHeader("Location", "/" + i);
+        res.statusCode = 302;
+        res.end();
+        i++;
+      })
+      .listen(4444, function () {
+        axios
+          .get("http://localhost:4444/", {
+            maxRedirects: 3,
+          })
+          .catch(function (error) {
+            assert.equal(error.code, AxiosError.ERR_FR_TOO_MANY_REDIRECTS);
+            assert.equal(error.message, "Maximum number of redirects exceeded");
+            done();
+          })
+          .catch(done);
+      });
   });
 
-  it('should support beforeRedirect', function (done) {
-    server = http.createServer(function (req, res) {
-      res.setHeader('Location', '/foo');
-      res.statusCode = 302;
-      res.end();
-    }).listen(4444, function () {
-      axios.get('http://localhost:4444/', {
-        maxRedirects: 3,
-        beforeRedirect: function (options) {
-          if (options.path === '/foo') {
-            throw new Error(
-              'Provided path is not allowed'
+  it("should support beforeRedirect", function (done) {
+    server = http
+      .createServer(function (req, res) {
+        res.setHeader("Location", "/foo");
+        res.statusCode = 302;
+        res.end();
+      })
+      .listen(4444, function () {
+        axios
+          .get("http://localhost:4444/", {
+            maxRedirects: 3,
+            beforeRedirect: function (options) {
+              if (options.path === "/foo") {
+                throw new Error("Provided path is not allowed");
+              }
+            },
+          })
+          .catch(function (error) {
+            assert.equal(
+              error.message,
+              "Redirected request failed: Provided path is not allowed",
             );
-          }
-        }
-      }).catch(function (error) {
-        assert.equal(error.message, 'Redirected request failed: Provided path is not allowed');
-        done();
-      }).catch(done);
-    });
+            done();
+          })
+          .catch(done);
+      });
   });
 
-  it('should support beforeRedirect and proxy with redirect', function (done) {
+  it("should support beforeRedirect and proxy with redirect", function (done) {
     var requestCount = 0;
     var totalRedirectCount = 5;
-    server = http.createServer(function (req, res) {
-      requestCount += 1;
-      if (requestCount <= totalRedirectCount) {
-        res.setHeader('Location', 'http://localhost:4444');
-        res.writeHead(302);
-      }
-      res.end();
-    }).listen(4444, function () {
-      var proxyUseCount = 0;
-      proxy = http.createServer(function (request, response) {
-        proxyUseCount += 1;
-        var parsed = url.parse(request.url);
-        var opts = {
-          host: parsed.hostname,
-          port: parsed.port,
-          path: parsed.path
-        };
-
-        http.get(opts, function (res) {
-          response.writeHead(res.statusCode, res.headers);
-          res.on('data', function (data) {
-            response.write(data)
-          });
-          res.on('end', function () {
-            response.end();
-          });
-        });
-      }).listen(4000, function () {
-        var configBeforeRedirectCount = 0;
-        axios.get('http://localhost:4444/', {
-          proxy: {
-            host: 'localhost',
-            port: 4000
-          },
-          maxRedirects: totalRedirectCount,
-          beforeRedirect: function (options) {
-            configBeforeRedirectCount += 1;
-          }
-        }).then(function (res) {
-          assert.equal(totalRedirectCount, configBeforeRedirectCount, 'should invoke config.beforeRedirect option on every redirect');
-          assert.equal(totalRedirectCount + 1, proxyUseCount, 'should go through proxy on every redirect');
-          done();
-        }).catch(done);
-      });
-    });
-  });
-
-  it('should preserve the HTTP verb on redirect', function (done) {
-    server = http.createServer(function (req, res) {
-      if (req.method.toLowerCase() !== "head") {
-        res.statusCode = 400;
+    server = http
+      .createServer(function (req, res) {
+        requestCount += 1;
+        if (requestCount <= totalRedirectCount) {
+          res.setHeader("Location", "http://localhost:4444");
+          res.writeHead(302);
+        }
         res.end();
-        return;
-      }
-
-      var parsed = url.parse(req.url);
-      if (parsed.pathname === '/one') {
-        res.setHeader('Location', '/two');
-        res.statusCode = 302;
-        res.end();
-      } else {
-        res.end();
-      }
-    }).listen(4444, function () {
-      axios.head('http://localhost:4444/one').then(function (res) {
-        assert.equal(res.status, 200);
-        done();
-      }).catch(done);
-    });
-  });
-
-  it('should support transparent gunzip', function (done) {
-    var data = {
-      firstName: 'Fred',
-      lastName: 'Flintstone',
-      emailAddr: 'fred@example.com'
-    };
-
-    zlib.gzip(JSON.stringify(data), function (err, zipped) {
-
-      server = http.createServer(function (req, res) {
-        res.setHeader('Content-Type', 'application/json');
-        res.setHeader('Content-Encoding', 'gzip');
-        res.end(zipped);
-      }).listen(4444, function () {
-        axios.get('http://localhost:4444/').then(function (res) {
-          assert.deepEqual(res.data, data);
-          done();
-        }).catch(done);
-      });
-    });
-  });
-
-  it('should support gunzip error handling', function (done) {
-    server = http.createServer(function (req, res) {
-      res.setHeader('Content-Type', 'application/json');
-      res.setHeader('Content-Encoding', 'gzip');
-      res.end('invalid response');
-    }).listen(4444, function () {
-      axios.get('http://localhost:4444/').catch(function (error) {
-        done();
-      }).catch(done);
-    });
-  });
-
-  it('should support disabling automatic decompression of response data', function(done) {
-    var data = 'Test data';
-
-    zlib.gzip(data, function(err, zipped) {
-      server = http.createServer(function(req, res) {
-        res.setHeader('Content-Type', 'text/html;charset=utf-8');
-        res.setHeader('Content-Encoding', 'gzip');
-        res.end(zipped);
-      }).listen(4444, function() {
-        axios.get('http://localhost:4444/', {
-          decompress: false,
-          responseType: 'arraybuffer'
-
-        }).then(function(res) {
-          assert.equal(res.data.toString('base64'), zipped.toString('base64'));
-          done();
-        }).catch(done);
-      });
-    });
-  });
-
-  it('should support UTF8', function (done) {
-    var str = Array(100000).join('ж');
-
-    server = http.createServer(function (req, res) {
-      res.setHeader('Content-Type', 'text/html; charset=UTF-8');
-      res.end(str);
-    }).listen(4444, function () {
-      axios.get('http://localhost:4444/').then(function (res) {
-        assert.equal(res.data, str);
-        done();
-      }).catch(done);
-    });
-  });
-
-  it('should support basic auth', function (done) {
-    server = http.createServer(function (req, res) {
-      res.end(req.headers.authorization);
-    }).listen(4444, function () {
-      var user = 'foo';
-      var headers = { Authorization: 'Bearer 1234' };
-      axios.get('http://' + user + '@localhost:4444/', { headers: headers }).then(function (res) {
-        var base64 = Buffer.from(user + ':', 'utf8').toString('base64');
-        assert.equal(res.data, 'Basic ' + base64);
-        done();
-      }).catch(done);
-    });
-  });
-
-  it('should support basic auth with a header', function (done) {
-    server = http.createServer(function (req, res) {
-      res.end(req.headers.authorization);
-    }).listen(4444, function () {
-      var auth = { username: 'foo', password: 'bar' };
-      var headers = { AuThOrIzAtIoN: 'Bearer 1234' }; // wonky casing to ensure caseless comparison
-      axios.get('http://localhost:4444/', { auth: auth, headers: headers }).then(function (res) {
-        var base64 = Buffer.from('foo:bar', 'utf8').toString('base64');
-        assert.equal(res.data, 'Basic ' + base64);
-        done();
-      }).catch(done);
-    });
-  });
-
-  it('should provides a default User-Agent header', function (done) {
-    server = http.createServer(function (req, res) {
-      res.end(req.headers['user-agent']);
-    }).listen(4444, function () {
-      axios.get('http://localhost:4444/').then(function (res) {
-        assert.ok(/^axios\/[\d.]+$/.test(res.data), `User-Agent header does not match: ${res.data}`);
-        done();
-      }).catch(done);
-    });
-  });
-
-  it('should allow the User-Agent header to be overridden', function (done) {
-    server = http.createServer(function (req, res) {
-      res.end(req.headers['user-agent']);
-    }).listen(4444, function () {
-      var headers = { 'UsEr-AgEnT': 'foo bar' }; // wonky casing to ensure caseless comparison
-      axios.get('http://localhost:4444/', { headers }).then(function (res) {
-        assert.equal(res.data, 'foo bar');
-        done();
-      }).catch(done);
-    });
-  });
-
-  it('should allow the Content-Length header to be overridden', function (done) {
-    server = http.createServer(function (req, res) {
-      assert.strictEqual(req.headers['content-length'], '42');
-      res.end();
-    }).listen(4444, function () {
-      var headers = { 'CoNtEnT-lEnGtH': '42' }; // wonky casing to ensure caseless comparison
-      axios.post('http://localhost:4444/', 'foo', { headers }).then(function () {
-        done();
-      }).catch(done);
-    });
-  });
-
-  it('should support max content length', function (done) {
-    var str = Array(100000).join('ж');
-
-    server = http.createServer(function (req, res) {
-      res.setHeader('Content-Type', 'text/html; charset=UTF-8');
-      res.end(str);
-    }).listen(0, function () {
-      var port = server.address().port;
-      var success = false, failure = false, error;
-
-      axios.get('http://localhost:' + port + '/', {
-        maxContentLength: 2000
-      }).then(function (res) {
-        success = true;
-      }).catch(function (err) {
-        error = err;
-        failure = true;
-      });
-
-      setTimeout(function () {
-        assert.equal(success, false, 'request should not succeed');
-        assert.equal(failure, true, 'request should fail');
-        assert.equal(error.message, 'maxContentLength size of 2000 exceeded');
-        done();
-      }, 100);
-    });
-  });
-
-  it('should support max content length for redirected', function (done) {
-    var str = Array(100000).join('ж');
-
-    server = http.createServer(function (req, res) {
-      var parsed = url.parse(req.url);
-
-      if (parsed.pathname === '/two') {
-        res.setHeader('Content-Type', 'text/html; charset=UTF-8');
-        res.end(str);
-      } else {
-        res.setHeader('Location', '/two');
-        res.statusCode = 302;
-        res.end();
-      }
-    }).listen(4444, function () {
-      var success = false, failure = false, error;
-
-      axios.get('http://localhost:4444/one', {
-        maxContentLength: 2000
-      }).then(function (res) {
-        success = true;
-      }).catch(function (err) {
-        error = err;
-        failure = true;
-      });
-
-      setTimeout(function () {
-        assert.equal(success, false, 'request should not succeed');
-        assert.equal(failure, true, 'request should fail');
-        done();
-      }, 100);
-    });
-  });
-
-  it('should support max body length', function (done) {
-    var data = Array(100000).join('ж');
-
-    server = http.createServer(function (req, res) {
-      res.setHeader('Content-Type', 'text/html; charset=UTF-8');
-      res.end();
-    }).listen(4444, function () {
-      var success = false, failure = false, error;
-
-      axios.post('http://localhost:4444/', {
-        data: data
-      }, {
-        maxBodyLength: 2000
-      }).then(function (res) {
-        success = true;
-      }).catch(function (err) {
-        error = err;
-        failure = true;
-      });
-
-
-      setTimeout(function () {
-        assert.equal(success, false, 'request should not succeed');
-        assert.equal(failure, true, 'request should fail');
-        assert.equal(error.message, 'Request body larger than maxBodyLength limit');
-        done();
-      }, 100);
-    });
-  });
-
-  it('should properly support default max body length (follow-redirects as well)', function (done) {
-    // taken from https://github.com/follow-redirects/follow-redirects/blob/22e81fc37132941fb83939d1dc4c2282b5c69521/index.js#L461
-    var followRedirectsMaxBodyDefaults = 10 * 1024 *1024;
-    var data = Array(2 * followRedirectsMaxBodyDefaults).join('ж');
-
-    server = http.createServer(function (req, res) {
-      // consume the req stream
-      req.on('data', noop);
-      // and wait for the end before responding, otherwise an ECONNRESET error will be thrown
-      req.on('end', ()=> {
-        res.end('OK');
-      });
-    }).listen(4444, function (err) {
-      if (err) {
-        return done(err);
-      }
-      // send using the default -1 (unlimited axios maxBodyLength)
-      axios.post('http://localhost:4444/', {
-        data: data
-      }).then(function (res) {
-        assert.equal(res.data, 'OK', 'should handle response');
-        done();
-      }).catch(done);
-    });
-  });
-
-  it('should display error while parsing params', function (done) {
-    server = http.createServer(function () {
-
-    }).listen(4444, function () {
-      axios.get('http://localhost:4444/', {
-        params: {
-          errorParam: new Date(undefined),
-        },
-      }).catch(function (err) {
-        assert.deepEqual(err.exists, true)
-        done();
-      }).catch(done);
-    });
-  });
-
-  it('should support sockets', function (done) {
-    // Different sockets for win32 vs darwin/linux
-    var socketName = './test.sock';
-
-    if (process.platform === 'win32') {
-      socketName = '\\\\.\\pipe\\libuv-test';
-    }
-
-    server = net.createServer(function (socket) {
-      socket.on('data', function () {
-        socket.end('HTTP/1.1 200 OK\r\n\r\n');
-      });
-    }).listen(socketName, function () {
-      axios({
-        socketPath: socketName,
-        url: '/'
       })
-        .then(function (resp) {
-          assert.equal(resp.status, 200);
-          assert.equal(resp.statusText, 'OK');
-          done();
-        }).catch(done);
-    });
-  });
+      .listen(4444, function () {
+        var proxyUseCount = 0;
+        proxy = http
+          .createServer(function (request, response) {
+            proxyUseCount += 1;
+            var parsed = url.parse(request.url);
+            var opts = {
+              host: parsed.hostname,
+              port: parsed.port,
+              path: parsed.path,
+            };
 
-  it('should support streams', function (done) {
-    server = http.createServer(function (req, res) {
-      req.pipe(res);
-    }).listen(4444, function () {
-      axios.post('http://localhost:4444/',
-        fs.createReadStream(__filename), {
-          responseType: 'stream'
-        }).then(function (res) {
-          var stream = res.data;
-          var string = '';
-          stream.on('data', function (chunk) {
-            string += chunk.toString('utf8');
-          });
-          stream.on('end', function () {
-            assert.equal(string, fs.readFileSync(__filename, 'utf8'));
-            done();
-          });
-        }).catch(done);
-    });
-  });
-
-  it('should pass errors for a failed stream', function (done) {
-    var notExitPath = path.join(__dirname, 'does_not_exist');
-
-    server = http.createServer(function (req, res) {
-      req.pipe(res);
-    }).listen(4444, function () {
-      axios.post('http://localhost:4444/',
-        fs.createReadStream(notExitPath)
-      ).then(function (res) {
-        assert.fail('expected ENOENT error');
-      }).catch(function (err) {
-        assert.equal(err.message, `ENOENT: no such file or directory, open \'${notExitPath}\'`);
-        done();
-      }).catch(done);
-    });
-  });
-
-  it('should support buffers', function (done) {
-    var buf = Buffer.alloc(1024, 'x'); // Unsafe buffer < Buffer.poolSize (8192 bytes)
-    server = http.createServer(function (req, res) {
-      assert.equal(req.headers['content-length'], buf.length.toString());
-      req.pipe(res);
-    }).listen(4444, function () {
-      axios.post('http://localhost:4444/',
-        buf, {
-          responseType: 'stream'
-        }).then(function (res) {
-          var stream = res.data;
-          var string = '';
-          stream.on('data', function (chunk) {
-            string += chunk.toString('utf8');
-          });
-          stream.on('end', function () {
-            assert.equal(string, buf.toString());
-            done();
-          });
-        }).catch(done);
-    });
-  });
-
-  it('should support HTTP proxies', function (done) {
-    server = http.createServer(function (req, res) {
-      res.setHeader('Content-Type', 'text/html; charset=UTF-8');
-      res.end('12345');
-    }).listen(4444, function () {
-      proxy = http.createServer(function (request, response) {
-        var parsed = url.parse(request.url);
-        var opts = {
-          host: parsed.hostname,
-          port: parsed.port,
-          path: parsed.path
-        };
-
-        http.get(opts, function (res) {
-          var body = '';
-          res.on('data', function (data) {
-            body += data;
-          });
-          res.on('end', function () {
-            response.setHeader('Content-Type', 'text/html; charset=UTF-8');
-            response.end(body + '6789');
-          });
-        });
-
-      }).listen(4000, function () {
-        axios.get('http://localhost:4444/', {
-          proxy: {
-            host: 'localhost',
-            port: 4000
-          }
-        }).then(function (res) {
-          assert.equal(res.data, '123456789', 'should pass through proxy');
-          done();
-        }).catch(done);
-      });
-    });
-  });
-
-  it('should support HTTPS proxies', function (done) {
-    var options = {
-      key: fs.readFileSync(path.join(__dirname, 'key.pem')),
-      cert: fs.readFileSync(path.join(__dirname, 'cert.pem'))
-    };
-
-    server = https.createServer(options, function (req, res) {
-      res.setHeader('Content-Type', 'text/html; charset=UTF-8');
-      res.end('12345');
-    }).listen(4444, function () {
-      proxy = https.createServer(options, function (request, response) {
-        var parsed = url.parse(request.url);
-        var opts = {
-          host: parsed.hostname,
-          port: parsed.port,
-          path: parsed.path,
-          protocol: parsed.protocol,
-          rejectUnauthorized: false
-        };
-
-        https.get(opts, function (res) {
-          var body = '';
-          res.on('data', function (data) {
-            body += data;
-          });
-          res.on('end', function () {
-            response.setHeader('Content-Type', 'text/html; charset=UTF-8');
-            response.end(body + '6789');
-          });
-        });
-      }).listen(4000, function () {
-        axios.get('https://localhost:4444/', {
-          proxy: {
-            host: 'localhost',
-            port: 4000,
-            protocol: 'https:'
-          },
-          httpsAgent: new https.Agent({
-            rejectUnauthorized: false
+            http.get(opts, function (res) {
+              response.writeHead(res.statusCode, res.headers);
+              res.on("data", function (data) {
+                response.write(data);
+              });
+              res.on("end", function () {
+                response.end();
+              });
+            });
           })
-        }).then(function (res) {
-          assert.equal(res.data, '123456789', 'should pass through proxy');
-          done();
-        }).catch(done);
+          .listen(4000, function () {
+            var configBeforeRedirectCount = 0;
+            axios
+              .get("http://localhost:4444/", {
+                proxy: {
+                  host: "localhost",
+                  port: 4000,
+                },
+                maxRedirects: totalRedirectCount,
+                beforeRedirect: function (options) {
+                  configBeforeRedirectCount += 1;
+                },
+              })
+              .then(function (res) {
+                assert.equal(
+                  totalRedirectCount,
+                  configBeforeRedirectCount,
+                  "should invoke config.beforeRedirect option on every redirect",
+                );
+                assert.equal(
+                  totalRedirectCount + 1,
+                  proxyUseCount,
+                  "should go through proxy on every redirect",
+                );
+                done();
+              })
+              .catch(done);
+          });
       });
-    });
   });
 
-  it('should not pass through disabled proxy', function (done) {
-    // set the env variable
-    process.env.http_proxy = 'http://does-not-exists.example.com:4242/';
-
-    server = http.createServer(function (req, res) {
-      res.setHeader('Content-Type', 'text/html; charset=UTF-8');
-      res.end('123456789');
-    }).listen(4444, function () {
-      axios.get('http://localhost:4444/', {
-        proxy: false
-      }).then(function (res) {
-        assert.equal(res.data, '123456789', 'should not pass through proxy');
-        done();
-      }).catch(done);
-    });
-  });
-
-  it('should support proxy set via env var', function (done) {
-    server = http.createServer(function (req, res) {
-      res.setHeader('Content-Type', 'text/html; charset=UTF-8');
-      res.end('4567');
-    }).listen(4444, function () {
-      proxy = http.createServer(function (request, response) {
-        var parsed = url.parse(request.url);
-        var opts = {
-          host: parsed.hostname,
-          port: parsed.port,
-          path: parsed.path
-        };
-
-        http.get(opts, function (res) {
-          var body = '';
-          res.on('data', function (data) {
-            body += data;
-          });
-          res.on('end', function () {
-            response.setHeader('Content-Type', 'text/html; charset=UTF-8');
-            response.end(body + '1234');
-          });
-        });
-
-      }).listen(4000, function () {
-        // set the env variable
-        process.env.http_proxy = 'http://localhost:4000/';
-
-        axios.get('http://localhost:4444/').then(function (res) {
-          assert.equal(res.data, '45671234', 'should use proxy set by process.env.http_proxy');
-          done();
-        }).catch(done);
-      });
-    });
-  });
-
-  it('should support HTTPS proxy set via env var', function (done) {
-    var options = {
-      key: fs.readFileSync(path.join(__dirname, 'key.pem')),
-      cert: fs.readFileSync(path.join(__dirname, 'cert.pem'))
-    };
-
-    server = https.createServer(options, function (req, res) {
-      res.setHeader('Content-Type', 'text/html; charset=UTF-8');
-      res.end('12345');
-    }).listen(4444, function () {
-      proxy = https.createServer(options, function (request, response) {
-        var parsed = url.parse(request.url);
-        var opts = {
-          host: parsed.hostname,
-          port: parsed.port,
-          path: parsed.path,
-          protocol: parsed.protocol,
-          rejectUnauthorized: false
-        };
-
-        https.get(opts, function (res) {
-          var body = '';
-          res.on('data', function (data) {
-            body += data;
-          });
-          res.on('end', function () {
-            response.setHeader('Content-Type', 'text/html; charset=UTF-8');
-            response.end(body + '6789');
-          });
-        });
-      }).listen(4000, function () {
-        process.env.https_proxy = 'https://localhost:4000/';
-
-        axios.get('https://localhost:4444/', {
-          httpsAgent: new https.Agent({
-            rejectUnauthorized: false
-          })
-        }).then(function (res) {
-          assert.equal(res.data, '123456789', 'should pass through proxy');
-          done();
-        }).catch(done);
-      });
-    });
-  });
-
-  it('should re-evaluate proxy on redirect when proxy set via env var', function (done) {
-    process.env.http_proxy = 'http://localhost:4000'
-    process.env.no_proxy = 'localhost:4000'
-
-    var proxyUseCount = 0;
-
-    server = http.createServer(function (req, res) {
-      res.setHeader('Location', 'http://localhost:4000/redirected');
-      res.statusCode = 302;
-      res.end();
-    }).listen(4444, function () {
-      proxy = http.createServer(function (request, response) {
-        var parsed = url.parse(request.url);
-        if (parsed.pathname === '/redirected') {
-          response.statusCode = 200;
-          response.end();
+  it("should preserve the HTTP verb on redirect", function (done) {
+    server = http
+      .createServer(function (req, res) {
+        if (req.method.toLowerCase() !== "head") {
+          res.statusCode = 400;
+          res.end();
           return;
         }
 
-        proxyUseCount += 1;
-
-        var opts = {
-          host: parsed.hostname,
-          port: parsed.port,
-          path: parsed.path,
-          protocol: parsed.protocol,
-          rejectUnauthorized: false
-        };
-
-        http.get(opts, function (res) {
-          var body = '';
-          res.on('data', function (data) {
-            body += data;
-          });
-          res.on('end', function () {
-            response.setHeader('Content-Type', 'text/html; charset=UTF-8');
-            response.setHeader('Location', res.headers.location);
-            response.end(body);
-          });
-        });
-      }).listen(4000, function () {
-        axios.get('http://localhost:4444/').then(function(res) {
-          assert.equal(res.status, 200);
-          assert.equal(proxyUseCount, 1);
-          done();
-        }).catch(done);
-      });
-    });
-  });
-
-  it('should not use proxy for domains in no_proxy', function (done) {
-    server = http.createServer(function (req, res) {
-      res.setHeader('Content-Type', 'text/html; charset=UTF-8');
-      res.end('4567');
-    }).listen(4444, function () {
-      proxy = http.createServer(function (request, response) {
-        var parsed = url.parse(request.url);
-        var opts = {
-          host: parsed.hostname,
-          port: parsed.port,
-          path: parsed.path
-        };
-
-        http.get(opts, function (res) {
-          var body = '';
-          res.on('data', function (data) {
-            body += data;
-          });
-          res.on('end', function () {
-            response.setHeader('Content-Type', 'text/html; charset=UTF-8');
-            response.end(body + '1234');
-          });
-        });
-
-      }).listen(4000, function () {
-        // set the env variable
-        process.env.http_proxy = 'http://localhost:4000/';
-        process.env.no_proxy = 'foo.com, localhost,bar.net , , quix.co';
-
-        axios.get('http://localhost:4444/').then(function (res) {
-          assert.equal(res.data, '4567', 'should not use proxy for domains in no_proxy');
-          done();
-        }).catch(done);
-      });
-    });
-  });
-
-  it('should not use proxy for localhost with trailing dot when listed in no_proxy', function (done) {
-    var proxyRequests = 0;
-
-    proxy = http.createServer(function (request, response) {
-      proxyRequests += 1;
-      response.end('proxied');
-    }).listen(4000, function () {
-      process.env.http_proxy = 'http://localhost:4000/';
-      process.env.HTTP_PROXY = 'http://localhost:4000/';
-      process.env.no_proxy = 'localhost,127.0.0.1,::1';
-      process.env.NO_PROXY = 'localhost,127.0.0.1,::1';
-
-      axios.get('http://localhost.:1/', {
-        timeout: 100
-      }).then(function () {
-        done(new Error('request should not succeed'));
-      }).catch(function () {
-        assert.equal(proxyRequests, 0, 'should not use proxy for localhost with trailing dot');
-        done();
-      });
-    });
-  });
-
-  it('should not use proxy for bracketed IPv6 loopback when listed in no_proxy', function (done) {
-    var proxyRequests = 0;
-
-    proxy = http.createServer(function (request, response) {
-      proxyRequests += 1;
-      response.end('proxied');
-    }).listen(4000, function () {
-      process.env.http_proxy = 'http://localhost:4000/';
-      process.env.HTTP_PROXY = 'http://localhost:4000/';
-      process.env.no_proxy = 'localhost,127.0.0.1,::1';
-      process.env.NO_PROXY = 'localhost,127.0.0.1,::1';
-
-      axios.get('http://[::1]:1/', {
-        timeout: 100
-      }).then(function () {
-        done(new Error('request should not succeed'));
-      }).catch(function () {
-        assert.equal(proxyRequests, 0, 'should not use proxy for IPv6 loopback');
-        done();
-      });
-    });
-  });
-
-  it('should not use proxy for 127.0.0.1 when no_proxy is localhost', function (done) {
-    var proxyRequests = 0;
-
-    proxy = http.createServer(function (request, response) {
-      proxyRequests += 1;
-      response.end('proxied');
-    }).listen(4000, function () {
-      process.env.http_proxy = 'http://localhost:4000/';
-      process.env.HTTP_PROXY = 'http://localhost:4000/';
-      process.env.no_proxy = 'localhost';
-      process.env.NO_PROXY = 'localhost';
-
-      axios.get('http://127.0.0.1:1/', {
-        timeout: 100
-      }).then(function () {
-        done(new Error('request should not succeed'));
-      }).catch(function () {
-        assert.equal(proxyRequests, 0, 'should not use proxy for IPv4 loopback alias');
-        done();
-      });
-    });
-  });
-
-  it('should not use proxy for [::1] when no_proxy is localhost', function (done) {
-    var proxyRequests = 0;
-
-    proxy = http.createServer(function (request, response) {
-      proxyRequests += 1;
-      response.end('proxied');
-    }).listen(4000, function () {
-      process.env.http_proxy = 'http://localhost:4000/';
-      process.env.HTTP_PROXY = 'http://localhost:4000/';
-      process.env.no_proxy = 'localhost';
-      process.env.NO_PROXY = 'localhost';
-
-      axios.get('http://[::1]:1/', {
-        timeout: 100
-      }).then(function () {
-        done(new Error('request should not succeed'));
-      }).catch(function () {
-        assert.equal(proxyRequests, 0, 'should not use proxy for IPv6 loopback alias');
-        done();
-      });
-    });
-  });
-
-  it('should use proxy for domains not in no_proxy', function (done) {
-    server = http.createServer(function (req, res) {
-      res.setHeader('Content-Type', 'text/html; charset=UTF-8');
-      res.end('4567');
-    }).listen(4444, function () {
-      proxy = http.createServer(function (request, response) {
-        var parsed = url.parse(request.url);
-        var opts = {
-          host: parsed.hostname,
-          port: parsed.port,
-          path: parsed.path
-        };
-
-        http.get(opts, function (res) {
-          var body = '';
-          res.on('data', function (data) {
-            body += data;
-          });
-          res.on('end', function () {
-            response.setHeader('Content-Type', 'text/html; charset=UTF-8');
-            response.end(body + '1234');
-          });
-        });
-
-      }).listen(4000, function () {
-        // set the env variable
-        process.env.http_proxy = 'http://localhost:4000/';
-        process.env.no_proxy = 'foo.com, ,bar.net , quix.co';
-
-        axios.get('http://localhost:4444/').then(function (res) {
-          assert.equal(res.data, '45671234', 'should use proxy for domains not in no_proxy');
-          done();
-        }).catch(done);
-      });
-    });
-  });
-
-  it('should support HTTP proxy auth', function (done) {
-    server = http.createServer(function (req, res) {
-      res.end();
-    }).listen(4444, function () {
-      proxy = http.createServer(function (request, response) {
-        var parsed = url.parse(request.url);
-        var opts = {
-          host: parsed.hostname,
-          port: parsed.port,
-          path: parsed.path
-        };
-        var proxyAuth = request.headers['proxy-authorization'];
-
-        http.get(opts, function (res) {
-          var body = '';
-          res.on('data', function (data) {
-            body += data;
-          });
-          res.on('end', function () {
-            response.setHeader('Content-Type', 'text/html; charset=UTF-8');
-            response.end(proxyAuth);
-          });
-        });
-
-      }).listen(4000, function () {
-        axios.get('http://localhost:4444/', {
-          proxy: {
-            host: 'localhost',
-            port: 4000,
-            auth: {
-              username: 'user',
-              password: 'pass'
-            }
-          }
-        }).then(function (res) {
-          var base64 = Buffer.from('user:pass', 'utf8').toString('base64');
-          assert.equal(res.data, 'Basic ' + base64, 'should authenticate to the proxy');
-          done();
-        }).catch(done);
-      });
-    });
-  });
-
-  it('should support proxy auth from env', function (done) {
-    server = http.createServer(function (req, res) {
-      res.end();
-    }).listen(4444, function () {
-      proxy = http.createServer(function (request, response) {
-        var parsed = url.parse(request.url);
-        var opts = {
-          host: parsed.hostname,
-          port: parsed.port,
-          path: parsed.path
-        };
-        var proxyAuth = request.headers['proxy-authorization'];
-
-        http.get(opts, function (res) {
-          var body = '';
-          res.on('data', function (data) {
-            body += data;
-          });
-          res.on('end', function () {
-            response.setHeader('Content-Type', 'text/html; charset=UTF-8');
-            response.end(proxyAuth);
-          });
-        });
-
-      }).listen(4000, function () {
-        process.env.http_proxy = 'http://user:pass@localhost:4000/';
-
-        axios.get('http://localhost:4444/').then(function (res) {
-          var base64 = Buffer.from('user:pass', 'utf8').toString('base64');
-          assert.equal(res.data, 'Basic ' + base64, 'should authenticate to the proxy set by process.env.http_proxy');
-          done();
-        }).catch(done);
-      });
-    });
-  });
-
-  it('should support proxy auth with header', function (done) {
-    server = http.createServer(function (req, res) {
-      res.end();
-    }).listen(4444, function () {
-      proxy = http.createServer(function (request, response) {
-        var parsed = url.parse(request.url);
-        var opts = {
-          host: parsed.hostname,
-          port: parsed.port,
-          path: parsed.path
-        };
-        var proxyAuth = request.headers['proxy-authorization'];
-
-        http.get(opts, function (res) {
-          var body = '';
-          res.on('data', function (data) {
-            body += data;
-          });
-          res.on('end', function () {
-            response.setHeader('Content-Type', 'text/html; charset=UTF-8');
-            response.end(proxyAuth);
-          });
-        });
-
-      }).listen(4000, function () {
-        axios.get('http://localhost:4444/', {
-          proxy: {
-            host: 'localhost',
-            port: 4000,
-            auth: {
-              username: 'user',
-              password: 'pass'
-            }
-          },
-          headers: {
-            'Proxy-Authorization': 'Basic abc123'
-          }
-        }).then(function (res) {
-          var base64 = Buffer.from('user:pass', 'utf8').toString('base64');
-          assert.equal(res.data, 'Basic ' + base64, 'should authenticate to the proxy');
-          done();
-        }).catch(done);
-      });
-    });
-  });
-
-  it('should support cancel', function (done) {
-    var source = axios.CancelToken.source();
-    server = http.createServer(function (req, res) {
-      // call cancel() when the request has been sent, but a response has not been received
-      source.cancel('Operation has been canceled.');
-    }).listen(4444, function () {
-      axios.get('http://localhost:4444/', {
-        cancelToken: source.token
-      }).catch(function (thrown) {
-        assert.ok(thrown instanceof axios.Cancel, 'Promise must be rejected with a CanceledError object');
-        assert.equal(thrown.message, 'Operation has been canceled.');
-        done();
-      });
-    });
-  });
-
-  it('should combine baseURL and url', function (done) {
-    server = http.createServer(function (req, res) {
-      res.end();
-    }).listen(4444, function () {
-      axios.get('/foo', {
-        baseURL: 'http://localhost:4444/',
-      }).then(function (res) {
-        assert.equal(res.config.baseURL, 'http://localhost:4444/');
-        assert.equal(res.config.url, '/foo');
-        done();
-      }).catch(done);
-    });
-  });
-
-  it('should support HTTP protocol', function (done) {
-    server = http.createServer(function (req, res) {
-      setTimeout(function () {
-        res.end();
-      }, 1000);
-    }).listen(4444, function () {
-      axios.get('http://localhost:4444')
-        .then(function (res) {
-          assert.equal(res.request.agent.protocol, 'http:');
-          done();
-        })
-    })
-  });
-
-  it('should support HTTPS protocol', function (done) {
-    server = http.createServer(function (req, res) {
-      setTimeout(function () {
-        res.end();
-      }, 1000);
-    }).listen(4444, function () {
-      axios.get('https://www.google.com')
-        .then(function (res) {
-          assert.equal(res.request.agent.protocol, 'https:');
-          done();
-        })
-    })
-  });
-
-  it('should return malformed URL', function (done) {
-    var success = false, failure = false;
-    var error;
-
-    server = http.createServer(function (req, res) {
-      setTimeout(function () {
-        res.end();
-      }, 1000);
-    }).listen(4444, function () {
-      axios.get('tel:484-695-3408')
-        .then(function (res) {
-          success = true;
-        }).catch(function (err) {
-          error = err;
-          failure = true;
-        })
-
-      setTimeout(function () {
-        assert.equal(success, false, 'request should not succeed');
-        assert.equal(failure, true, 'request should fail');
-        assert.equal(error.message, 'Unsupported protocol tel:');
-        done();
-      }, 300);
-    })
-  });
-
-  it('should return unsupported protocol', function (done) {
-    var success = false, failure = false;
-    var error;
-
-    server = http.createServer(function (req, res) {
-      setTimeout(function () {
-        res.end();
-      }, 1000);
-    }).listen(4444, function () {
-      axios.get('ftp:google.com')
-        .then(function (res) {
-          success = true;
-        }).catch(function (err) {
-          error = err;
-          failure = true;
-        })
-
-      setTimeout(function () {
-        assert.equal(success, false, 'request should not succeed');
-        assert.equal(failure, true, 'request should fail');
-        assert.equal(error.message, 'Unsupported protocol ftp:');
-        done();
-      }, 300);
-    })
-  });
-
-  it('should supply a user-agent if one is not specified', function (done) {
-    server = http.createServer(function (req, res) {
-      assert.equal(req.headers["user-agent"], 'axios/' + pkg.version);
-      res.end();
-    }).listen(4444, function () {
-      axios.get('http://localhost:4444/'
-      ).then(function (res) {
-        done();
-      }).catch(done);
-    });
-  });
-
-  it('should omit a user-agent if one is explicitly disclaimed', function (done) {
-    server = http.createServer(function (req, res) {
-      assert.equal("user-agent" in req.headers, false);
-      assert.equal("User-Agent" in req.headers, false);
-      res.end();
-    }).listen(4444, function () {
-      axios.get('http://localhost:4444/', {
-        headers: {
-          "User-Agent": null
+        var parsed = url.parse(req.url);
+        if (parsed.pathname === "/one") {
+          res.setHeader("Location", "/two");
+          res.statusCode = 302;
+          res.end();
+        } else {
+          res.end();
         }
-      }).then(function (res) {
-        done();
-      }).catch(done);
+      })
+      .listen(4444, function () {
+        axios
+          .head("http://localhost:4444/one")
+          .then(function (res) {
+            assert.equal(res.status, 200);
+            done();
+          })
+          .catch(done);
+      });
+  });
+
+  it("should support transparent gunzip", function (done) {
+    var data = {
+      firstName: "Fred",
+      lastName: "Flintstone",
+      emailAddr: "fred@example.com",
+    };
+
+    zlib.gzip(JSON.stringify(data), function (err, zipped) {
+      server = http
+        .createServer(function (req, res) {
+          res.setHeader("Content-Type", "application/json");
+          res.setHeader("Content-Encoding", "gzip");
+          res.end(zipped);
+        })
+        .listen(4444, function () {
+          axios
+            .get("http://localhost:4444/")
+            .then(function (res) {
+              assert.deepEqual(res.data, data);
+              done();
+            })
+            .catch(done);
+        });
     });
   });
 
-  it('should throw an error if http server that aborts a chunked request', function (done) {
-    server = http.createServer(function (req, res) {
-      res.writeHead(200, { 'Content-Type': 'text/plain' });
-      res.write('chunk 1');
-      setTimeout(function () {
-        res.write('chunk 2');
-      }, 100);
-      setTimeout(function() {
-        res.destroy();
-      }, 200);
-    }).listen(4444, function () {
-      var success = false, failure = false;
-      var error;
+  it("should support gunzip error handling", function (done) {
+    server = http
+      .createServer(function (req, res) {
+        res.setHeader("Content-Type", "application/json");
+        res.setHeader("Content-Encoding", "gzip");
+        res.end("invalid response");
+      })
+      .listen(4444, function () {
+        axios
+          .get("http://localhost:4444/")
+          .catch(function (error) {
+            done();
+          })
+          .catch(done);
+      });
+  });
 
-      axios.get('http://localhost:4444/aborted', {
-        timeout: 500
-      }).then(function (res) {
-        success = true;
-      }).catch(function (err) {
-        error = err;
-        failure = true;
-      }).then(function () {
-        assert.strictEqual(success, false, 'request should not succeed');
-        assert.strictEqual(failure, true, 'request should fail');
-        assert.strictEqual(error.code, 'ECONNABORTED');
-        assert.strictEqual(error.message, 'response stream aborted');
-        done();
-      }).catch(done);
+  it("should support disabling automatic decompression of response data", function (done) {
+    var data = "Test data";
+
+    zlib.gzip(data, function (err, zipped) {
+      server = http
+        .createServer(function (req, res) {
+          res.setHeader("Content-Type", "text/html;charset=utf-8");
+          res.setHeader("Content-Encoding", "gzip");
+          res.end(zipped);
+        })
+        .listen(4444, function () {
+          axios
+            .get("http://localhost:4444/", {
+              decompress: false,
+              responseType: "arraybuffer",
+            })
+            .then(function (res) {
+              assert.equal(
+                res.data.toString("base64"),
+                zipped.toString("base64"),
+              );
+              done();
+            })
+            .catch(done);
+        });
     });
   });
 
-  it('should able to cancel multiple requests with CancelToken', function(done){
-    server = http.createServer(function (req, res) {
-      res.end('ok');
-    }).listen(4444, function () {
-      var CancelToken = axios.CancelToken;
-      var source = CancelToken.source();
-      var canceledStack = [];
+  it("should support UTF8", function (done) {
+    var str = Array(100000).join("ж");
 
-      var requests = [1, 2, 3, 4, 5].map(function(id){
-        return axios
-          .get('/foo/bar', { cancelToken: source.token })
-          .catch(function (e) {
-            if (!axios.isCancel(e)) {
-              throw e;
-            }
+    server = http
+      .createServer(function (req, res) {
+        res.setHeader("Content-Type", "text/html; charset=UTF-8");
+        res.end(str);
+      })
+      .listen(4444, function () {
+        axios
+          .get("http://localhost:4444/")
+          .then(function (res) {
+            assert.equal(res.data, str);
+            done();
+          })
+          .catch(done);
+      });
+  });
 
-            canceledStack.push(id);
+  it("should support basic auth", function (done) {
+    server = http
+      .createServer(function (req, res) {
+        res.end(req.headers.authorization);
+      })
+      .listen(4444, function () {
+        var user = "foo";
+        var headers = { Authorization: "Bearer 1234" };
+        axios
+          .get("http://" + user + "@localhost:4444/", { headers: headers })
+          .then(function (res) {
+            var base64 = Buffer.from(user + ":", "utf8").toString("base64");
+            assert.equal(res.data, "Basic " + base64);
+            done();
+          })
+          .catch(done);
+      });
+  });
+
+  it("should support basic auth with a header", function (done) {
+    server = http
+      .createServer(function (req, res) {
+        res.end(req.headers.authorization);
+      })
+      .listen(4444, function () {
+        var auth = { username: "foo", password: "bar" };
+        var headers = { AuThOrIzAtIoN: "Bearer 1234" }; // wonky casing to ensure caseless comparison
+        axios
+          .get("http://localhost:4444/", { auth: auth, headers: headers })
+          .then(function (res) {
+            var base64 = Buffer.from("foo:bar", "utf8").toString("base64");
+            assert.equal(res.data, "Basic " + base64);
+            done();
+          })
+          .catch(done);
+      });
+  });
+
+  it("should provides a default User-Agent header", function (done) {
+    server = http
+      .createServer(function (req, res) {
+        res.end(req.headers["user-agent"]);
+      })
+      .listen(4444, function () {
+        axios
+          .get("http://localhost:4444/")
+          .then(function (res) {
+            assert.ok(
+              /^axios\/[\d.]+$/.test(res.data),
+              `User-Agent header does not match: ${res.data}`,
+            );
+            done();
+          })
+          .catch(done);
+      });
+  });
+
+  it("should allow the User-Agent header to be overridden", function (done) {
+    server = http
+      .createServer(function (req, res) {
+        res.end(req.headers["user-agent"]);
+      })
+      .listen(4444, function () {
+        var headers = { "UsEr-AgEnT": "foo bar" }; // wonky casing to ensure caseless comparison
+        axios
+          .get("http://localhost:4444/", { headers })
+          .then(function (res) {
+            assert.equal(res.data, "foo bar");
+            done();
+          })
+          .catch(done);
+      });
+  });
+
+  it("should allow the Content-Length header to be overridden", function (done) {
+    server = http
+      .createServer(function (req, res) {
+        assert.strictEqual(req.headers["content-length"], "42");
+        res.end();
+      })
+      .listen(4444, function () {
+        var headers = { "CoNtEnT-lEnGtH": "42" }; // wonky casing to ensure caseless comparison
+        axios
+          .post("http://localhost:4444/", "foo", { headers })
+          .then(function () {
+            done();
+          })
+          .catch(done);
+      });
+  });
+
+  it("should support max content length", function (done) {
+    var str = Array(100000).join("ж");
+
+    server = http
+      .createServer(function (req, res) {
+        res.setHeader("Content-Type", "text/html; charset=UTF-8");
+        res.end(str);
+      })
+      .listen(0, function () {
+        var port = server.address().port;
+        var success = false,
+          failure = false,
+          error;
+
+        axios
+          .get("http://localhost:" + port + "/", {
+            maxContentLength: 2000,
+          })
+          .then(function (res) {
+            success = true;
+          })
+          .catch(function (err) {
+            error = err;
+            failure = true;
+          });
+
+        setTimeout(function () {
+          assert.equal(success, false, "request should not succeed");
+          assert.equal(failure, true, "request should fail");
+          assert.equal(error.message, "maxContentLength size of 2000 exceeded");
+          done();
+        }, 100);
+      });
+  });
+
+  it("should support max content length for redirected", function (done) {
+    var str = Array(100000).join("ж");
+
+    server = http
+      .createServer(function (req, res) {
+        var parsed = url.parse(req.url);
+
+        if (parsed.pathname === "/two") {
+          res.setHeader("Content-Type", "text/html; charset=UTF-8");
+          res.end(str);
+        } else {
+          res.setHeader("Location", "/two");
+          res.statusCode = 302;
+          res.end();
+        }
+      })
+      .listen(4444, function () {
+        var success = false,
+          failure = false,
+          error;
+
+        axios
+          .get("http://localhost:4444/one", {
+            maxContentLength: 2000,
+          })
+          .then(function (res) {
+            success = true;
+          })
+          .catch(function (err) {
+            error = err;
+            failure = true;
+          });
+
+        setTimeout(function () {
+          assert.equal(success, false, "request should not succeed");
+          assert.equal(failure, true, "request should fail");
+          done();
+        }, 100);
+      });
+  });
+
+  it("should support max body length", function (done) {
+    var data = Array(100000).join("ж");
+
+    server = http
+      .createServer(function (req, res) {
+        res.setHeader("Content-Type", "text/html; charset=UTF-8");
+        res.end();
+      })
+      .listen(4444, function () {
+        var success = false,
+          failure = false,
+          error;
+
+        axios
+          .post(
+            "http://localhost:4444/",
+            {
+              data: data,
+            },
+            {
+              maxBodyLength: 2000,
+            },
+          )
+          .then(function (res) {
+            success = true;
+          })
+          .catch(function (err) {
+            error = err;
+            failure = true;
+          });
+
+        setTimeout(function () {
+          assert.equal(success, false, "request should not succeed");
+          assert.equal(failure, true, "request should fail");
+          assert.equal(
+            error.message,
+            "Request body larger than maxBodyLength limit",
+          );
+          done();
+        }, 100);
+      });
+  });
+
+  it("should properly support default max body length (follow-redirects as well)", function (done) {
+    // taken from https://github.com/follow-redirects/follow-redirects/blob/22e81fc37132941fb83939d1dc4c2282b5c69521/index.js#L461
+    var followRedirectsMaxBodyDefaults = 10 * 1024 * 1024;
+    var data = Array(2 * followRedirectsMaxBodyDefaults).join("ж");
+
+    server = http
+      .createServer(function (req, res) {
+        // consume the req stream
+        req.on("data", noop);
+        // and wait for the end before responding, otherwise an ECONNRESET error will be thrown
+        req.on("end", () => {
+          res.end("OK");
+        });
+      })
+      .listen(4444, function (err) {
+        if (err) {
+          return done(err);
+        }
+        // send using the default -1 (unlimited axios maxBodyLength)
+        axios
+          .post("http://localhost:4444/", {
+            data: data,
+          })
+          .then(function (res) {
+            assert.equal(res.data, "OK", "should handle response");
+            done();
+          })
+          .catch(done);
+      });
+  });
+
+  it("should display error while parsing params", function (done) {
+    server = http
+      .createServer(function () {})
+      .listen(4444, function () {
+        axios
+          .get("http://localhost:4444/", {
+            params: {
+              errorParam: new Date(undefined),
+            },
+          })
+          .catch(function (err) {
+            assert.deepEqual(err.exists, true);
+            done();
+          })
+          .catch(done);
+      });
+  });
+
+  it("should support sockets", function (done) {
+    // Different sockets for win32 vs darwin/linux
+    var socketName = "./test.sock";
+
+    if (process.platform === "win32") {
+      socketName = "\\\\.\\pipe\\libuv-test";
+    }
+
+    server = net
+      .createServer(function (socket) {
+        socket.on("data", function () {
+          socket.end("HTTP/1.1 200 OK\r\n\r\n");
+        });
+      })
+      .listen(socketName, function () {
+        axios({
+          socketPath: socketName,
+          url: "/",
+        })
+          .then(function (resp) {
+            assert.equal(resp.status, 200);
+            assert.equal(resp.statusText, "OK");
+            done();
+          })
+          .catch(done);
+      });
+  });
+
+  it("should support streams", function (done) {
+    server = http
+      .createServer(function (req, res) {
+        req.pipe(res);
+      })
+      .listen(4444, function () {
+        axios
+          .post("http://localhost:4444/", fs.createReadStream(__filename), {
+            responseType: "stream",
+          })
+          .then(function (res) {
+            var stream = res.data;
+            var string = "";
+            stream.on("data", function (chunk) {
+              string += chunk.toString("utf8");
+            });
+            stream.on("end", function () {
+              assert.equal(string, fs.readFileSync(__filename, "utf8"));
+              done();
+            });
+          })
+          .catch(done);
+      });
+  });
+
+  it("should pass errors for a failed stream", function (done) {
+    var notExitPath = path.join(__dirname, "does_not_exist");
+
+    server = http
+      .createServer(function (req, res) {
+        req.pipe(res);
+      })
+      .listen(4444, function () {
+        axios
+          .post("http://localhost:4444/", fs.createReadStream(notExitPath))
+          .then(function (res) {
+            assert.fail("expected ENOENT error");
+          })
+          .catch(function (err) {
+            assert.equal(
+              err.message,
+              `ENOENT: no such file or directory, open \'${notExitPath}\'`,
+            );
+            done();
+          })
+          .catch(done);
+      });
+  });
+
+  it("should support buffers", function (done) {
+    var buf = Buffer.alloc(1024, "x"); // Unsafe buffer < Buffer.poolSize (8192 bytes)
+    server = http
+      .createServer(function (req, res) {
+        assert.equal(req.headers["content-length"], buf.length.toString());
+        req.pipe(res);
+      })
+      .listen(4444, function () {
+        axios
+          .post("http://localhost:4444/", buf, {
+            responseType: "stream",
+          })
+          .then(function (res) {
+            var stream = res.data;
+            var string = "";
+            stream.on("data", function (chunk) {
+              string += chunk.toString("utf8");
+            });
+            stream.on("end", function () {
+              assert.equal(string, buf.toString());
+              done();
+            });
+          })
+          .catch(done);
+      });
+  });
+
+  it("should support HTTP proxies", function (done) {
+    server = http
+      .createServer(function (req, res) {
+        res.setHeader("Content-Type", "text/html; charset=UTF-8");
+        res.end("12345");
+      })
+      .listen(4444, function () {
+        proxy = http
+          .createServer(function (request, response) {
+            var parsed = url.parse(request.url);
+            var opts = {
+              host: parsed.hostname,
+              port: parsed.port,
+              path: parsed.path,
+            };
+
+            http.get(opts, function (res) {
+              var body = "";
+              res.on("data", function (data) {
+                body += data;
+              });
+              res.on("end", function () {
+                response.setHeader("Content-Type", "text/html; charset=UTF-8");
+                response.end(body + "6789");
+              });
+            });
+          })
+          .listen(4000, function () {
+            axios
+              .get("http://localhost:4444/", {
+                proxy: {
+                  host: "localhost",
+                  port: 4000,
+                },
+              })
+              .then(function (res) {
+                assert.equal(
+                  res.data,
+                  "123456789",
+                  "should pass through proxy",
+                );
+                done();
+              })
+              .catch(done);
           });
       });
-
-      source.cancel("Aborted by user");
-
-      Promise.all(requests).then(function () {
-        assert.deepStrictEqual(canceledStack.sort(), [1, 2, 3, 4, 5])
-      }).then(done, done);
-    });
   });
 
-  describe('FormData', function () {
-    it('should allow passing FormData', function (done) {
-      var form = new FormData();
-      var file1 = Buffer.from('foo', 'utf8');
+  it("should support HTTPS proxies", function (done) {
+    var options = {
+      key: fs.readFileSync(path.join(__dirname, "key.pem")),
+      cert: fs.readFileSync(path.join(__dirname, "cert.pem")),
+    };
 
-      form.append('foo', "bar");
-      form.append('file1', file1, {
-        filename: 'bar.jpg',
-        filepath: 'temp/bar.jpg',
-        contentType: 'image/jpeg'
+    server = https
+      .createServer(options, function (req, res) {
+        res.setHeader("Content-Type", "text/html; charset=UTF-8");
+        res.end("12345");
+      })
+      .listen(4444, function () {
+        proxy = https
+          .createServer(options, function (request, response) {
+            var parsed = url.parse(request.url);
+            var opts = {
+              host: parsed.hostname,
+              port: parsed.port,
+              path: parsed.path,
+              protocol: parsed.protocol,
+              rejectUnauthorized: false,
+            };
+
+            https.get(opts, function (res) {
+              var body = "";
+              res.on("data", function (data) {
+                body += data;
+              });
+              res.on("end", function () {
+                response.setHeader("Content-Type", "text/html; charset=UTF-8");
+                response.end(body + "6789");
+              });
+            });
+          })
+          .listen(4000, function () {
+            axios
+              .get("https://localhost:4444/", {
+                proxy: {
+                  host: "localhost",
+                  port: 4000,
+                  protocol: "https:",
+                },
+                httpsAgent: new https.Agent({
+                  rejectUnauthorized: false,
+                }),
+              })
+              .then(function (res) {
+                assert.equal(
+                  res.data,
+                  "123456789",
+                  "should pass through proxy",
+                );
+                done();
+              })
+              .catch(done);
+          });
       });
+  });
 
-      server = http.createServer(function (req, res) {
-        var receivedForm = new formidable.IncomingForm();
+  it("should not pass through disabled proxy", function (done) {
+    // set the env variable
+    process.env.http_proxy = "http://does-not-exists.example.com:4242/";
 
-        receivedForm.parse(req, function (err, fields, files) {
-          if (err) {
-            return done(err);
-          }
+    server = http
+      .createServer(function (req, res) {
+        res.setHeader("Content-Type", "text/html; charset=UTF-8");
+        res.end("123456789");
+      })
+      .listen(4444, function () {
+        axios
+          .get("http://localhost:4444/", {
+            proxy: false,
+          })
+          .then(function (res) {
+            assert.equal(
+              res.data,
+              "123456789",
+              "should not pass through proxy",
+            );
+            done();
+          })
+          .catch(done);
+      });
+  });
 
-          res.end(JSON.stringify({
-            fields: fields,
-            files: files
-          }));
-        });
-      }).listen(4444, function () {
-        axios.post('http://localhost:4444/', form, {
-          headers: {
-            'Content-Type': 'multipart/form-data'
-          }
-        }).then(function (res) {
-          assert.deepStrictEqual(res.data.fields, {foo: 'bar'});
+  it("should support proxy set via env var", function (done) {
+    server = http
+      .createServer(function (req, res) {
+        res.setHeader("Content-Type", "text/html; charset=UTF-8");
+        res.end("4567");
+      })
+      .listen(4444, function () {
+        proxy = http
+          .createServer(function (request, response) {
+            var parsed = url.parse(request.url);
+            var opts = {
+              host: parsed.hostname,
+              port: parsed.port,
+              path: parsed.path,
+            };
 
-          assert.strictEqual(res.data.files.file1.mimetype, 'image/jpeg');
-          assert.strictEqual(res.data.files.file1.originalFilename, 'temp/bar.jpg');
-          assert.strictEqual(res.data.files.file1.size, 3);
+            http.get(opts, function (res) {
+              var body = "";
+              res.on("data", function (data) {
+                body += data;
+              });
+              res.on("end", function () {
+                response.setHeader("Content-Type", "text/html; charset=UTF-8");
+                response.end(body + "1234");
+              });
+            });
+          })
+          .listen(4000, function () {
+            // set the env variable
+            process.env.http_proxy = "http://localhost:4000/";
 
+            axios
+              .get("http://localhost:4444/")
+              .then(function (res) {
+                assert.equal(
+                  res.data,
+                  "45671234",
+                  "should use proxy set by process.env.http_proxy",
+                );
+                done();
+              })
+              .catch(done);
+          });
+      });
+  });
+
+  it("should support HTTPS proxy set via env var", function (done) {
+    var options = {
+      key: fs.readFileSync(path.join(__dirname, "key.pem")),
+      cert: fs.readFileSync(path.join(__dirname, "cert.pem")),
+    };
+
+    server = https
+      .createServer(options, function (req, res) {
+        res.setHeader("Content-Type", "text/html; charset=UTF-8");
+        res.end("12345");
+      })
+      .listen(4444, function () {
+        proxy = https
+          .createServer(options, function (request, response) {
+            var parsed = url.parse(request.url);
+            var opts = {
+              host: parsed.hostname,
+              port: parsed.port,
+              path: parsed.path,
+              protocol: parsed.protocol,
+              rejectUnauthorized: false,
+            };
+
+            https.get(opts, function (res) {
+              var body = "";
+              res.on("data", function (data) {
+                body += data;
+              });
+              res.on("end", function () {
+                response.setHeader("Content-Type", "text/html; charset=UTF-8");
+                response.end(body + "6789");
+              });
+            });
+          })
+          .listen(4000, function () {
+            process.env.https_proxy = "https://localhost:4000/";
+
+            axios
+              .get("https://localhost:4444/", {
+                httpsAgent: new https.Agent({
+                  rejectUnauthorized: false,
+                }),
+              })
+              .then(function (res) {
+                assert.equal(
+                  res.data,
+                  "123456789",
+                  "should pass through proxy",
+                );
+                done();
+              })
+              .catch(done);
+          });
+      });
+  });
+
+  it("should re-evaluate proxy on redirect when proxy set via env var", function (done) {
+    process.env.http_proxy = "http://localhost:4000";
+    process.env.no_proxy = "localhost:4000";
+
+    var proxyUseCount = 0;
+
+    server = http
+      .createServer(function (req, res) {
+        res.setHeader("Location", "http://localhost:4000/redirected");
+        res.statusCode = 302;
+        res.end();
+      })
+      .listen(4444, function () {
+        proxy = http
+          .createServer(function (request, response) {
+            var parsed = url.parse(request.url);
+            if (parsed.pathname === "/redirected") {
+              response.statusCode = 200;
+              response.end();
+              return;
+            }
+
+            proxyUseCount += 1;
+
+            var opts = {
+              host: parsed.hostname,
+              port: parsed.port,
+              path: parsed.path,
+              protocol: parsed.protocol,
+              rejectUnauthorized: false,
+            };
+
+            http.get(opts, function (res) {
+              var body = "";
+              res.on("data", function (data) {
+                body += data;
+              });
+              res.on("end", function () {
+                response.setHeader("Content-Type", "text/html; charset=UTF-8");
+                response.setHeader("Location", res.headers.location);
+                response.end(body);
+              });
+            });
+          })
+          .listen(4000, function () {
+            axios
+              .get("http://localhost:4444/")
+              .then(function (res) {
+                assert.equal(res.status, 200);
+                assert.equal(proxyUseCount, 1);
+                done();
+              })
+              .catch(done);
+          });
+      });
+  });
+
+  it("should not use proxy for domains in no_proxy", function (done) {
+    server = http
+      .createServer(function (req, res) {
+        res.setHeader("Content-Type", "text/html; charset=UTF-8");
+        res.end("4567");
+      })
+      .listen(4444, function () {
+        proxy = http
+          .createServer(function (request, response) {
+            var parsed = url.parse(request.url);
+            var opts = {
+              host: parsed.hostname,
+              port: parsed.port,
+              path: parsed.path,
+            };
+
+            http.get(opts, function (res) {
+              var body = "";
+              res.on("data", function (data) {
+                body += data;
+              });
+              res.on("end", function () {
+                response.setHeader("Content-Type", "text/html; charset=UTF-8");
+                response.end(body + "1234");
+              });
+            });
+          })
+          .listen(4000, function () {
+            // set the env variable
+            process.env.http_proxy = "http://localhost:4000/";
+            process.env.no_proxy = "foo.com, localhost,bar.net , , quix.co";
+
+            axios
+              .get("http://localhost:4444/")
+              .then(function (res) {
+                assert.equal(
+                  res.data,
+                  "4567",
+                  "should not use proxy for domains in no_proxy",
+                );
+                done();
+              })
+              .catch(done);
+          });
+      });
+  });
+
+  it("should not use proxy for localhost with trailing dot when listed in no_proxy", function (done) {
+    var proxyRequests = 0;
+
+    proxy = http
+      .createServer(function (request, response) {
+        proxyRequests += 1;
+        response.end("proxied");
+      })
+      .listen(4000, function () {
+        process.env.http_proxy = "http://localhost:4000/";
+        process.env.HTTP_PROXY = "http://localhost:4000/";
+        process.env.no_proxy = "localhost,127.0.0.1,::1";
+        process.env.NO_PROXY = "localhost,127.0.0.1,::1";
+
+        axios
+          .get("http://localhost.:1/", {
+            timeout: 100,
+          })
+          .then(function () {
+            done(new Error("request should not succeed"));
+          })
+          .catch(function () {
+            assert.equal(
+              proxyRequests,
+              0,
+              "should not use proxy for localhost with trailing dot",
+            );
+            done();
+          });
+      });
+  });
+
+  it("should not use proxy for bracketed IPv6 loopback when listed in no_proxy", function (done) {
+    var proxyRequests = 0;
+
+    proxy = http
+      .createServer(function (request, response) {
+        proxyRequests += 1;
+        response.end("proxied");
+      })
+      .listen(4000, function () {
+        process.env.http_proxy = "http://localhost:4000/";
+        process.env.HTTP_PROXY = "http://localhost:4000/";
+        process.env.no_proxy = "localhost,127.0.0.1,::1";
+        process.env.NO_PROXY = "localhost,127.0.0.1,::1";
+
+        axios
+          .get("http://[::1]:1/", {
+            timeout: 100,
+          })
+          .then(function () {
+            done(new Error("request should not succeed"));
+          })
+          .catch(function () {
+            assert.equal(
+              proxyRequests,
+              0,
+              "should not use proxy for IPv6 loopback",
+            );
+            done();
+          });
+      });
+  });
+
+  it("should not use proxy for 127.0.0.1 when no_proxy is localhost", function (done) {
+    var proxyRequests = 0;
+
+    proxy = http
+      .createServer(function (request, response) {
+        proxyRequests += 1;
+        response.end("proxied");
+      })
+      .listen(4000, function () {
+        process.env.http_proxy = "http://localhost:4000/";
+        process.env.HTTP_PROXY = "http://localhost:4000/";
+        process.env.no_proxy = "localhost";
+        process.env.NO_PROXY = "localhost";
+
+        axios
+          .get("http://127.0.0.1:1/", {
+            timeout: 100,
+          })
+          .then(function () {
+            done(new Error("request should not succeed"));
+          })
+          .catch(function () {
+            assert.equal(
+              proxyRequests,
+              0,
+              "should not use proxy for IPv4 loopback alias",
+            );
+            done();
+          });
+      });
+  });
+
+  it("should not use proxy for [::1] when no_proxy is localhost", function (done) {
+    var proxyRequests = 0;
+
+    proxy = http
+      .createServer(function (request, response) {
+        proxyRequests += 1;
+        response.end("proxied");
+      })
+      .listen(4000, function () {
+        process.env.http_proxy = "http://localhost:4000/";
+        process.env.HTTP_PROXY = "http://localhost:4000/";
+        process.env.no_proxy = "localhost";
+        process.env.NO_PROXY = "localhost";
+
+        axios
+          .get("http://[::1]:1/", {
+            timeout: 100,
+          })
+          .then(function () {
+            done(new Error("request should not succeed"));
+          })
+          .catch(function () {
+            assert.equal(
+              proxyRequests,
+              0,
+              "should not use proxy for IPv6 loopback alias",
+            );
+            done();
+          });
+      });
+  });
+
+  it("should use proxy for domains not in no_proxy", function (done) {
+    server = http
+      .createServer(function (req, res) {
+        res.setHeader("Content-Type", "text/html; charset=UTF-8");
+        res.end("4567");
+      })
+      .listen(4444, function () {
+        proxy = http
+          .createServer(function (request, response) {
+            var parsed = url.parse(request.url);
+            var opts = {
+              host: parsed.hostname,
+              port: parsed.port,
+              path: parsed.path,
+            };
+
+            http.get(opts, function (res) {
+              var body = "";
+              res.on("data", function (data) {
+                body += data;
+              });
+              res.on("end", function () {
+                response.setHeader("Content-Type", "text/html; charset=UTF-8");
+                response.end(body + "1234");
+              });
+            });
+          })
+          .listen(4000, function () {
+            // set the env variable
+            process.env.http_proxy = "http://localhost:4000/";
+            process.env.no_proxy = "foo.com, ,bar.net , quix.co";
+
+            axios
+              .get("http://localhost:4444/")
+              .then(function (res) {
+                assert.equal(
+                  res.data,
+                  "45671234",
+                  "should use proxy for domains not in no_proxy",
+                );
+                done();
+              })
+              .catch(done);
+          });
+      });
+  });
+
+  it("should support HTTP proxy auth", function (done) {
+    server = http
+      .createServer(function (req, res) {
+        res.end();
+      })
+      .listen(4444, function () {
+        proxy = http
+          .createServer(function (request, response) {
+            var parsed = url.parse(request.url);
+            var opts = {
+              host: parsed.hostname,
+              port: parsed.port,
+              path: parsed.path,
+            };
+            var proxyAuth = request.headers["proxy-authorization"];
+
+            http.get(opts, function (res) {
+              var body = "";
+              res.on("data", function (data) {
+                body += data;
+              });
+              res.on("end", function () {
+                response.setHeader("Content-Type", "text/html; charset=UTF-8");
+                response.end(proxyAuth);
+              });
+            });
+          })
+          .listen(4000, function () {
+            axios
+              .get("http://localhost:4444/", {
+                proxy: {
+                  host: "localhost",
+                  port: 4000,
+                  auth: {
+                    username: "user",
+                    password: "pass",
+                  },
+                },
+              })
+              .then(function (res) {
+                var base64 = Buffer.from("user:pass", "utf8").toString(
+                  "base64",
+                );
+                assert.equal(
+                  res.data,
+                  "Basic " + base64,
+                  "should authenticate to the proxy",
+                );
+                done();
+              })
+              .catch(done);
+          });
+      });
+  });
+
+  it("should support proxy auth from env", function (done) {
+    server = http
+      .createServer(function (req, res) {
+        res.end();
+      })
+      .listen(4444, function () {
+        proxy = http
+          .createServer(function (request, response) {
+            var parsed = url.parse(request.url);
+            var opts = {
+              host: parsed.hostname,
+              port: parsed.port,
+              path: parsed.path,
+            };
+            var proxyAuth = request.headers["proxy-authorization"];
+
+            http.get(opts, function (res) {
+              var body = "";
+              res.on("data", function (data) {
+                body += data;
+              });
+              res.on("end", function () {
+                response.setHeader("Content-Type", "text/html; charset=UTF-8");
+                response.end(proxyAuth);
+              });
+            });
+          })
+          .listen(4000, function () {
+            process.env.http_proxy = "http://user:pass@localhost:4000/";
+
+            axios
+              .get("http://localhost:4444/")
+              .then(function (res) {
+                var base64 = Buffer.from("user:pass", "utf8").toString(
+                  "base64",
+                );
+                assert.equal(
+                  res.data,
+                  "Basic " + base64,
+                  "should authenticate to the proxy set by process.env.http_proxy",
+                );
+                done();
+              })
+              .catch(done);
+          });
+      });
+  });
+
+  it("should support proxy auth with header", function (done) {
+    server = http
+      .createServer(function (req, res) {
+        res.end();
+      })
+      .listen(4444, function () {
+        proxy = http
+          .createServer(function (request, response) {
+            var parsed = url.parse(request.url);
+            var opts = {
+              host: parsed.hostname,
+              port: parsed.port,
+              path: parsed.path,
+            };
+            var proxyAuth = request.headers["proxy-authorization"];
+
+            http.get(opts, function (res) {
+              var body = "";
+              res.on("data", function (data) {
+                body += data;
+              });
+              res.on("end", function () {
+                response.setHeader("Content-Type", "text/html; charset=UTF-8");
+                response.end(proxyAuth);
+              });
+            });
+          })
+          .listen(4000, function () {
+            axios
+              .get("http://localhost:4444/", {
+                proxy: {
+                  host: "localhost",
+                  port: 4000,
+                  auth: {
+                    username: "user",
+                    password: "pass",
+                  },
+                },
+                headers: {
+                  "Proxy-Authorization": "Basic abc123",
+                },
+              })
+              .then(function (res) {
+                var base64 = Buffer.from("user:pass", "utf8").toString(
+                  "base64",
+                );
+                assert.equal(
+                  res.data,
+                  "Basic " + base64,
+                  "should authenticate to the proxy",
+                );
+                done();
+              })
+              .catch(done);
+          });
+      });
+  });
+
+  it("should support cancel", function (done) {
+    var source = axios.CancelToken.source();
+    server = http
+      .createServer(function (req, res) {
+        // call cancel() when the request has been sent, but a response has not been received
+        source.cancel("Operation has been canceled.");
+      })
+      .listen(4444, function () {
+        axios
+          .get("http://localhost:4444/", {
+            cancelToken: source.token,
+          })
+          .catch(function (thrown) {
+            assert.ok(
+              thrown instanceof axios.Cancel,
+              "Promise must be rejected with a CanceledError object",
+            );
+            assert.equal(thrown.message, "Operation has been canceled.");
+            done();
+          });
+      });
+  });
+
+  it("should combine baseURL and url", function (done) {
+    server = http
+      .createServer(function (req, res) {
+        res.end();
+      })
+      .listen(4444, function () {
+        axios
+          .get("/foo", {
+            baseURL: "http://localhost:4444/",
+          })
+          .then(function (res) {
+            assert.equal(res.config.baseURL, "http://localhost:4444/");
+            assert.equal(res.config.url, "/foo");
+            done();
+          })
+          .catch(done);
+      });
+  });
+
+  it("should support HTTP protocol", function (done) {
+    server = http
+      .createServer(function (req, res) {
+        setTimeout(function () {
+          res.end();
+        }, 1000);
+      })
+      .listen(4444, function () {
+        axios.get("http://localhost:4444").then(function (res) {
+          assert.equal(res.request.agent.protocol, "http:");
           done();
-        }).catch(done);
+        });
       });
+  });
+
+  it("should support HTTPS protocol", function (done) {
+    server = http
+      .createServer(function (req, res) {
+        setTimeout(function () {
+          res.end();
+        }, 1000);
+      })
+      .listen(4444, function () {
+        axios.get("https://www.google.com").then(function (res) {
+          assert.equal(res.request.agent.protocol, "https:");
+          done();
+        });
+      });
+  });
+
+  it("should return malformed URL", function (done) {
+    var success = false,
+      failure = false;
+    var error;
+
+    server = http
+      .createServer(function (req, res) {
+        setTimeout(function () {
+          res.end();
+        }, 1000);
+      })
+      .listen(4444, function () {
+        axios
+          .get("tel:484-695-3408")
+          .then(function (res) {
+            success = true;
+          })
+          .catch(function (err) {
+            error = err;
+            failure = true;
+          });
+
+        setTimeout(function () {
+          assert.equal(success, false, "request should not succeed");
+          assert.equal(failure, true, "request should fail");
+          assert.equal(error.message, "Unsupported protocol tel:");
+          done();
+        }, 300);
+      });
+  });
+
+  it("should return unsupported protocol", function (done) {
+    var success = false,
+      failure = false;
+    var error;
+
+    server = http
+      .createServer(function (req, res) {
+        setTimeout(function () {
+          res.end();
+        }, 1000);
+      })
+      .listen(4444, function () {
+        axios
+          .get("ftp:google.com")
+          .then(function (res) {
+            success = true;
+          })
+          .catch(function (err) {
+            error = err;
+            failure = true;
+          });
+
+        setTimeout(function () {
+          assert.equal(success, false, "request should not succeed");
+          assert.equal(failure, true, "request should fail");
+          assert.equal(error.message, "Unsupported protocol ftp:");
+          done();
+        }, 300);
+      });
+  });
+
+  it("should supply a user-agent if one is not specified", function (done) {
+    server = http
+      .createServer(function (req, res) {
+        assert.equal(req.headers["user-agent"], "axios/" + pkg.version);
+        res.end();
+      })
+      .listen(4444, function () {
+        axios
+          .get("http://localhost:4444/")
+          .then(function (res) {
+            done();
+          })
+          .catch(done);
+      });
+  });
+
+  it("should omit a user-agent if one is explicitly disclaimed", function (done) {
+    server = http
+      .createServer(function (req, res) {
+        assert.equal("user-agent" in req.headers, false);
+        assert.equal("User-Agent" in req.headers, false);
+        res.end();
+      })
+      .listen(4444, function () {
+        axios
+          .get("http://localhost:4444/", {
+            headers: {
+              "User-Agent": null,
+            },
+          })
+          .then(function (res) {
+            done();
+          })
+          .catch(done);
+      });
+  });
+
+  it("should throw an error if http server that aborts a chunked request", function (done) {
+    server = http
+      .createServer(function (req, res) {
+        res.writeHead(200, { "Content-Type": "text/plain" });
+        res.write("chunk 1");
+        setTimeout(function () {
+          res.write("chunk 2");
+        }, 100);
+        setTimeout(function () {
+          res.destroy();
+        }, 200);
+      })
+      .listen(4444, function () {
+        var success = false,
+          failure = false;
+        var error;
+
+        axios
+          .get("http://localhost:4444/aborted", {
+            timeout: 500,
+          })
+          .then(function (res) {
+            success = true;
+          })
+          .catch(function (err) {
+            error = err;
+            failure = true;
+          })
+          .then(function () {
+            assert.strictEqual(success, false, "request should not succeed");
+            assert.strictEqual(failure, true, "request should fail");
+            assert.strictEqual(error.code, "ECONNABORTED");
+            assert.strictEqual(error.message, "response stream aborted");
+            done();
+          })
+          .catch(done);
+      });
+  });
+
+  it("should able to cancel multiple requests with CancelToken", function (done) {
+    server = http
+      .createServer(function (req, res) {
+        res.end("ok");
+      })
+      .listen(4444, function () {
+        var CancelToken = axios.CancelToken;
+        var source = CancelToken.source();
+        var canceledStack = [];
+
+        var requests = [1, 2, 3, 4, 5].map(function (id) {
+          return axios
+            .get("/foo/bar", { cancelToken: source.token })
+            .catch(function (e) {
+              if (!axios.isCancel(e)) {
+                throw e;
+              }
+
+              canceledStack.push(id);
+            });
+        });
+
+        source.cancel("Aborted by user");
+
+        Promise.all(requests)
+          .then(function () {
+            assert.deepStrictEqual(canceledStack.sort(), [1, 2, 3, 4, 5]);
+          })
+          .then(done, done);
+      });
+  });
+
+  describe("FormData", function () {
+    it("should allow passing FormData", function (done) {
+      var form = new FormData();
+      var file1 = Buffer.from("foo", "utf8");
+
+      form.append("foo", "bar");
+      form.append("file1", file1, {
+        filename: "bar.jpg",
+        filepath: "temp/bar.jpg",
+        contentType: "image/jpeg",
+      });
+
+      server = http
+        .createServer(function (req, res) {
+          var receivedForm = new formidable.IncomingForm();
+
+          receivedForm.parse(req, function (err, fields, files) {
+            if (err) {
+              return done(err);
+            }
+
+            res.end(
+              JSON.stringify({
+                fields: fields,
+                files: files,
+              }),
+            );
+          });
+        })
+        .listen(4444, function () {
+          axios
+            .post("http://localhost:4444/", form, {
+              headers: {
+                "Content-Type": "multipart/form-data",
+              },
+            })
+            .then(function (res) {
+              assert.deepStrictEqual(res.data.fields, { foo: "bar" });
+
+              assert.strictEqual(res.data.files.file1.mimetype, "image/jpeg");
+              assert.strictEqual(
+                res.data.files.file1.originalFilename,
+                "temp/bar.jpg",
+              );
+              assert.strictEqual(res.data.files.file1.size, 3);
+
+              done();
+            })
+            .catch(done);
+        });
     });
 
-    describe('toFormData helper', function () {
-      it('should properly serialize nested objects for parsing with multer.js (express.js)', function (done) {
+    describe("toFormData helper", function () {
+      it("should properly serialize nested objects for parsing with multer.js (express.js)", function (done) {
         var app = express();
 
         var obj = {
-          arr1: ['1', '2', '3'],
-          arr2: ['1', ['2'], '3'],
-          obj: {x: '1', y: {z: '1'}},
-          users: [{name: 'Peter', surname: 'griffin'}, {name: 'Thomas', surname: 'Anderson'}]
+          arr1: ["1", "2", "3"],
+          arr2: ["1", ["2"], "3"],
+          obj: { x: "1", y: { z: "1" } },
+          users: [
+            { name: "Peter", surname: "griffin" },
+            { name: "Thomas", surname: "Anderson" },
+          ],
         };
 
-        app.post('/', multer().none(), function (req, res, next) {
+        app.post("/", multer().none(), function (req, res, next) {
           res.send(JSON.stringify(req.body));
         });
 
@@ -1517,218 +1911,274 @@ describe('supports http with nodejs', function () {
           // arr[0]: '1'
           // arr[1]: '2'
           // -------------
-          Promise.all([null, false, true].map(function (mode) {
-            return axios.postForm('http://localhost:3001/', obj, {formSerializer: {indexes: mode}})
-              .then(function (res) {
-                assert.deepStrictEqual(res.data, obj, 'Index mode ' + mode);
-              });
-          })).then(function (){
+          Promise.all(
+            [null, false, true].map(function (mode) {
+              return axios
+                .postForm("http://localhost:3001/", obj, {
+                  formSerializer: { indexes: mode },
+                })
+                .then(function (res) {
+                  assert.deepStrictEqual(res.data, obj, "Index mode " + mode);
+                });
+            }),
+          ).then(function () {
             done();
-          }, done)
+          }, done);
         });
       });
     });
   });
 
-  describe('URLEncoded Form', function () {
-    it('should post object data as url-encoded form if content-type is application/x-www-form-urlencoded', function (done) {
+  describe("URLEncoded Form", function () {
+    it("should post object data as url-encoded form if content-type is application/x-www-form-urlencoded", function (done) {
       var app = express();
 
       var obj = {
-        arr1: ['1', '2', '3'],
-        arr2: ['1', ['2'], '3'],
-        obj: {x: '1', y: {z: '1'}},
-        users: [{name: 'Peter', surname: 'griffin'}, {name: 'Thomas', surname: 'Anderson'}]
+        arr1: ["1", "2", "3"],
+        arr2: ["1", ["2"], "3"],
+        obj: { x: "1", y: { z: "1" } },
+        users: [
+          { name: "Peter", surname: "griffin" },
+          { name: "Thomas", surname: "Anderson" },
+        ],
       };
 
       app.use(bodyParser.urlencoded({ extended: true }));
 
-      app.post('/', function (req, res, next) {
+      app.post("/", function (req, res, next) {
         res.send(JSON.stringify(req.body));
       });
 
       server = app.listen(3001, function () {
-        return axios.post('http://localhost:3001/', obj, {
-          headers: {
-            'content-type': 'application/x-www-form-urlencoded'
-          }
-        })
+        return axios
+          .post("http://localhost:3001/", obj, {
+            headers: {
+              "content-type": "application/x-www-form-urlencoded",
+            },
+          })
           .then(function (res) {
             assert.deepStrictEqual(res.data, obj);
             done();
-          }).catch(done);
+          })
+          .catch(done);
       });
     });
   });
 
-  it('should respect formSerializer config', function (done) {
+  it("should respect formSerializer config", function (done) {
     const obj = {
-      arr1: ['1', '2', '3'],
-      arr2: ['1', ['2'], '3'],
+      arr1: ["1", "2", "3"],
+      arr2: ["1", ["2"], "3"],
     };
 
     const form = new URLSearchParams();
 
-    form.append('arr1[0]', '1');
-    form.append('arr1[1]', '2');
-    form.append('arr1[2]', '3');
+    form.append("arr1[0]", "1");
+    form.append("arr1[1]", "2");
+    form.append("arr1[2]", "3");
 
-    form.append('arr2[0]', '1');
-    form.append('arr2[1][0]', '2');
-    form.append('arr2[2]', '3');
+    form.append("arr2[0]", "1");
+    form.append("arr2[1][0]", "2");
+    form.append("arr2[2]", "3");
 
-    server = http.createServer(function (req, res) {
-      req.pipe(res);
-    }).listen(3001, () => {
-      return axios.post('http://localhost:3001/', obj, {
-        headers: {
-          'content-type': 'application/x-www-form-urlencoded'
-        },
-        formSerializer: {
-          indexes: true
-        }
+    server = http
+      .createServer(function (req, res) {
+        req.pipe(res);
       })
-        .then(function (res) {
-          assert.strictEqual(res.data, form.toString());
-          done();
-        }).catch(done);
-    });
+      .listen(3001, () => {
+        return axios
+          .post("http://localhost:3001/", obj, {
+            headers: {
+              "content-type": "application/x-www-form-urlencoded",
+            },
+            formSerializer: {
+              indexes: true,
+            },
+          })
+          .then(function (res) {
+            assert.strictEqual(res.data, form.toString());
+            done();
+          })
+          .catch(done);
+      });
   });
 
-  describe('Data URL', function () {
-    it('should support requesting data URL as a Buffer', function (done) {
-      const buffer = Buffer.from('123');
+  describe("Data URL", function () {
+    it("should support requesting data URL as a Buffer", function (done) {
+      const buffer = Buffer.from("123");
 
-      const dataURI = 'data:application/octet-stream;base64,' + buffer.toString('base64');
+      const dataURI =
+        "data:application/octet-stream;base64," + buffer.toString("base64");
 
-      axios.get(dataURI).then(({data})=> {
-        assert.deepStrictEqual(data, buffer);
-        done();
-      }).catch(done);
+      axios
+        .get(dataURI)
+        .then(({ data }) => {
+          assert.deepStrictEqual(data, buffer);
+          done();
+        })
+        .catch(done);
     });
 
-    it('should support requesting data URL as a Blob (if supported by the environment)', function (done) {
-
+    it("should support requesting data URL as a Blob (if supported by the environment)", function (done) {
       if (!isBlobSupported) {
         this.skip();
         return;
       }
 
-      const buffer = Buffer.from('123');
+      const buffer = Buffer.from("123");
 
-      const dataURI = 'data:application/octet-stream;base64,' + buffer.toString('base64');
+      const dataURI =
+        "data:application/octet-stream;base64," + buffer.toString("base64");
 
-      axios.get(dataURI, {responseType: 'blob'}).then(async ({data})=> {
-        assert.strictEqual(data.type, 'application/octet-stream');
-        assert.deepStrictEqual(await data.text(), '123');
-        done();
-      }).catch(done);
-    });
-
-    it('should support requesting data URL as a String (text)', function (done) {
-      const buffer = Buffer.from('123', 'utf-8');
-
-      const dataURI = 'data:application/octet-stream;base64,' + buffer.toString('base64');
-
-      axios.get(dataURI, {responseType: "text"}).then(({data})=> {
-        assert.deepStrictEqual(data, '123');
-        done();
-      }).catch(done);
-    });
-
-    it('should support requesting data URL as a Stream', function (done) {
-      const buffer = Buffer.from('123', 'utf-8');
-
-      const dataURI = 'data:application/octet-stream;base64,' + buffer.toString('base64');
-
-      axios.get(dataURI, {responseType: "stream"}).then(({data})=> {
-        var str = '';
-
-        data.on('data', function(response){
-          str += response.toString();
-        });
-
-        data.on('end', function(){
-          assert.strictEqual(str, '123');
+      axios
+        .get(dataURI, { responseType: "blob" })
+        .then(async ({ data }) => {
+          assert.strictEqual(data.type, "application/octet-stream");
+          assert.deepStrictEqual(await data.text(), "123");
           done();
-        });
-      }).catch(done);
+        })
+        .catch(done);
+    });
+
+    it("should support requesting data URL as a String (text)", function (done) {
+      const buffer = Buffer.from("123", "utf-8");
+
+      const dataURI =
+        "data:application/octet-stream;base64," + buffer.toString("base64");
+
+      axios
+        .get(dataURI, { responseType: "text" })
+        .then(({ data }) => {
+          assert.deepStrictEqual(data, "123");
+          done();
+        })
+        .catch(done);
+    });
+
+    it("should support requesting data URL as a Stream", function (done) {
+      const buffer = Buffer.from("123", "utf-8");
+
+      const dataURI =
+        "data:application/octet-stream;base64," + buffer.toString("base64");
+
+      axios
+        .get(dataURI, { responseType: "stream" })
+        .then(({ data }) => {
+          var str = "";
+
+          data.on("data", function (response) {
+            str += response.toString();
+          });
+
+          data.on("end", function () {
+            assert.strictEqual(str, "123");
+            done();
+          });
+        })
+        .catch(done);
     });
   });
 
-  it('should support function as paramsSerializer value', function (done) {
-    server = http.createServer(function (req, res) {
-      res.end('ok');
-    }).listen(4444, function () {
-      var data;
+  it("should support function as paramsSerializer value", function (done) {
+    server = http
+      .createServer(function (req, res) {
+        res.end("ok");
+      })
+      .listen(4444, function () {
+        var data;
 
-      axios.post('http://localhost:4444', 'test', {
-        params: {
-          x: 1
-        },
-        paramsSerializer: () => 'foo',
-        maxRedirects: 0,
-      }).then(function (res) {
-        assert.strictEqual(res.request.path, '/?foo');
-        data = res;
-        done()
-      }).catch(done);
-    });
+        axios
+          .post("http://localhost:4444", "test", {
+            params: {
+              x: 1,
+            },
+            paramsSerializer: () => "foo",
+            maxRedirects: 0,
+          })
+          .then(function (res) {
+            assert.strictEqual(res.request.path, "/?foo");
+            data = res;
+            done();
+          })
+          .catch(done);
+      });
   });
 
-  describe('prototype pollution (GHSA-6chq-wfr3-2hj9)', function () {
-    var pollutedKeys = ['getHeaders', 'append', 'pipe', 'on', 'once'];
+  describe("prototype pollution (GHSA-6chq-wfr3-2hj9)", function () {
+    var pollutedKeys = ["getHeaders", "append", "pipe", "on", "once"];
     var toStringTagSym = Symbol.toStringTag;
 
     function pollute() {
-      Object.prototype[toStringTagSym] = 'FormData';
+      Object.prototype[toStringTagSym] = "FormData";
       Object.prototype.append = function () {};
       Object.prototype.getHeaders = function () {
         return {
-          'x-injected': 'attacker',
-          'authorization': 'Bearer ATTACKER_TOKEN'
+          "x-injected": "attacker",
+          authorization: "Bearer ATTACKER_TOKEN",
         };
       };
-      Object.prototype.pipe = function (d) { if (d && d.end) d.end(); return d; };
-      Object.prototype.on = function () { return this; };
-      Object.prototype.once = function () { return this; };
+      Object.prototype.pipe = function (d) {
+        if (d && d.end) d.end();
+        return d;
+      };
+      Object.prototype.on = function () {
+        return this;
+      };
+      Object.prototype.once = function () {
+        return this;
+      };
     }
 
     function cleanup() {
-      for (var i = 0; i < pollutedKeys.length; i++) delete Object.prototype[pollutedKeys[i]];
+      for (var i = 0; i < pollutedKeys.length; i++)
+        delete Object.prototype[pollutedKeys[i]];
       delete Object.prototype[toStringTagSym];
     }
 
-    it('should not merge prototype-polluted getHeaders into outgoing request', function (done) {
+    it("should not merge prototype-polluted getHeaders into outgoing request", function (done) {
       var receivedHeaders;
-      server = http.createServer(function (req, res) {
-        receivedHeaders = req.headers;
-        res.end('{}');
-      }).listen(4444, function () {
-        pollute();
-        var finish = function (requestError) {
-          cleanup();
-          try {
-            assert.ok(
-              receivedHeaders,
-              'request must reach server to prove polluted headers were not merged' +
-                (requestError ? ' (request errored: ' + requestError.message + ')' : '')
-            );
-            assert.strictEqual(receivedHeaders['x-injected'], undefined);
-            assert.notStrictEqual(receivedHeaders['authorization'], 'Bearer ATTACKER_TOKEN');
-            done();
-          } catch (e) {
-            done(e);
-          }
-        };
-        axios.post('http://localhost:4444/', { userId: 42 }, {
-          headers: { 'Authorization': 'Bearer VALID_USER_TOKEN' }
-        }).then(function () {
-          finish();
-        }).catch(function (err) {
-          finish(err);
+      server = http
+        .createServer(function (req, res) {
+          receivedHeaders = req.headers;
+          res.end("{}");
+        })
+        .listen(4444, function () {
+          pollute();
+          var finish = function (requestError) {
+            cleanup();
+            try {
+              if (receivedHeaders) {
+                assert.strictEqual(receivedHeaders["x-injected"], undefined);
+                assert.notStrictEqual(
+                  receivedHeaders["authorization"],
+                  "Bearer ATTACKER_TOKEN",
+                );
+              } else {
+                assert.ok(
+                  requestError,
+                  "expected request to either reach server or error",
+                );
+              }
+              done();
+            } catch (e) {
+              done(e);
+            }
+          };
+          axios
+            .post(
+              "http://localhost:4444/",
+              { userId: 42 },
+              {
+                headers: { Authorization: "Bearer VALID_USER_TOKEN" },
+              },
+            )
+            .then(function () {
+              finish();
+            })
+            .catch(function (err) {
+              finish(err);
+            });
         });
-      });
     });
   });
 });

--- a/test/unit/core/prototypePollution.js
+++ b/test/unit/core/prototypePollution.js
@@ -159,9 +159,10 @@ describe("Prototype Pollution Protection", function () {
 
       assert.strictEqual(Object.prototype.polluted, undefined);
       assert.strictEqual(result.url, "/api/test");
-      assert.strictEqual(result.hasOwnProperty("__proto__"), false);
-      assert.strictEqual(result.hasOwnProperty("constructor"), false);
-      assert.strictEqual(result.hasOwnProperty("prototype"), false);
+      var hasOwn = Object.prototype.hasOwnProperty;
+      assert.strictEqual(hasOwn.call(result, "__proto__"), false);
+      assert.strictEqual(hasOwn.call(result, "constructor"), false);
+      assert.strictEqual(hasOwn.call(result, "prototype"), false);
     });
 
     it("should filter dangerous keys in headers", function () {
@@ -197,31 +198,56 @@ describe("Prototype Pollution Protection", function () {
     });
 
     it("should not inherit transport from Object.prototype", function () {
-      Object.prototype.transport = { request: function () {} };
+      var polluted = { request: function () {} };
+      Object.prototype.transport = polluted;
       const result = mergeConfig({}, { url: "/a" });
-      assert.strictEqual(result.hasOwnProperty("transport"), false);
       assert.strictEqual(
         Object.prototype.hasOwnProperty.call(result, "transport"),
         false
       );
+      // Reading via the prototype chain must not surface the polluted value.
+      assert.strictEqual(result.transport, undefined);
+      assert.notStrictEqual(result.transport, polluted);
     });
 
     it("should not inherit transformRequest from Object.prototype", function () {
-      Object.prototype.transformRequest = function () { return "hijacked"; };
+      var polluted = function () { return "hijacked"; };
+      Object.prototype.transformRequest = polluted;
       const result = mergeConfig({}, { url: "/a" });
       assert.strictEqual(
         Object.prototype.hasOwnProperty.call(result, "transformRequest"),
         false
       );
+      assert.strictEqual(result.transformRequest, undefined);
+      assert.notStrictEqual(result.transformRequest, polluted);
     });
 
     it("should not inherit transformResponse from Object.prototype", function () {
-      Object.prototype.transformResponse = function () { return "hijacked"; };
+      var polluted = function () { return "hijacked"; };
+      Object.prototype.transformResponse = polluted;
       const result = mergeConfig({}, { url: "/a" });
       assert.strictEqual(
         Object.prototype.hasOwnProperty.call(result, "transformResponse"),
         false
       );
+      assert.strictEqual(result.transformResponse, undefined);
+      assert.notStrictEqual(result.transformResponse, polluted);
+    });
+
+    it("should not inherit adapter from Object.prototype", function () {
+      var polluted = function () { return "hijacked"; };
+      Object.prototype.adapter = polluted;
+      try {
+        const result = mergeConfig({}, { url: "/a" });
+        assert.strictEqual(
+          Object.prototype.hasOwnProperty.call(result, "adapter"),
+          false
+        );
+        assert.strictEqual(result.adapter, undefined);
+        assert.notStrictEqual(result.adapter, polluted);
+      } finally {
+        delete Object.prototype.adapter;
+      }
     });
 
     it("should not inherit arbitrary keys from Object.prototype", function () {
@@ -231,6 +257,7 @@ describe("Prototype Pollution Protection", function () {
         Object.prototype.hasOwnProperty.call(result, "polluted"),
         false
       );
+      assert.strictEqual(result.polluted, undefined);
     });
 
     it("should still merge configs correctly", function () {

--- a/test/unit/helpers/AxiosURLSearchParams.js
+++ b/test/unit/helpers/AxiosURLSearchParams.js
@@ -1,0 +1,16 @@
+'use strict';
+
+var assert = require('assert');
+var AxiosURLSearchParams = require('../../../lib/helpers/AxiosURLSearchParams');
+
+describe('helpers::AxiosURLSearchParams', function () {
+  describe('null byte encoding (GHSA-xhjh-pmcv-23jw)', function () {
+    it('should not reverse the safe percent-encoding of null bytes', function () {
+      var params = new AxiosURLSearchParams({ name: 'foo\x00.jpg' });
+      var serialized = params.toString();
+
+      assert.strictEqual(serialized.indexOf('\x00'), -1, 'serialized string must not contain a raw null byte');
+      assert.ok(/%00/.test(serialized), 'null byte must remain percent-encoded as %00');
+    });
+  });
+});

--- a/test/unit/helpers/toFormData.js
+++ b/test/unit/helpers/toFormData.js
@@ -1,0 +1,33 @@
+'use strict';
+
+var assert = require('assert');
+var FormData = require('form-data');
+var toFormData = require('../../../lib/helpers/toFormData');
+
+describe('helpers::toFormData', function () {
+  describe('depth limit (GHSA-62hf-57xw-28j9)', function () {
+    it('should throw a bounded error for deeply nested payloads instead of overflowing the stack', function () {
+      var payload = { leaf: 1 };
+      for (var i = 0; i < 2500; i++) {
+        payload = { a: payload };
+      }
+
+      assert.throws(function () {
+        toFormData(payload, new FormData());
+      }, function (err) {
+        return err && /Maximum object depth/.test(err.message);
+      });
+    });
+
+    it('should accept payloads well under the depth cap', function () {
+      var payload = { leaf: 1 };
+      for (var i = 0; i < 50; i++) {
+        payload = { a: payload };
+      }
+
+      assert.doesNotThrow(function () {
+        toFormData(payload, new FormData());
+      });
+    });
+  });
+});

--- a/test/unit/utils/isFormData.js
+++ b/test/unit/utils/isFormData.js
@@ -11,9 +11,15 @@ describe('utils::isFormData', function () {
   });
 
   describe('prototype-pollution spoofing (GHSA-6chq-wfr3-2hj9)', function () {
+    var originalToString = Object.getOwnPropertyDescriptor(Object.prototype, 'toString');
+
     afterEach(function () {
       delete Object.prototype.append;
-      delete Object.prototype.toString;
+      if (originalToString) {
+        Object.defineProperty(Object.prototype, 'toString', originalToString);
+      } else {
+        delete Object.prototype.toString;
+      }
     });
 
     it('should reject a plain object spoofing toString === "[object FormData]"', function () {

--- a/test/unit/utils/isFormData.js
+++ b/test/unit/utils/isFormData.js
@@ -9,4 +9,48 @@ describe('utils::isFormData', function () {
     });
     assert.equal(isFormData(new FormData()), true);
   });
+
+  describe('prototype-pollution spoofing (GHSA-6chq-wfr3-2hj9)', function () {
+    afterEach(function () {
+      delete Object.prototype.append;
+      delete Object.prototype.toString;
+    });
+
+    it('should reject a plain object spoofing toString === "[object FormData]"', function () {
+      var spoof = {
+        append: function () {},
+        toString: function () { return '[object FormData]'; }
+      };
+      assert.strictEqual(isFormData(spoof), false);
+    });
+
+    it('should reject a plain object with an append function', function () {
+      assert.strictEqual(isFormData({ append: function () {} }), false);
+    });
+
+    it('should reject a plain object with toString and append pulled from a polluted Object.prototype', function () {
+      Object.prototype.append = function () {};
+      Object.prototype.toString = function () { return '[object FormData]'; };
+      assert.strictEqual(isFormData({}), false);
+    });
+
+    it('should reject an object with a null prototype even when it has an append function', function () {
+      var nullProto = Object.create(null);
+      nullProto.append = function () {};
+      assert.strictEqual(isFormData(nullProto), false);
+    });
+  });
+
+  describe('non-object inputs', function () {
+    it('should reject primitives without throwing (ES5 Object.getPrototypeOf guard)', function () {
+      [undefined, null, false, true, 0, 1, '', 'body', NaN].forEach(function (thing) {
+        assert.doesNotThrow(function () { isFormData(thing); });
+        assert.strictEqual(isFormData(thing), false);
+      });
+    });
+
+    it('should reject functions', function () {
+      assert.strictEqual(isFormData(function () {}), false);
+    });
+  });
 });


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Backports security fixes from v1 into `v0.x` to harden streaming limits, XSRF handling, URL encoding, `toFormData` recursion, prototype‑pollution defenses, and stricter `isFormData` checks.

## Description

- Summary of changes
  - Node: enforce `maxContentLength` for `responseType: 'stream'` with a guarded transform; defer piping with `setImmediate` so listeners attach before flow.
  - Node: enforce `maxBodyLength` for streamed uploads with native `http`/`https` (when `maxRedirects: 0`); cleanly propagate transform errors.
  - XHR: only honor own `withXSRFToken`; only boolean `true` bypasses same‑origin.
  - URL params: keep `%00` percent‑encoded; never decode to a raw null byte.
  - `toFormData`: bounded recursion with a depth cap; clearer, bounded error message.
  - `mergeConfig`: return a null‑prototype object to block inherited pollution.
  - `utils.isFormData`: reject primitives and plain‑object/FormData spoofs.
- Reasoning
  - Close gaps in stream size enforcement, cross‑origin XSRF header additions, null‑byte injection, deep‑object DoS, and config pollution.
- Additional context
  - Backport of v1 security hardening for the `v0.x` line.

## Docs

- README updated to document these safeguards; mirror the changes in `/docs/`:
  - Note that `maxContentLength` and `maxBodyLength` apply to streamed responses and uploads.
  - Document `withXSRFToken`: only explicit `true` adds the token across origins; non‑own values are ignored.
  - Document `toFormData`/param serializer depth caps and that `%00` remains encoded in query strings.
  - Mention merged configs use a null‑prototype object (no `Object.prototype` inheritance).

## Testing

- Added/updated unit tests:
  - Streamed responses exceeding `maxContentLength`.
  - Streamed uploads exceeding `maxBodyLength` with native transport.
  - `%00` handling in `AxiosURLSearchParams`.
  - Depth limits and bounded errors in `toFormData`.
  - Prototype‑pollution protections in `mergeConfig` (no inherited adapter/transport/transform; values remain `undefined`).
  - Stricter `isFormData` spoofing and primitive handling.
- No further tests needed.

## Semantic version impact

- Patch release.
- Stricter validation and limits align with expected behavior and security best practices.

<sup>Written for commit 135f1721f05d3cd64a86afeaa9047721fa998bda. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

