### PR TITLE
docs: fix interceptor eject example to use correct instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1188,7 +1188,7 @@ const instance = axios.create();
 const myInterceptor = instance.interceptors.request.use(function () {
   /*...*/
 });
-axios.interceptors.request.eject(myInterceptor);
+instance.interceptors.request.eject(myInterceptor);
 ```
 
 You can also clear all interceptors for requests or responses.


### PR DESCRIPTION
Fix interceptor eject example in README

The example creates an interceptor using an Axios instance but attempts to eject it using the global axios object. Updated the code to use the correct instance for consistency and clarity.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the interceptor eject example to use the created `axios` instance instead of the global `axios` object. This prevents confusion and shows the correct way to remove an interceptor from an instance.

## Description

- Summary of changes: Updated README to call `instance.interceptors.request.eject(myInterceptor)` instead of `axios.interceptors.request.eject(myInterceptor)`.
- Reasoning: The interceptor is registered on `instance`, so ejecting on `axios` would not remove it and misleads readers.
- Additional context: Docs-only; no runtime changes.

## Docs

- Mirror this fix in any code samples on the docs site under `/docs/` to keep examples consistent.

## Testing

- No tests added; documentation-only change. Tests not needed.

## Semantic version impact

- No impact. Docs-only change; no release required.

<sup>Written for commit 719903e0a1022358b917eb26b6ce4df4e415ed74. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

