### PR TITLE
chore: added clarifying docs for the type change

### DIFF
--- a/index.d.cts
+++ b/index.d.cts
@@ -320,10 +320,35 @@ declare namespace axios {
 
   type AxiosResponseHeaders = RawAxiosResponseHeaders & AxiosHeaders;
 
+  /**
+   * `transformRequest` is invoked as a left-fold pipeline: each function's return
+   * value becomes the next function's `data` argument (see `lib/core/transformData.js`).
+   *
+   * The `D` generic describes the type of `data` entering the *first* transformer
+   * in the chain. Subsequent transformers in an array — and any user transformer
+   * that runs after axios's default `transformRequest` (which serializes objects
+   * to JSON, FormData, URLSearchParams, etc.) — may receive a serialized form
+   * (`string`, `Buffer`, `ArrayBuffer`, `FormData`, `URLSearchParams`,
+   * `Stream`, ...) rather than `D`. The final transformer in the chain is
+   * expected to return one of those serialized forms.
+   *
+   * For best results, type `D` only when supplying a single transformer that
+   * runs first, or accept that intermediate stages may need a runtime check.
+   */
   interface AxiosRequestTransformer<D = any> {
     (this: InternalAxiosRequestConfig<D>, data: D, headers: AxiosRequestHeaders): any;
   }
 
+  /**
+   * `transformResponse` is invoked as a left-fold pipeline: each function's
+   * return value becomes the next function's `data` argument.
+   *
+   * The `T` generic describes the type of `data` entering the *first* transformer
+   * in the chain — typically the raw response body (`string`, `ArrayBuffer`,
+   * `Buffer`, or `Stream` depending on `responseType`). Later transformers
+   * receive whatever the previous stage returned, so `T` is only accurate for
+   * the first call.
+   */
   interface AxiosResponseTransformer<T = any> {
     (
       this: InternalAxiosRequestConfig,

--- a/index.d.ts
+++ b/index.d.ts
@@ -138,10 +138,35 @@ export type RawAxiosResponseHeaders = Partial<RawAxiosHeaders & RawCommonRespons
 
 export type AxiosResponseHeaders = RawAxiosResponseHeaders & AxiosHeaders;
 
+/**
+ * `transformRequest` is invoked as a left-fold pipeline: each function's return
+ * value becomes the next function's `data` argument (see `lib/core/transformData.js`).
+ *
+ * The `D` generic describes the type of `data` entering the *first* transformer
+ * in the chain. Subsequent transformers in an array — and any user transformer
+ * that runs after axios's default `transformRequest` (which serializes objects
+ * to JSON, FormData, URLSearchParams, etc.) — may receive a serialized form
+ * (`string`, `Buffer`, `ArrayBuffer`, `FormData`, `URLSearchParams`,
+ * `Stream`, ...) rather than `D`. The final transformer in the chain is
+ * expected to return one of those serialized forms.
+ *
+ * For best results, type `D` only when supplying a single transformer that
+ * runs first, or accept that intermediate stages may need a runtime check.
+ */
 export interface AxiosRequestTransformer<D = any> {
   (this: InternalAxiosRequestConfig<D>, data: D, headers: AxiosRequestHeaders): any;
 }
 
+/**
+ * `transformResponse` is invoked as a left-fold pipeline: each function's
+ * return value becomes the next function's `data` argument.
+ *
+ * The `T` generic describes the type of `data` entering the *first* transformer
+ * in the chain — typically the raw response body (`string`, `ArrayBuffer`,
+ * `Buffer`, or `Stream` depending on `responseType`). Later transformers
+ * receive whatever the previous stage returned, so `T` is only accurate for
+ * the first call.
+ */
 export interface AxiosResponseTransformer<T = any> {
   (
     this: InternalAxiosRequestConfig,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds clarifying docs to `AxiosRequestTransformer<D>` and `AxiosResponseTransformer<T>` explaining the transform pipeline and what the generics represent. No runtime or type API changes; comments only in `index.d.ts` and `index.d.cts`.

**Description**
- Summary of changes: Added JSDoc to `AxiosRequestTransformer` and `AxiosResponseTransformer` to describe left-fold pipeline behavior and scope of `D`/`T` generics; updated both `index.d.ts` and `index.d.cts`.
- Reasoning: Clarifies how data flows through transform arrays and when generic types apply, reducing confusion after the recent type change.
- Additional context: Guidance notes recommend typing `D` only for the first transformer and noting that later stages may receive serialized forms.

**Docs**
- Suggest adding a short note in `/docs/` under request/response transforms explaining:
  - Transforms run as a left-fold pipeline.
  - `D`/`T` describe the input to the first transformer only.
  - Later transformers may receive serialized data (string, Buffer, FormData, etc.).
  - Example showing a single typed request transformer vs. an array with mixed outputs.

**Testing**
- No tests added or modified. This is a comments-only update to type definition files; no behavior or type signatures changed, so tests are not required.

**Semantic version impact**
- Patch: documentation-only change within `.d.ts`/`.d.cts` comments, no runtime or public type API changes.

<sup>Written for commit c3f187e9fb9eba575172214daf42f46c4f520609. Summary will update on new commits. <a href="https://cubic.dev/pr/axios/axios/pull/10804?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

