### PR TITLE
fix: RFC 2397 compliant data URI regex in fromDataURI

### DIFF
--- a/lib/helpers/fromDataURI.js
+++ b/lib/helpers/fromDataURI.js
@@ -4,7 +4,9 @@ import AxiosError from '../core/AxiosError.js';
 import parseProtocol from './parseProtocol.js';
 import platform from '../platform/index.js';
 
-const DATA_URL_PATTERN = /^(?:([^;]+);)?(?:[^;]+;)?(base64|),([\s\S]*)$/;
+// RFC 2397 compliant: "data:" [ mediatype ] [ ";base64" ] "," data
+// mediatype := [ type "/" subtype ] *( ";" parameter )
+const DATA_URL_PATTERN = /^([^,;]+\/[^,;]+)?((?:;[^,;=]+=[^,;]+)*)(;base64)?,([\s\S]*)$/;
 
 /**
  * Parse data uri to a Buffer or Blob
@@ -33,9 +35,9 @@ export default function fromDataURI(uri, asBlob, options) {
       throw new AxiosError('Invalid URL', AxiosError.ERR_INVALID_URL);
     }
 
-    const mime = match[1];
-    const isBase64 = match[2];
-    const body = match[3];
+    const mime = (match[1] || '') + (match[2] || '');
+    const isBase64 = match[3];
+    const body = match[4];
     const buffer = Buffer.from(decodeURIComponent(body), isBase64 ? 'base64' : 'utf8');
 
     if (asBlob) {


### PR DESCRIPTION
## Summary

The `DATA_URL_PATTERN` regex in `lib/helpers/fromDataURI.js` doesn't properly match RFC 2397 compliant data URIs, causing valid URIs to throw `Invalid URL` errors.

## Failing cases (now fixed)

All three of these are RFC 2397 compliant and were previously rejected:

- `data:;base64,MTIz` — no media type
- `data:application/octet-stream,123` — no parameters before the comma
- `data:text/plain;charset=US-ASCII,123` — non-base64 parameter

The previous regex required `[^;]+;` for the first segment, so any URI without a `;` before the body failed to match.

## Solution

Updated the regex to properly match RFC 2397 grammar: `"data:" [ mediatype ] [ ";base64" ] "," data` where `mediatype := [ type "/" subtype ] *( ";" parameter )`.

New regex:
```js
const DATA_URL_PATTERN = /^([^,;]+\/[^,;]+)?((?:;[^,;=]+=[^,;]+)*)(;base64)?,([\s\S]*)$/;
```

Capture groups:
- group 1: media type (may be empty)
- group 2: parameter list (e.g. `;charset=US-ASCII`)
- group 3: `;base64` marker (truthy when present)
- group 4: body

The mime type for Blob is now constructed as `match[1] + match[2]` to preserve charset and other parameters.

## Related

- #7295 — previously proposed using `data-uri-to-buffer` dependency, but this inline fix avoids the runtime dependency

Closes #10808

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes RFC 2397 data URI parsing in `fromDataURI` by updating the regex and preserving parameters in the Blob MIME type. Prevents Invalid URL errors for valid data URIs.

- **Bug Fixes**
  - Replaced `DATA_URL_PATTERN` with an RFC 2397 compliant regex that supports optional media type, multiple `;key=value` parameters, optional `;base64`, and the body.
  - Blob MIME now includes media type plus parameters (e.g. `;charset=US-ASCII`).

- **Testing, Docs, and Semver**
  - Tests: none added. Recommend adding cases for `data:;base64,MTIz`, `data:application/octet-stream,123`, and `data:text/plain;charset=US-ASCII,123`.
  - Docs: suggest updating `/docs/` to document accepted data URI forms and parameter preservation.
  - Semantic version impact: patch.

<sup>Written for commit 9e3afc3db7499a8a2105fe82413d02624b386900. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

