### PR TITLE
fix: update fromDataURI regex to match RFC 2397

### DIFF
--- a/lib/helpers/fromDataURI.js
+++ b/lib/helpers/fromDataURI.js
@@ -4,7 +4,7 @@ import AxiosError from '../core/AxiosError.js';
 import parseProtocol from './parseProtocol.js';
 import platform from '../platform/index.js';
 
-const DATA_URL_PATTERN = /^(?:([^;]+);)?(?:[^;]+;)?(base64|),([\s\S]*)$/;
+const DATA_URL_PATTERN = /^([^,]*?)(;base64)?,(.*)$/s;
 
 /**
  * Parse data uri to a Buffer or Blob
@@ -33,8 +33,8 @@ export default function fromDataURI(uri, asBlob, options) {
       throw new AxiosError('Invalid URL', AxiosError.ERR_INVALID_URL);
     }
 
-    const mime = match[1];
-    const isBase64 = match[2];
+    const mime = match[1] || undefined;
+    const isBase64 = match[2] ? 'base64' : '';
     const body = match[3];
     const buffer = Buffer.from(decodeURIComponent(body), isBase64 ? 'base64' : 'utf8');
 

--- a/test/unit/helpers/fromDataURI.js
+++ b/test/unit/helpers/fromDataURI.js
@@ -9,4 +9,45 @@ describe('helpers::fromDataURI', function () {
 
     assert.deepStrictEqual(fromDataURI(dataURI, false), buffer);
   });
+
+  it('should parse data URI with no mediatype and base64', function () {
+    const buffer = Buffer.from('123');
+    const dataURI = 'data:;base64,' + buffer.toString('base64');
+
+    assert.deepStrictEqual(fromDataURI(dataURI, false), buffer);
+  });
+
+  it('should parse data URI with mediatype and no base64', function () {
+    const buffer = Buffer.from('123');
+    const dataURI = 'data:application/octet-stream,123';
+
+    assert.deepStrictEqual(fromDataURI(dataURI, false), buffer);
+  });
+
+  it('should parse full form data URI with text/plain and base64', function () {
+    const buffer = Buffer.from('hello');
+    const dataURI = 'data:text/plain;base64,' + buffer.toString('base64');
+
+    assert.deepStrictEqual(fromDataURI(dataURI, false), buffer);
+  });
+
+  it('should parse minimal valid data URI', function () {
+    const buffer = Buffer.from('');
+    const dataURI = 'data:,';
+
+    assert.deepStrictEqual(fromDataURI(dataURI, false), buffer);
+  });
+
+  it('should parse data URI with spaces in data', function () {
+    const buffer = Buffer.from('hello world');
+    const dataURI = 'data:text/plain,hello world';
+
+    assert.deepStrictEqual(fromDataURI(dataURI, false), buffer);
+  });
+
+  it('should reject invalid URI without data protocol', function () {
+    assert.throws(function () {
+      fromDataURI('notadata:uri', false);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
Update the `fromDataURI` regex to correctly match all valid RFC 2397 data URIs.

## Problem
The current `DATA_URL_PATTERN` regex requires a semicolon-terminated media type segment, which rejects valid data URIs like `data:;base64,MTIz` and `data:application/octet-stream,123` per RFC 2397.

## Solution
Replace the regex with an RFC 2397-compliant pattern that correctly handles optional media types, optional base64 flag, and various data content.

## Test Plan
- [x] Added tests for valid RFC 2397 data URIs (no mediatype, no base64, minimal, with spaces)
- [x] Added tests for invalid URIs (rejection)
- [x] Existing test suite passes

Fixes #10808