### PR TITLE
fix: preserve abort signal reason in CanceledError

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -356,7 +356,11 @@ export default isHttpAdapterSupported && function httpAdapter(config) {
 
     function abort(reason) {
       try {
-        abortEmitter.emit('abort', !reason || reason.type ? new CanceledError(null, config, req) : reason);
+        abortEmitter.emit('abort', reason instanceof AxiosError ? reason : new CanceledError(
+          reason instanceof Error ? reason.message : (reason && typeof reason !== 'object' ? reason : null),
+          config,
+          req
+        ));
       } catch(err) {
         console.warn('emit error', err);
       }
@@ -364,13 +368,15 @@ export default isHttpAdapterSupported && function httpAdapter(config) {
 
     abortEmitter.once('abort', reject);
 
+    const onSignalAbort = config.signal && (() => abort(config.signal.reason));
+
     const onFinished = () => {
       if (config.cancelToken) {
         config.cancelToken.unsubscribe(abort);
       }
 
       if (config.signal) {
-        config.signal.removeEventListener('abort', abort);
+        config.signal.removeEventListener('abort', onSignalAbort);
       }
 
       abortEmitter.removeAllListeners();
@@ -379,7 +385,7 @@ export default isHttpAdapterSupported && function httpAdapter(config) {
     if (config.cancelToken || config.signal) {
       config.cancelToken && config.cancelToken.subscribe(abort);
       if (config.signal) {
-        config.signal.aborted ? abort() : config.signal.addEventListener('abort', abort);
+        config.signal.aborted ? abort(config.signal.reason) : config.signal.addEventListener('abort', onSignalAbort);
       }
     }
 

--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -18,6 +18,7 @@ export default isXHRAdapterSupported && function (config) {
     const requestHeaders = AxiosHeaders.from(_config.headers).normalize();
     let {responseType, onUploadProgress, onDownloadProgress} = _config;
     let onCanceled;
+    let onSignalAbort;
     let uploadThrottled, downloadThrottled;
     let flushUpload, flushDownload;
 
@@ -27,7 +28,7 @@ export default isXHRAdapterSupported && function (config) {
 
       _config.cancelToken && _config.cancelToken.unsubscribe(onCanceled);
 
-      _config.signal && _config.signal.removeEventListener('abort', onCanceled);
+      _config.signal && _config.signal.removeEventListener('abort', onSignalAbort);
     }
 
     let request = new XMLHttpRequest();
@@ -186,7 +187,8 @@ export default isXHRAdapterSupported && function (config) {
 
       _config.cancelToken && _config.cancelToken.subscribe(onCanceled);
       if (_config.signal) {
-        _config.signal.aborted ? onCanceled(_config.signal.reason) : _config.signal.addEventListener('abort', () => onCanceled(_config.signal.reason));
+        onSignalAbort = () => onCanceled(_config.signal.reason);
+        _config.signal.aborted ? onCanceled(_config.signal.reason) : _config.signal.addEventListener('abort', onSignalAbort);
       }
     }
 

--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -175,14 +175,18 @@ export default isXHRAdapterSupported && function (config) {
         if (!request) {
           return;
         }
-        reject(!cancel || cancel.type ? new CanceledError(null, config, request) : cancel);
+        reject(cancel instanceof AxiosError ? cancel : new CanceledError(
+          cancel instanceof Error ? cancel.message : (cancel && typeof cancel !== 'object' ? cancel : null),
+          config,
+          request
+        ));
         request.abort();
         request = null;
       };
 
       _config.cancelToken && _config.cancelToken.subscribe(onCanceled);
       if (_config.signal) {
-        _config.signal.aborted ? onCanceled() : _config.signal.addEventListener('abort', onCanceled);
+        _config.signal.aborted ? onCanceled(_config.signal.reason) : _config.signal.addEventListener('abort', () => onCanceled(_config.signal.reason));
       }
     }
 

--- a/test/unit/adapters/http.js
+++ b/test/unit/adapters/http.js
@@ -2474,7 +2474,7 @@ describe('supports http with nodejs', function () {
         await http2Axios.get(LOCAL_SERVER_URL, {
           signal: AbortSignal.timeout(500)
         });
-      }, /CanceledError:/);
+      }, /CanceledError: The operation was aborted due to timeout/);
 
       await promise;
 

--- a/test/unit/adapters/http.js
+++ b/test/unit/adapters/http.js
@@ -2474,7 +2474,7 @@ describe('supports http with nodejs', function () {
         await http2Axios.get(LOCAL_SERVER_URL, {
           signal: AbortSignal.timeout(500)
         });
-      }, /CanceledError: canceled/);
+      }, /CanceledError:/);
 
       await promise;
 


### PR DESCRIPTION
## What

Pass `signal.reason` directly to the cancellation handler in both the XHR and HTTP adapters, instead of the DOM `abort` Event object. Update the handler to forward `AxiosError` instances as-is and wrap other reasons in a `CanceledError` using their message.

## Why

When an `AbortSignal` is aborted with a custom reason (e.g. `controller.abort('TimeoutError')` or `AbortSignal.timeout()`), the reason was silently discarded. Both adapters registered `addEventListener('abort', handler)` which passes the Event object (with `.type = 'abort'`) to the handler. The existing guard `!reason || reason.type` detected the Event and created a generic `new CanceledError(null)`, throwing away the actual abort reason.

This made it impossible for callers to distinguish cancellation causes — e.g. a user-triggered cancel vs. a timeout.

Reported in #7434.

## Changes

- **`lib/adapters/xhr.js`**: Pass `_config.signal.reason` to `onCanceled` instead of the Event. Update `onCanceled` to use `AxiosError` instances directly and wrap other reasons in `CanceledError`.
- **`lib/adapters/http.js`**: Introduce `onSignalAbort` arrow function that calls `abort(config.signal.reason)`, keeping a stable reference for `removeEventListener`. Same logic update in `abort()`.
- **`test/unit/adapters/http.js`**: Relax the HTTP2 cancellation regex from `/CanceledError: canceled/` to `/CanceledError:/` — the test now correctly sees the preserved `AbortSignal.timeout()` reason message.

## How to test

```js
const controller = new AbortController();

axios.get('/slow-endpoint', { signal: controller.signal })
  .catch(err => {
    console.log(axios.isCancel(err)); // true
    console.log(err.message);         // 'TimeoutError' ← was 'canceled' before
  });

controller.abort('TimeoutError');
```

Closes #7434

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserve `AbortSignal.reason` across XHR and Node HTTP/HTTP2 adapters so callers can tell why a request was canceled (e.g., timeout vs user cancel), and clean up abort listeners correctly.

## Description

- Pass `signal.reason` to cancel handlers in XHR and HTTP/HTTP2 adapters.
- Forward `AxiosError` reasons as-is; wrap other reasons in `CanceledError` using Error.message or string.
- Use a stable `onSignalAbort` in both adapters so `removeEventListener` reliably removes the handler.
- Update HTTP2 cancellation test to assert the exact preserved reason: "The operation was aborted due to timeout".
- Fixes #7434.

Reasoning:
- Previously the abort event object hid the real reason, forcing a generic "canceled" message.

## Docs

- Update `/docs/` cancellation guidance to note `CanceledError.message` reflects `AbortSignal.reason` (including `AbortSignal.timeout()`), with a brief example.

## Testing

- Modified HTTP2 cancellation test to match the exact timeout reason string.
- Recommend adding an XHR test to assert custom `signal.reason` is preserved in `CanceledError.message` and that the abort listener is removed after completion.

## Semantic version impact

- Patch: bug fix preserving abort reasons and improving listener cleanup; no API changes, but error messages may differ.

<sup>Written for commit 418f52b7006b8cc75281ebabfe3ea4a988410cac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

