### PR TITLE
fix: clear stale header on redirect when target is no-proxy

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -194,7 +194,7 @@ function dispatchBeforeRedirect(options, responseDetails) {
  *
  * @returns {http.ClientRequestArgs}
  */
-function setProxy(options, configProxy, location) {
+function setProxy(options, configProxy, location, isRedirect) {
   let proxy = configProxy;
   if (!proxy && proxy !== false) {
     const proxyUrl = getProxyForUrl(location);
@@ -204,11 +204,11 @@ function setProxy(options, configProxy, location) {
       }
     }
   }
-  // Always strip any stale Proxy-Authorization header carried over from a prior
-  // request (e.g. a redirect where the new target no longer uses a proxy, or uses
-  // a different proxy). It will be re-added below if the resolved proxy requires it.
-  // Header names are case-insensitive, so remove every case variant.
-  if (options.headers) {
+  // On redirect re-invocation, strip any stale Proxy-Authorization header carried
+  // over from the prior request (e.g. new target no longer uses a proxy, or uses
+  // a different proxy). Skip on the initial request so user-supplied headers are
+  // preserved. Header names are case-insensitive, so remove every case variant.
+  if (isRedirect && options.headers) {
     for (const name of Object.keys(options.headers)) {
       if (name.toLowerCase() === 'proxy-authorization') {
         delete options.headers[name];
@@ -251,7 +251,7 @@ function setProxy(options, configProxy, location) {
   options.beforeRedirects.proxy = function beforeRedirect(redirectOptions) {
     // Configure proxy for redirected request, passing the original config proxy to apply
     // the exact same logic as if the redirected request was performed by axios directly.
-    setProxy(redirectOptions, configProxy, redirectOptions.href);
+    setProxy(redirectOptions, configProxy, redirectOptions.href, true);
   };
 }
 

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -207,8 +207,13 @@ function setProxy(options, configProxy, location) {
   // Always strip any stale Proxy-Authorization header carried over from a prior
   // request (e.g. a redirect where the new target no longer uses a proxy, or uses
   // a different proxy). It will be re-added below if the resolved proxy requires it.
+  // Header names are case-insensitive, so remove every case variant.
   if (options.headers) {
-    delete options.headers['Proxy-Authorization'];
+    for (const name of Object.keys(options.headers)) {
+      if (name.toLowerCase() === 'proxy-authorization') {
+        delete options.headers[name];
+      }
+    }
   }
   if (proxy) {
     // Basic proxy authorization

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -204,6 +204,12 @@ function setProxy(options, configProxy, location) {
       }
     }
   }
+  // Always strip any stale Proxy-Authorization header carried over from a prior
+  // request (e.g. a redirect where the new target no longer uses a proxy, or uses
+  // a different proxy). It will be re-added below if the resolved proxy requires it.
+  if (options.headers) {
+    delete options.headers['Proxy-Authorization'];
+  }
   if (proxy) {
     // Basic proxy authorization
     if (proxy.username) {

--- a/tests/unit/adapters/http.test.js
+++ b/tests/unit/adapters/http.test.js
@@ -2416,6 +2416,32 @@ describe('supports http with nodejs', () => {
         'stale credentials from previous proxy must not leak to a new proxy without credentials'
       );
     });
+
+    it('strips stale Proxy-Authorization regardless of header key casing', () => {
+      const staleValue = 'Basic ' + Buffer.from('user:pass', 'utf8').toString('base64');
+      const casings = ['proxy-authorization', 'PROXY-AUTHORIZATION', 'Proxy-authorization', 'pRoXy-AuThOrIzAtIoN'];
+
+      for (const casing of casings) {
+        const redirectOptions = {
+          headers: { [casing]: staleValue },
+          beforeRedirects: {},
+          hostname: 'attacker.example.com',
+          host: 'attacker.example.com',
+          port: 443,
+        };
+
+        __setProxy(redirectOptions, false, 'https://attacker.example.com/final');
+
+        const leaked = Object.keys(redirectOptions.headers).filter(
+          (name) => name.toLowerCase() === 'proxy-authorization'
+        );
+        assert.deepStrictEqual(
+          leaked,
+          [],
+          `stale Proxy-Authorization with key "${casing}" must be stripped regardless of casing`
+        );
+      }
+    });
   });
 
   it('should support cancel', async () => {

--- a/tests/unit/adapters/http.test.js
+++ b/tests/unit/adapters/http.test.js
@@ -2333,7 +2333,7 @@ describe('supports http with nodejs', () => {
         host: 'attacker.example.com',
         port: 443,
       };
-      __setProxy(redirectOptions, false, 'https://attacker.example.com/final');
+      __setProxy(redirectOptions, false, 'https://attacker.example.com/final', true);
 
       assert.strictEqual(
         redirectOptions.headers['Proxy-Authorization'],
@@ -2375,7 +2375,7 @@ describe('supports http with nodejs', () => {
           port: 443,
           protocol: 'https:',
         };
-        __setProxy(redirectOptions, undefined, 'https://attacker.example.com/final');
+        __setProxy(redirectOptions, undefined, 'https://attacker.example.com/final', true);
 
         assert.strictEqual(
           redirectOptions.headers['Proxy-Authorization'],
@@ -2408,12 +2408,61 @@ describe('supports http with nodejs', () => {
         host: 'second.example.com',
         port: 80,
       };
-      __setProxy(redirectOptions, { host: '127.0.0.2', port: 8031 }, 'http://second.example.com/final');
+      __setProxy(redirectOptions, { host: '127.0.0.2', port: 8031 }, 'http://second.example.com/final', true);
 
       assert.strictEqual(
         redirectOptions.headers['Proxy-Authorization'],
         undefined,
         'stale credentials from previous proxy must not leak to a new proxy without credentials'
+      );
+    });
+
+    it('strips stale Proxy-Authorization when the beforeRedirects.proxy hook is invoked with configProxy=false', () => {
+      const options = {
+        headers: { 'Proxy-Authorization': 'Basic ' + Buffer.from('user:pass', 'utf8').toString('base64') },
+        beforeRedirects: {},
+        hostname: 'initial.example.com',
+        host: 'initial.example.com',
+        port: 80,
+      };
+
+      __setProxy(options, false, 'http://initial.example.com/start');
+      assert.strictEqual(typeof options.beforeRedirects.proxy, 'function', 'initial setProxy must install redirect hook');
+
+      const redirectOptions = {
+        headers: { 'Proxy-Authorization': 'Basic ' + Buffer.from('user:pass', 'utf8').toString('base64') },
+        beforeRedirects: {},
+        hostname: 'attacker.example.com',
+        host: 'attacker.example.com',
+        port: 443,
+        href: 'https://attacker.example.com/final',
+      };
+
+      options.beforeRedirects.proxy(redirectOptions);
+
+      assert.strictEqual(
+        redirectOptions.headers['Proxy-Authorization'],
+        undefined,
+        'beforeRedirects.proxy hook must strip stale Proxy-Authorization when redirect target has no proxy'
+      );
+    });
+
+    it('preserves a user-supplied Proxy-Authorization header on the initial request when no proxy is configured', () => {
+      const userValue = 'Basic ' + Buffer.from('alice:secret', 'utf8').toString('base64');
+      const options = {
+        headers: { 'Proxy-Authorization': userValue },
+        beforeRedirects: {},
+        hostname: 'example.com',
+        host: 'example.com',
+        port: 80,
+      };
+
+      __setProxy(options, false, 'http://example.com/start');
+
+      assert.strictEqual(
+        options.headers['Proxy-Authorization'],
+        userValue,
+        'user-supplied Proxy-Authorization must not be stripped on the initial request'
       );
     });
 
@@ -2430,7 +2479,7 @@ describe('supports http with nodejs', () => {
           port: 443,
         };
 
-        __setProxy(redirectOptions, false, 'https://attacker.example.com/final');
+        __setProxy(redirectOptions, false, 'https://attacker.example.com/final', true);
 
         const leaked = Object.keys(redirectOptions.headers).filter(
           (name) => name.toLowerCase() === 'proxy-authorization'

--- a/tests/unit/adapters/http.test.js
+++ b/tests/unit/adapters/http.test.js
@@ -2348,7 +2348,7 @@ describe('supports http with nodejs', () => {
       const originalNoProxy = process.env.no_proxy;
 
       process.env.http_proxy = 'http://user:pass@127.0.0.1:8030';
-      delete process.env.https_proxy;
+      process.env.https_proxy = 'http://user:pass@127.0.0.1:8030';
       process.env.no_proxy = 'attacker.example.com';
 
       try {

--- a/tests/unit/adapters/http.test.js
+++ b/tests/unit/adapters/http.test.js
@@ -2786,30 +2786,53 @@ describe('supports http with nodejs', () => {
       }
 
       it('should not merge prototype-polluted getHeaders into outgoing request', async () => {
-        let receivedHeaders;
-        const server = await startHTTPServer(
-          (req, res) => {
-            receivedHeaders = req.headers;
-            res.end('{}');
+        // Use a stub transport rather than a real HTTP server: polluting
+        // Object.prototype in-process can destabilise Node's HTTP server
+        // internals and cause spurious ECONNRESET. The stub captures the final
+        // outgoing headers axios constructs, which is what this test asserts on.
+        let capturedHeaders;
+        const stubTransport = {
+          request(options, handleResponse) {
+            capturedHeaders = { ...options.headers };
+            const req = new EventEmitter();
+            req.write = () => true;
+            req.setTimeout = () => {};
+            req.destroy = () => {};
+            req.end = () => {
+              const res = new stream.Readable({ read() {} });
+              res.statusCode = 200;
+              res.statusMessage = 'OK';
+              res.headers = {};
+              res.rawHeaders = [];
+              res.req = req;
+              process.nextTick(() => {
+                handleResponse(res);
+                res.push(null);
+              });
+            };
+            return req;
           },
-          { port: SERVER_PORT }
-        );
+        };
 
         try {
           pollute();
           await axios.post(
-            `http://localhost:${server.address().port}/`,
+            'http://stub.invalid/',
             { userId: 42 },
-            { headers: { 'Authorization': 'Bearer VALID_USER_TOKEN' } }
+            {
+              headers: { 'Authorization': 'Bearer VALID_USER_TOKEN' },
+              transport: stubTransport,
+              maxRedirects: 0,
+            }
           );
         } finally {
           cleanup();
-          await stopHTTPServer(server);
         }
 
-        assert.ok(receivedHeaders, 'request did not reach server');
-        assert.strictEqual(receivedHeaders['x-injected'], undefined);
-        assert.notStrictEqual(receivedHeaders['authorization'], 'Bearer ATTACKER_TOKEN');
+        assert.ok(capturedHeaders, 'transport was not invoked');
+        assert.strictEqual(capturedHeaders['x-injected'], undefined);
+        assert.notStrictEqual(capturedHeaders['Authorization'], 'Bearer ATTACKER_TOKEN');
+        assert.notStrictEqual(capturedHeaders['authorization'], 'Bearer ATTACKER_TOKEN');
       });
     });
   });

--- a/tests/unit/adapters/http.test.js
+++ b/tests/unit/adapters/http.test.js
@@ -2307,6 +2307,117 @@ describe('supports http with nodejs', () => {
     }
   });
 
+  describe('Proxy-Authorization header leak on redirect (GHSA-j5f8-grm9-p9fc)', () => {
+    it('clears a stale Proxy-Authorization header when redirected request resolves to no proxy (configProxy=false)', () => {
+      const options = {
+        headers: {},
+        beforeRedirects: {},
+        hostname: 'initial.example.com',
+        host: 'initial.example.com',
+        port: 80,
+      };
+
+      __setProxy(options, { host: '127.0.0.1', port: 8030, auth: { username: 'user', password: 'pass' } }, 'http://initial.example.com/start');
+      assert.strictEqual(
+        options.headers['Proxy-Authorization'],
+        'Basic ' + Buffer.from('user:pass', 'utf8').toString('base64'),
+        'initial request should carry Proxy-Authorization'
+      );
+
+      // Simulate redirect re-invocation where the redirected request is resolved to no proxy.
+      // This mirrors the beforeRedirects.proxy hook being called with configProxy=false.
+      const redirectOptions = {
+        headers: { ...options.headers },
+        beforeRedirects: {},
+        hostname: 'attacker.example.com',
+        host: 'attacker.example.com',
+        port: 443,
+      };
+      __setProxy(redirectOptions, false, 'https://attacker.example.com/final');
+
+      assert.strictEqual(
+        redirectOptions.headers['Proxy-Authorization'],
+        undefined,
+        'stale Proxy-Authorization must be stripped when redirected request no longer uses a proxy'
+      );
+    });
+
+    it('clears a stale Proxy-Authorization header when environment-derived proxy is bypassed on redirect (NO_PROXY)', () => {
+      const originalHttpProxy = process.env.http_proxy;
+      const originalHttpsProxy = process.env.https_proxy;
+      const originalNoProxy = process.env.no_proxy;
+
+      process.env.http_proxy = 'http://user:pass@127.0.0.1:8030';
+      delete process.env.https_proxy;
+      process.env.no_proxy = 'attacker.example.com';
+
+      try {
+        const options = {
+          headers: {},
+          beforeRedirects: {},
+          hostname: 'initial.example.com',
+          host: 'initial.example.com',
+          port: 80,
+        };
+
+        __setProxy(options, undefined, 'http://initial.example.com/start');
+        assert.strictEqual(
+          options.headers['Proxy-Authorization'],
+          'Basic ' + Buffer.from('user:pass', 'utf8').toString('base64'),
+          'initial request should pick up proxy credentials from env'
+        );
+
+        const redirectOptions = {
+          headers: { ...options.headers },
+          beforeRedirects: {},
+          hostname: 'attacker.example.com',
+          host: 'attacker.example.com',
+          port: 443,
+          protocol: 'https:',
+        };
+        __setProxy(redirectOptions, undefined, 'https://attacker.example.com/final');
+
+        assert.strictEqual(
+          redirectOptions.headers['Proxy-Authorization'],
+          undefined,
+          'stale Proxy-Authorization must be stripped when redirect target is covered by NO_PROXY'
+        );
+      } finally {
+        if (originalHttpProxy === undefined) delete process.env.http_proxy; else process.env.http_proxy = originalHttpProxy;
+        if (originalHttpsProxy === undefined) delete process.env.https_proxy; else process.env.https_proxy = originalHttpsProxy;
+        if (originalNoProxy === undefined) delete process.env.no_proxy; else process.env.no_proxy = originalNoProxy;
+      }
+    });
+
+    it('replaces Proxy-Authorization when redirect target resolves to a different proxy without credentials', () => {
+      const options = {
+        headers: {},
+        beforeRedirects: {},
+        hostname: 'initial.example.com',
+        host: 'initial.example.com',
+        port: 80,
+      };
+
+      __setProxy(options, { host: '127.0.0.1', port: 8030, auth: { username: 'user', password: 'pass' } }, 'http://initial.example.com/start');
+      assert.ok(options.headers['Proxy-Authorization'], 'precondition: initial proxy auth header set');
+
+      const redirectOptions = {
+        headers: { ...options.headers },
+        beforeRedirects: {},
+        hostname: 'second.example.com',
+        host: 'second.example.com',
+        port: 80,
+      };
+      __setProxy(redirectOptions, { host: '127.0.0.2', port: 8031 }, 'http://second.example.com/final');
+
+      assert.strictEqual(
+        redirectOptions.headers['Proxy-Authorization'],
+        undefined,
+        'stale credentials from previous proxy must not leak to a new proxy without credentials'
+      );
+    });
+  });
+
   it('should support cancel', async () => {
     const source = axios.CancelToken.source();
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stops leaking `Proxy-Authorization` across redirects by stripping it on redirected requests, then re-adding it only if the final proxy needs credentials. Covers no-proxy targets, different proxies, env-derived proxies, `NO_PROXY` bypasses, and case-insensitive header keys. Addresses AXI-197 and GHSA-j5f8-grm9-p9fc.

- **Description**
  - Strip stale `Proxy-Authorization` in `setProxy` only on redirect; preserve user-supplied header on the initial request.
  - Recalculate proxy per redirect from config/env; handles no-proxy, different proxy, and `NO_PROXY` bypass.
  - Docs: update `/docs/` proxy section to note the header is not carried across redirects; add a short security note.
  - Semantic version impact: Patch (bug fix, no API changes).

- **Testing**
  - Added unit tests for: redirect to no proxy, `NO_PROXY` bypass, redirect to a different proxy without credentials, hook with `configProxy=false`, preserving user-supplied header on the initial request, and case-insensitive stripping.
  - Switched the prototype‑pollution test to a stub transport and asserted final outgoing headers; verifies neither `Authorization` nor `authorization` leak attacker values.

<sup>Written for commit d78e4ca2f810d448ec36239bf29618cc81ec2d0c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

