### PR TITLE
refactor: clean up composeSignals early-return structure

### DIFF
--- a/lib/helpers/composeSignals.js
+++ b/lib/helpers/composeSignals.js
@@ -3,54 +3,55 @@ import AxiosError from '../core/AxiosError.js';
 import utils from '../utils.js';
 
 const composeSignals = (signals, timeout) => {
-  const { length } = (signals = signals ? signals.filter(Boolean) : []);
+  signals = signals ? signals.filter(Boolean) : [];
 
-  if (timeout || length) {
-    let controller = new AbortController();
-
-    let aborted;
-
-    const onabort = function (reason) {
-      if (!aborted) {
-        aborted = true;
-        unsubscribe();
-        const err = reason instanceof Error ? reason : this.reason;
-        controller.abort(
-          err instanceof AxiosError
-            ? err
-            : new CanceledError(err instanceof Error ? err.message : err)
-        );
-      }
-    };
-
-    let timer =
-      timeout &&
-      setTimeout(() => {
-        timer = null;
-        onabort(new AxiosError(`timeout of ${timeout}ms exceeded`, AxiosError.ETIMEDOUT));
-      }, timeout);
-
-    const unsubscribe = () => {
-      if (signals) {
-        timer && clearTimeout(timer);
-        timer = null;
-        signals.forEach((signal) => {
-          signal.unsubscribe
-            ? signal.unsubscribe(onabort)
-            : signal.removeEventListener('abort', onabort);
-        });
-        signals = null;
-      }
-    };
-
-    signals.forEach((signal) => signal.addEventListener('abort', onabort));
-
-    const { signal } = controller;
-
-    signal.unsubscribe = () => utils.asap(unsubscribe);
-
-    return signal;
+  if (!timeout && !signals.length) {
+    return;
   }
+
+  const controller = new AbortController();
+
+  let aborted = false;
+
+  const onabort = function (reason) {
+    if (!aborted) {
+      aborted = true;
+      unsubscribe();
+      const err = reason instanceof Error ? reason : this.reason;
+      controller.abort(
+        err instanceof AxiosError
+          ? err
+          : new CanceledError(err instanceof Error ? err.message : err)
+      );
+    }
+  };
+
+  let timer =
+    timeout &&
+    setTimeout(() => {
+      timer = null;
+      onabort(new AxiosError(`timeout of ${timeout}ms exceeded`, AxiosError.ETIMEDOUT));
+    }, timeout);
+
+  const unsubscribe = () => {
+    if (!signals) { return; }
+    timer && clearTimeout(timer);
+    timer = null;
+    signals.forEach((signal) => {
+      signal.unsubscribe
+        ? signal.unsubscribe(onabort)
+        : signal.removeEventListener('abort', onabort);
+    });
+    signals = null;
+  };
+
+  signals.forEach((signal) => signal.addEventListener('abort', onabort));
+
+  const { signal } = controller;
+
+  signal.unsubscribe = () => utils.asap(unsubscribe);
+
+  return signal;
 };
 
 export default composeSignals;


### PR DESCRIPTION
## What
Restructures `lib/helpers/composeSignals.js` from a nested if-block to an early-return pattern, reducing indentation and making the flow clearer.

## Changes
- Flips the outer `if (timeout || length)` to `if (!timeout && !signals.length) return;`
- Uses `const` for the `AbortController` (not reassigned)
- Explicitly initializes `aborted = false` instead of relying on implicit `undefined`
- Adds a guard clause `if (!signals) return` at the top of `unsubscribe` for cleaner double-call protection
- Preserves the existing manual event-listener approach

## Why not AbortSignal.any()
I explored using `AbortSignal.any(signals)` instead of manual `addEventListener` calls. While it works for basic abort scenarios, it introduces subtle event-loop timing differences that cause the fetch adapter's stream-abort tests to fail (10 of 42 fetch tests hang). The composed signal's abort event fires in a different microtask queue compared to the direct listener approach, which changes the order of operations during stream abort handling. Until that's resolved upstream, the manual approach is more reliable.

## Tests
All 45 relevant tests pass (3 composeSignals + 42 fetch adapter).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors `composeSignals` to use an early-return pattern with small safety guards while keeping manual listener composition to preserve abort timing. No API or behavior changes.

**Description**
- Summary of changes
  - Early return: `if (!timeout && !signals.length) return`
  - Use `const` for `AbortController`
  - Initialize `aborted = false`
  - Guard `unsubscribe` to ignore double calls
  - Keep manual listeners instead of `AbortSignal.any()`
- Reasoning
  - Early returns simplify flow and reduce nesting
  - `AbortSignal.any()` changes event-loop timing and breaks stream-abort tests; manual listeners keep current behavior
- Additional context
  - Only `lib/helpers/composeSignals.js` is changed
  - Merged latest `v1.x` into this branch; no functional changes

**Docs**
- No API change; no docs required
- Optional note in `/docs/` that `composeSignals` uses manual signal composition and an early-return guard for empty input

**Testing**
- No new tests
- All existing tests pass (3 `composeSignals`, 42 fetch adapter)
- No new tests needed; abort and timeout paths are covered

**Semantic version impact**
- Patch: internal refactor with no API or behavior changes

<sup>Written for commit e7b6bd5295a32e6ac7eb67e9d89bcd3181a57251. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



