### PR TITLE
fix(http): decode URL basic auth credentials

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -57,6 +57,18 @@ const supportedProtocols = platform.protocols.map((protocol) => {
   return protocol + ':';
 });
 
+const decodeURIComponentSafe = (value) => {
+  if (!utils.isString(value)) {
+    return value;
+  }
+
+  try {
+    return decodeURIComponent(value);
+  } catch (error) {
+    return value;
+  }
+};
+
 const flushOnFinish = (stream, [throttled, flush]) => {
   stream.on('end', flush).on('error', flush);
 
@@ -639,8 +651,8 @@ export default isHttpAdapterSupported &&
       }
 
       if (!auth && parsed.username) {
-        const urlUsername = decodeURIComponent(parsed.username);
-        const urlPassword = decodeURIComponent(parsed.password);
+        const urlUsername = decodeURIComponentSafe(parsed.username);
+        const urlPassword = decodeURIComponentSafe(parsed.password);
         auth = urlUsername + ':' + urlPassword;
       }
 

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -57,6 +57,10 @@ const supportedProtocols = platform.protocols.map((protocol) => {
   return protocol + ':';
 });
 
+// Node's WHATWG URL parser returns `username` and `password` percent-encoded.
+// Decode before composing the `auth` option so credentials such as
+// `my%40email.com:pass` are sent as `my@email.com:pass`. Falls back to the
+// original value for malformed input so a bad encoding never throws.
 const decodeURIComponentSafe = (value) => {
   if (!utils.isString(value)) {
     return value;

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -639,8 +639,8 @@ export default isHttpAdapterSupported &&
       }
 
       if (!auth && parsed.username) {
-        const urlUsername = parsed.username;
-        const urlPassword = parsed.password;
+        const urlUsername = decodeURIComponent(parsed.username);
+        const urlPassword = decodeURIComponent(parsed.password);
         auth = urlUsername + ':' + urlPassword;
       }
 

--- a/tests/unit/adapters/http.test.js
+++ b/tests/unit/adapters/http.test.js
@@ -868,6 +868,25 @@ describe('supports http with nodejs', () => {
     }
   });
 
+  it('should decode basic auth credentials from the request URL', async () => {
+    const server = await startHTTPServer(
+      (req, res) => {
+        res.end(req.headers.authorization);
+      },
+      { port: SERVER_PORT }
+    );
+
+    try {
+      const response = await axios.get(
+        `http://my%40email.com:pa%3Ass@localhost:${server.address().port}/`
+      );
+      const base64 = Buffer.from('my@email.com:pa:ss', 'utf8').toString('base64');
+      assert.strictEqual(response.data, `Basic ${base64}`);
+    } finally {
+      await stopHTTPServer(server);
+    }
+  });
+
   it('should support basic auth with a header', async () => {
     const server = await startHTTPServer(
       (req, res) => {

--- a/tests/unit/adapters/http.test.js
+++ b/tests/unit/adapters/http.test.js
@@ -887,6 +887,25 @@ describe('supports http with nodejs', () => {
     }
   });
 
+  it('keeps malformed URL credentials percent-encoding and does not throw', async () => {
+    const server = await startHTTPServer(
+      (req, res) => {
+        res.end(req.headers.authorization);
+      },
+      { port: SERVER_PORT }
+    );
+
+    try {
+      const response = await axios.get(
+        `http://user%:foo%zz@localhost:${server.address().port}/`
+      );
+      const base64 = Buffer.from('user%:foo%zz', 'utf8').toString('base64');
+      assert.strictEqual(response.data, `Basic ${base64}`);
+    } finally {
+      await stopHTTPServer(server);
+    }
+  });
+
   it('should support basic auth with a header', async () => {
     const server = await startHTTPServer(
       (req, res) => {

--- a/tests/unit/adapters/http.test.js
+++ b/tests/unit/adapters/http.test.js
@@ -900,9 +900,9 @@ describe('supports http with nodejs', () => {
 
     try {
       const response = await axios.get(
-        `http://my%40email.com:pa%3Ass@localhost:${server.address().port}/`
+        `http://my%40email.com:pa%24ss@localhost:${server.address().port}/`
       );
-      const base64 = Buffer.from('my@email.com:pa:ss', 'utf8').toString('base64');
+      const base64 = Buffer.from('my@email.com:pa$ss', 'utf8').toString('base64');
       assert.strictEqual(response.data, `Basic ${base64}`);
     } finally {
       await stopHTTPServer(server);


### PR DESCRIPTION
## Summary

Decodes username and password values parsed from URL userinfo before passing them to Node's HTTP `auth` option.

This fixes Basic auth credentials such as `my%40email.com:pass@host` being sent as `my%40email.com:pass` instead of `my@email.com:pass`.

Closes #5158.

## Validation

- `npm run test:vitest:unit -- tests/unit/adapters/http.test.js`
- `git diff --check`
- `npx eslint lib/adapters/http.js tests/unit/adapters/http.test.js`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Decodes URL-encoded Basic Auth credentials in request URLs and guards against malformed encodings. The Authorization header now uses decoded values without throwing on bad input.

## Description

- Decode `parsed.username` and `parsed.password` with a new `decodeURIComponentSafe` helper before composing the `auth` option in the Node HTTP adapter.
- If decoding fails, fall back to the original strings so malformed userinfo is passed through unchanged.

## Docs

- Add a note in `/docs/` that URL-encoded credentials in request URLs are decoded in the Node HTTP adapter, and malformed encodings are left as-is.

## Testing

- Added unit tests:
  - Decoded credentials produce the expected Basic header.
  - Malformed encodings do not throw and remain percent-encoded.

## Semantic version impact

- Patch (bug fix, no API changes).

<sup>Written for commit f4e39553f8f0a19483e7e86b5ee1aefbbfe60dd1. Summary will update on new commits. <a href="https://cubic.dev/pr/axios/axios/pull/10825?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

