### PR TITLE
fix(buildURL): support URL object as input

### DIFF
--- a/lib/helpers/buildURL.js
+++ b/lib/helpers/buildURL.js
@@ -33,6 +33,11 @@ export default function buildURL(url, params, options) {
     return url;
   }
 
+  // Convert URL object to string if necessary
+  if (typeof url === 'object' && url !== null && typeof url.toString === 'function') {
+    url = url.toString();
+  }
+
   const _encode = (options && options.encode) || encode;
 
   const _options = utils.isFunction(options)

--- a/tests/unit/helpers/buildURL.test.js
+++ b/tests/unit/helpers/buildURL.test.js
@@ -101,6 +101,16 @@ describe('helpers::buildURL', () => {
     expect(buildURL('/foo', new URLSearchParams('bar=baz'))).toEqual('/foo?bar=baz');
   });
 
+  it('should support URL object', () => {
+    const url = new URL('http://example.com/foo?a=1');
+    expect(buildURL(url, { b: 2 })).toEqual('http://example.com/foo?a=1&b=2');
+  });
+
+  it('should support URL object without params', () => {
+    const url = new URL('http://example.com/foo');
+    expect(buildURL(url, null)).toEqual(url.toString());
+  });
+
   it('should support custom serialize function', () => {
     const params = {
       x: 1,


### PR DESCRIPTION
## Bug Fix Summary

**Issue**: [#6546](https://github.com/axios/axios/issues/6546) - `url.indexOf is not a function`

## Problem

When passing a `URL` object to axios methods like `axios.get(url, { params: {...} })`, axios crashes with:
```
url.indexOf is not a function
```

This happens because `buildURL()` calls `url.indexOf('#')` assuming `url` is always a string, but `URL` objects don't have an `indexOf` method.

## Solution

Add a check at the beginning of `buildURL()` to convert `URL` objects to strings before processing.

## Changes

### lib/helpers/buildURL.js
```javascript
// Convert URL object to string if necessary
if (typeof url === 'object' && url !== null && typeof url.toString === 'function') {
  url = url.toString();
}
```

### tests/unit/helpers/buildURL.test.js
Added two test cases:
- `should support URL object` - verifies URL objects work with params
- `should support URL object without params` - verifies URL objects work without params

## Reproduction

```javascript
const url = new URL(document.location.href);

try {
  const response = await axios.get(url, { params: { test: "Hi" } });
} catch (err) {
  console.log(err); // Error: url.indexOf is not a function
}
```

## Fix

```javascript
const url = new URL(document.location.href);

const response = await axios.get(url, { params: { test: "Hi" } }); // Works!
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash when a `URL` object is passed as the request URL by updating `buildURL` to accept `URL` inputs. Prevents "url.indexOf is not a function" and restores parity with string URLs.

## Description

- Summary of changes: `buildURL` now coerces `URL` objects to strings before processing.
- Reasoning: `buildURL` assumed a string and called `indexOf`, which fails for `URL` objects passed to `axios.get(url, ...)`.
- Additional context: Fixes #6546 on the `v1.x` line.

## Docs

Please add a note in `/docs/` that request URLs can be either a string or a `URL` object. Include a short example using `new URL(...)` with `axios.get`.

## Testing

- Added two unit tests in `tests/unit/helpers/buildURL.test.js`:
  - Supports `URL` with query params.
  - Supports `URL` without params.
- No other tests changed; coverage for string URLs remains unaffected.

## Semantic version impact

Patch: backward-compatible bug fix for `axios`.

<sup>Written for commit 7b51e6d70b383f308cb97dfb1abc59daae187e61. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

