### PR TITLE
fix: preserve query and hash urls in combineURLs

### DIFF
--- a/lib/helpers/combineURLs.js
+++ b/lib/helpers/combineURLs.js
@@ -10,6 +10,8 @@
  */
 export default function combineURLs(baseURL, relativeURL) {
   return relativeURL
-    ? baseURL.replace(/\/?\/$/, '') + '/' + relativeURL.replace(/^\/+/, '')
+    ? baseURL.replace(/\/?\/$/, '') +
+        (relativeURL[0] === '?' || relativeURL[0] === '#' ? '' : '/') +
+        relativeURL.replace(/^\/+/, '')
     : baseURL;
 }

--- a/tests/unit/helpers/combineURLs.test.js
+++ b/tests/unit/helpers/combineURLs.test.js
@@ -21,4 +21,16 @@ describe('helpers::combineURLs', () => {
   it('should allow a single slash for relative url', () => {
     expect(combineURLs('https://api.github.com/users', '/')).toBe('https://api.github.com/users/');
   });
+
+  it('should not insert a slash before a query-only relative url', () => {
+    expect(combineURLs('https://api.github.com/users', '?page=2')).toBe(
+      'https://api.github.com/users?page=2'
+    );
+  });
+
+  it('should not insert a slash before a hash-only relative url', () => {
+    expect(combineURLs('https://api.github.com/users', '#profile')).toBe(
+      'https://api.github.com/users#profile'
+    );
+  });
 });


### PR DESCRIPTION

**Repo:** axios/axios (⭐ 106000)
**Type:** bugfix
**Files changed:** 2
**Lines:** +15/-1

## What
This change fixes `combineURLs()` so axios does not inject an extra `/` when the relative portion of a URL is only a query string or fragment. The patch keeps existing path-join behavior intact, while adding unit coverage for `'?page=2'` and `'#profile'` inputs.

## Why
When axios combines `baseURL` with a query-only or hash-only relative URL, the previous implementation produced values like `https://api.github.com/users/?page=2` and `https://api.github.com/users/#profile`. That alters the target URL by adding an unintended path separator. The fix makes helper behavior match standard URL resolution for these cases and reduces the chance of subtle request routing bugs.

## Testing
Intended verification: run `npx vitest run tests/unit/helpers/combineURLs.test.js`.
Local result: not run successfully in this clone because `node_modules/` is absent, so Vitest is not available without installing dependencies.

## Risk
Low - the change is isolated to one URL helper and covered by focused regression tests for the newly handled edge cases.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `combineURLs()` to avoid adding a slash when the relative URL is only a query or hash, matching standard URL resolution and preventing unintended path changes.

## Description

- Summary of changes
  - Skip inserting `/` when `relativeURL` starts with `?` or `#`.
  - Kept existing path-join behavior.
  - Added unit tests for `'?page=2'` and `'#profile'`.
- Reasoning
  - Previous behavior produced `https://api.github.com/users/?page=2` and `.../#profile`, which changed the target path.
- Additional context
  - Change is isolated to the `combineURLs()` helper.

## Docs

Suggest updating `docs/` to clarify how `baseURL` combines with query-only and hash-only relative URLs, with a brief example.

## Testing

- Added two unit tests in `tests/unit/helpers/combineURLs.test.js` for query-only and hash-only inputs.
- No other tests require changes.

## Semantic version impact

Patch: bug fix with no API changes.

<sup>Written for commit 532dd579f162dfb0ae1b4ff57c4296194b56404c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

