### PR TITLE
[Docs/Types] Update `parseReviver` TypeScript definitions for ES2023 and add to official configuration documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -700,8 +700,16 @@ These are the available config options for making requests. Only the `url` is re
     // In modern environments, context.source provides the raw JSON string
     // allowing for precision-safe parsing of BigInt
     if (typeof value === 'number' && context?.source) {
-      if (!Number.isSafeInteger(value)) {
-        return BigInt(context.source);
+      const isInteger = Number.isInteger(value);
+      const isUnsafe = !Number.isSafeInteger(value);
+      const isValidIntegerString = /^-?\d+$/.test(context.source);
+
+      if (isInteger && isUnsafe && isValidIntegerString) {
+        try {
+          return BigInt(context.source);
+        } catch {
+          // Fallback: return original value if parsing fails
+        }
       }
     }
     return value;

--- a/README.md
+++ b/README.md
@@ -694,6 +694,19 @@ These are the available config options for making requests. Only the `url` is re
     return data;
   }],
 
+  // `parseReviver` is an optional function that will be passed as the
+  // second argument (reviver) to JSON.parse()
+  parseReviver: function (key, value, context) {
+    // In modern environments, context.source provides the raw JSON string
+    // allowing for precision-safe parsing of BigInt
+    if (typeof value === 'number' && context?.source) {
+      if (!Number.isSafeInteger(value)) {
+        return BigInt(context.source);
+      }
+    }
+    return value;
+  },
+
   // `headers` are custom headers to be sent
   headers: {'X-Requested-With': 'XMLHttpRequest'},
 

--- a/docs/pages/advanced/request-config.md
+++ b/docs/pages/advanced/request-config.md
@@ -26,6 +26,34 @@ The `transformRequest` function allows you to modify the request data before it 
 
 The `transformResponse` function allows you to modify the response data before it is passed to the `then` or `catch` functions. This function is called with the response data as its only argument.
 
+### `parseReviver`
+
+The `parseReviver` function allows you to provide a custom "reviver" function directly to the native `JSON.parse()` call used by the default `transformResponse`.
+
+This is particularly useful for performing high-performance type hydration (e.g., converting ISO strings to `Temporal` or `Date` objects) or preventing precision loss during parsing.
+
+In modern environments (ES2023+), the reviver function receives a third `context` argument. This provides access to the raw JSON `source`, allowing for precise conversion of large integers (BigInt) that would otherwise lose precision if parsed as standard JavaScript numbers.
+
+```js
+const client = axios.create({
+  parseReviver: (key, value, context) => {
+    // Example: Precision-safe BigInt parsing
+    if (typeof value === 'number' && context?.source) {
+      if (context.source.length > 15 || !Number.isSafeInteger(value)) {
+        return BigInt(context.source);
+      }
+    }
+
+    // Example: Hydrating dates into Temporal objects
+    if (typeof value === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(value)) {
+      return Temporal.PlainDate.from(value);
+    }
+
+    return value;
+  },
+});
+```
+
 ### `headers`
 
 The `headers` are the HTTP headers to be sent with the request. The `Content-Type` header is set to `application/json` by default.
@@ -170,7 +198,7 @@ Restricts which socket paths may be used via `socketPath`. Accepts a string or a
 
 ```js
 const client = axios.create({
-  allowedSocketPaths: ['/var/run/docker.sock']
+  allowedSocketPaths: ['/var/run/docker.sock'],
 });
 
 // allowed

--- a/docs/pages/advanced/request-config.md
+++ b/docs/pages/advanced/request-config.md
@@ -34,18 +34,33 @@ This is particularly useful for performing high-performance type hydration (e.g.
 
 In modern environments (ES2023+), the reviver function receives a third `context` argument. This provides access to the raw JSON `source`, allowing for precise conversion of large integers (BigInt) that would otherwise lose precision if parsed as standard JavaScript numbers.
 
+> Note: `Temporal` is not yet available in all environments. Consider using a polyfill if needed.
+
 ```js
 const client = axios.create({
   parseReviver: (key, value, context) => {
     // Example: Precision-safe BigInt parsing
     if (typeof value === 'number' && context?.source) {
-      if (context.source.length > 15 || !Number.isSafeInteger(value)) {
-        return BigInt(context.source);
+      const isInteger = Number.isInteger(value);
+      const isUnsafe = !Number.isSafeInteger(value);
+      const isValidIntegerString = /^-?\d+$/.test(context.source);
+
+      if (isInteger && isUnsafe && isValidIntegerString) {
+        try {
+          return BigInt(context.source);
+        } catch {
+          // Fallback: return original value if parsing fails
+        }
       }
     }
 
     // Example: Hydrating dates into Temporal objects
-    if (typeof value === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    if (
+      typeof value === 'string' &&
+      /^\d{4}-\d{2}-\d{2}$/.test(value) &&
+      typeof Temporal !== 'undefined' &&
+      Temporal?.PlainDate
+    ) {
       return Temporal.PlainDate.from(value);
     }
 

--- a/index.d.cts
+++ b/index.d.cts
@@ -538,6 +538,7 @@ declare namespace axios {
           | LookupAddress
         >);
     withXSRFToken?: boolean | ((config: InternalAxiosRequestConfig) => boolean | undefined);
+    parseReviver?: (this: any, key: string, value: any, context?: { source: string }) => any;
     fetchOptions?:
       | Omit<RequestInit, 'body' | 'headers' | 'method' | 'signal'>
       | Record<string, any>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -440,7 +440,7 @@ export interface AxiosRequestConfig<D = any> {
         [address: LookupAddressEntry | LookupAddressEntry[], family?: AddressFamily] | LookupAddress
       >);
   withXSRFToken?: boolean | ((config: InternalAxiosRequestConfig) => boolean | undefined);
-  parseReviver?: (this: any, key: string, value: any) => any;
+  parseReviver?: (this: any, key: string, value: any, context?: { source: string }) => any;
   fetchOptions?: Omit<RequestInit, 'body' | 'headers' | 'method' | 'signal'> | Record<string, any>;
   httpVersion?: 1 | 2;
   http2Options?: Record<string, any> & {


### PR DESCRIPTION
### Description:
Currently, Axios passes the `parseReviver` configuration option directly to the native `JSON.parse` function under the hood (e.g., `return JSON.parse(data, own(this, 'parseReviver'));`). However, there are two issues regarding its discoverability and TypeScript support:

1. **Missing from Documentation:** The `parseReviver` option is completely absent from the [Request Config documentation](https://axios-http.com/docs/req_config).
2. **Outdated TypeScript Definitions:** The type definition for `parseReviver` does not support the ES2023/ES14 standard, which [introduces a third `context` argument](https://github.com/tc39/proposal-json-parse-with-source) to the reviver function (specifically for `context.source`).

### Expected Behavior:
**1. Documentation:**
`parseReviver` should be listed in the Request Config docs alongside `transformResponse`, explaining that it allows users to provide a custom reviver function to `JSON.parse`.

**2. TypeScript Definitions:**
The `index.d.ts` file should be updated to reflect modern JavaScript engine capabilities. The third argument allows developers to access the raw JSON source, which is critical for parsing large integers (BigInt) without precision loss or properly hydrating strict date types (like `Temporal`).

**Current Type:**
```typescript
parseReviver?: (this: any, key: string, value: any) => any;
```

**Proposed Type:**
```typescript
parseReviver?: (this: any, key: string, value: any, context?: { source: string }) => any;
```

### Steps To Reproduce / Motivation:
When attempting to use modern ES2023 features to hydrate data at the network edge, TypeScript throws an error because the Axios types do not recognize the third argument.

```typescript
const apiClient = axios.create({
  baseURL: '/api',
  parseReviver: (key, value, context) => { // TS Error: Expected 2 arguments, but got 3.
    // Use case: Prevent BigInt precision loss from backend systems
    if (typeof value === 'number' && context?.source && context.source.length > 15) {
       return BigInt(context.source);
    }
    return value;
  }
});
```
Currently, developers have to manually cast the function to bypass the Axios type definitions, even though the native JS engine executes the code perfectly.

### Environment:
* **Axios Version:** 1.15.1
* **Node.js/Browser:** Node 20+ / Chrome 114+ / Modern Browsers (ES2023 support)
* **TypeScript Version:** 5.9.3

### Proposed Solution:
* Add a brief entry for `parseReviver` in `docs/req_config.md`.
* Update the `parseReviver` signature in `index.d.ts` to include the optional `context` parameter.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds ES2023 `context.source` support to the `parseReviver` TypeScript type and documents safe usage (BigInt and optional `Temporal`). No runtime changes to `axios`.

## Description

- Summary of changes
  - Types: update `index.d.ts` and `index.d.cts` to `parseReviver?: (this: any, key: string, value: any, context?: { source: string }) => any`.
  - Docs: add a `parseReviver` section to `/docs/pages/advanced/request-config.md` with precision-safe BigInt parsing and guarded `Temporal` hydration; fix a minor formatting issue (trailing comma in examples).
  - README: add a `parseReviver` example showing precision-safe BigInt parsing.
- Reasoning
  - Aligns with ES2023 `JSON.parse` reviver `context` and surfaces safe parsing patterns.
- Additional context
  - `parseReviver` is passed to native `JSON.parse` by the default `transformResponse`.

## Docs

Update the docs site in `/docs/` to include the new `parseReviver` section and examples, and ensure the README references remain consistent.

## Testing

- No tests added.
- Recommend adding `tsd`/`dtslint` assertions for `(key, value, context?)` and `context.source: string` in both `.d.ts` and `.d.cts`. No runtime tests needed.

## Semantic version impact

Patch: types and docs only; no runtime behavior changes.

<sup>Written for commit 8df2d9ee69cf0e1b9e36e1e0ad042e2ef4bc97ec. Summary will update on new commits. <a href="https://cubic.dev/pr/axios/axios/pull/10782?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



