### PR TITLE
fix(http): preserve user-supplied Host header when forwarding through a proxy (#10805)

### DIFF
--- a/README.md
+++ b/README.md
@@ -928,6 +928,12 @@ These are the available config options for making requests. Only the `url` is re
   // This will set a `Proxy-Authorization` header, overwriting any existing
   // `Proxy-Authorization` custom headers you have set using `headers`.
   // If the proxy server uses HTTPS, then you must set the protocol to `https`.
+  // A user-supplied `Host` header in `headers` is preserved when forwarding
+  // through a proxy (case-insensitive match on `host`/`Host`/`HOST`); this
+  // lets you target a virtual host that differs from the request URL — for
+  // example, hitting `127.0.0.1:4000` while having the proxy treat the
+  // request as `example.com`. If no `Host` header is supplied, axios
+  // defaults it to the request URL's `hostname:port` as before.
   proxy: {
     protocol: 'https',
     host: '127.0.0.1',

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -238,9 +238,13 @@ function setProxy(options, configProxy, location, isRedirect) {
 
     // Preserve a user-supplied Host header (case-insensitive) so callers can override
     // the value forwarded to the proxy; otherwise default to the request URL's host.
-    const hasUserHostHeader = Object.keys(options.headers).some(
-      (name) => name.toLowerCase() === 'host'
-    );
+    let hasUserHostHeader = false;
+    for (const name in options.headers) {
+      if (name.toLowerCase() === 'host') {
+        hasUserHostHeader = true;
+        break;
+      }
+    }
     if (!hasUserHostHeader) {
       options.headers.host = options.hostname + (options.port ? ':' + options.port : '');
     }

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -236,7 +236,14 @@ function setProxy(options, configProxy, location, isRedirect) {
       options.headers['Proxy-Authorization'] = 'Basic ' + base64;
     }
 
-    options.headers.host = options.hostname + (options.port ? ':' + options.port : '');
+    // Preserve a user-supplied Host header (case-insensitive) so callers can override
+    // the value forwarded to the proxy; otherwise default to the request URL's host.
+    const hasUserHostHeader = Object.keys(options.headers).some(
+      (name) => name.toLowerCase() === 'host'
+    );
+    if (!hasUserHostHeader) {
+      options.headers.host = options.hostname + (options.port ? ':' + options.port : '');
+    }
     const proxyHost = proxy.hostname || proxy.host;
     options.hostname = proxyHost;
     // Replace 'host' since options is not a URL object

--- a/tests/unit/adapters/http.test.js
+++ b/tests/unit/adapters/http.test.js
@@ -2413,6 +2413,20 @@ describe('supports http with nodejs', () => {
       assert.strictEqual(options.headers.Host, 'example.com');
       assert.strictEqual(options.headers.host, undefined);
     });
+
+    it('preserves a user-supplied Host header across a redirect re-invocation', () => {
+      const options = {
+        headers: { Host: 'example.com' },
+        beforeRedirects: {},
+        hostname: '127.0.0.1',
+        port: 4000,
+      };
+
+      __setProxy(options, proxyConfig, 'http://127.0.0.1:4000/', true);
+
+      assert.strictEqual(options.headers.Host, 'example.com');
+      assert.strictEqual(options.headers.host, undefined);
+    });
   });
 
   describe('Proxy-Authorization header leak on redirect (GHSA-j5f8-grm9-p9fc)', () => {

--- a/tests/unit/adapters/http.test.js
+++ b/tests/unit/adapters/http.test.js
@@ -2349,6 +2349,50 @@ describe('supports http with nodejs', () => {
     }
   });
 
+  describe('Host header preservation when forwarding through a proxy (#10805)', () => {
+    const proxyConfig = { hostname: '127.0.0.1', protocol: 'http:', port: 8888 };
+
+    it('defaults the Host header to the request target when the user does not set one', () => {
+      const options = {
+        headers: {},
+        beforeRedirects: {},
+        hostname: '127.0.0.1',
+        port: 4000,
+      };
+
+      __setProxy(options, proxyConfig, 'http://127.0.0.1:4000/');
+
+      assert.strictEqual(options.headers.host, '127.0.0.1:4000');
+    });
+
+    it('preserves a user-supplied lowercase host header', () => {
+      const options = {
+        headers: { host: 'example.com' },
+        beforeRedirects: {},
+        hostname: '127.0.0.1',
+        port: 4000,
+      };
+
+      __setProxy(options, proxyConfig, 'http://127.0.0.1:4000/');
+
+      assert.strictEqual(options.headers.host, 'example.com');
+    });
+
+    it('preserves a user-supplied Host header regardless of casing', () => {
+      const options = {
+        headers: { Host: 'example.com' },
+        beforeRedirects: {},
+        hostname: '127.0.0.1',
+        port: 4000,
+      };
+
+      __setProxy(options, proxyConfig, 'http://127.0.0.1:4000/');
+
+      assert.strictEqual(options.headers.Host, 'example.com');
+      assert.strictEqual(options.headers.host, undefined);
+    });
+  });
+
   describe('Proxy-Authorization header leak on redirect (GHSA-j5f8-grm9-p9fc)', () => {
     it('clears a stale Proxy-Authorization header when redirected request resolves to no proxy (configProxy=false)', () => {
       const options = {


### PR DESCRIPTION
## Summary

Fixes #10805.

When sending a request through a proxy with the http adapter, axios was unconditionally rewriting `options.headers.host` to the request URL's `hostname:port`, overwriting any `Host` header the caller had set in `config.headers`. That made it impossible to direct a proxy to a virtual host that differs from the request URL.

### Before

```js
axios.get("http://127.0.0.1:4000", {
  headers: { host: "example.com" },
  proxy: { protocol: "http", host: "127.0.0.1", port: 8888 },
});
```

The proxy received:

```
GET / HTTP/1.1
host: 127.0.0.1:4000
```

### After

The proxy receives:

```
GET / HTTP/1.1
host: example.com
```

### Change

In ` lib/adapters/http.js#setProxy`, only assign the default `Host` header when the caller has not already provided one. The check is case-insensitive so users can pass `host`, `Host`, or `HOST`.

## Test plan

- [x] New unit tests in `tests/unit/adapters/http.test.js` covering the default behavior, lowercase user header, and mixed-case user header (`Host header preservation when forwarding through a proxy (#10805)` describe block).
- [x] All existing proxy-related unit tests still pass (`vitest run --project unit -t "proxy"` — 46 passed).
- [x] End-to-end smoke check with a real HTTP proxy + target server confirms the proxy now sees the user-supplied `Host` value while the target still sees its own hostname.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves a user-supplied Host header when requests go through a proxy in the Node http adapter for `axios`. This lets callers route to virtual hosts via proxies without the header being overwritten.

## Description

- Summary of changes: Skip setting `options.headers.host` if the user already set any `Host`/`host` header (case-insensitive). Otherwise default to `hostname:port`.
- Reasoning: Needed to target virtual hosts through proxies and avoid clobbering caller intent.
- Additional context: Behavior is limited to proxy forwarding logic; non-proxy requests are unchanged.

## Docs

Please update `/docs/` to note that `axios` respects a user-supplied `Host` header when using a proxy, with a short example showing virtual host routing via proxies.

## Testing

- Added unit tests for:
  - Defaulting when no `Host` is provided.
  - Preservation with lowercase `host` and mixed-case `Host`.
- All existing proxy tests still pass.
- Manual smoke check with a real HTTP proxy confirms the proxy sees the user-supplied `Host`.

## Semantic version impact

Patch (bug fix, no API changes).

<sup>Written for commit 584f28474509686aea4273381992cd539fae82e3. Summary will update on new commits. <a href="https://cubic.dev/pr/axios/axios/pull/10822?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

