### PR TITLE
fix: error unexpected token in fetch JS compatibility issue with Webpack 4

### DIFF
--- a/.github/workflows/run-ci.yml
+++ b/.github/workflows/run-ci.yml
@@ -27,6 +27,8 @@ jobs:
           cache: npm
       - name: Install dependencies
         run: npm ci --ignore-scripts
+      - name: Lint
+        run: npm run lint
       - name: Build project
         run: npm run build
       - name: Install Playwright with deps

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -33,20 +33,27 @@ export default [
     languageOptions: {
       globals: {
         ...globals.browser,
-        ...globals.node
+        ...globals.node,
+        globalThis: 'readonly'
       }
     }
   },
   {
     files: ['lib/adapters/http.js', 'lib/platform/node/**/*.js'],
     languageOptions: {
-      globals: globals.node
+      globals: {
+        ...globals.node,
+        globalThis: 'readonly'
+      }
     }
   },
   {
     files: ['lib/adapters/xhr.js', 'lib/platform/browser/**/*.js'],
     languageOptions: {
-      globals: globals.browser
+      globals: {
+        ...globals.browser,
+        globalThis: 'readonly'
+      }
     }
   }
 ];

--- a/lib/adapters/fetch.js
+++ b/lib/adapters/fetch.js
@@ -28,7 +28,10 @@ const test = (fn, ...args) => {
 };
 
 const factory = (env) => {
-  const globalObject = utils.global ?? globalThis;
+  const globalObject =
+    utils.global !== undefined && utils.global !== null
+      ? utils.global
+      : globalThis;
   const { ReadableStream, TextEncoder } = globalObject;
 
   env = utils.merge.call(

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "@vitest/browser": "^4.1.5",
         "@vitest/browser-playwright": "^4.1.5",
         "abortcontroller-polyfill": "^1.7.8",
+        "acorn": "^8.16.0",
         "body-parser": "^2.2.2",
         "chalk": "^5.6.2",
         "cross-env": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -141,6 +141,7 @@
     "@vitest/browser": "^4.1.5",
     "@vitest/browser-playwright": "^4.1.5",
     "abortcontroller-polyfill": "^1.7.8",
+    "acorn": "^8.16.0",
     "body-parser": "^2.2.2",
     "chalk": "^5.6.2",
     "cross-env": "^10.1.0",

--- a/tests/unit/syntaxCompat.test.js
+++ b/tests/unit/syntaxCompat.test.js
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Parser } from 'acorn';
+
+const LIB_DIR = fileURLToPath(new URL('../../lib/', import.meta.url));
+const ECMA_VERSION = 2018;
+
+function walk(dir) {
+  const out = [];
+  for (const name of readdirSync(dir)) {
+    const full = join(dir, name);
+    if (statSync(full).isDirectory()) out.push(...walk(full));
+    else if (full.endsWith('.js')) out.push(full);
+  }
+  return out;
+}
+
+describe('lib/ source files parse as ES2018', () => {
+  for (const file of walk(LIB_DIR)) {
+    const rel = file.slice(LIB_DIR.length);
+    it(rel, () => {
+      const src = readFileSync(file, 'utf8');
+      expect(() =>
+        Parser.parse(src, { ecmaVersion: ECMA_VERSION, sourceType: 'module' })
+      ).not.toThrow();
+    });
+  }
+});


### PR DESCRIPTION
#### Summary

Restore Webpack 4 / ES2018 compatibility for `lib/adapters/fetch.js`. The fetch adapter was using the nullish coalescing operator (`??`), which is ES2020 syntax and breaks consumers bundling axios source with Webpack 4 (e.g. Vue 2.7 projects). axios's `lib/` source has always been intended to stay ES2018-compatible; the lint config already enforces `ecmaVersion: 2018`, but the rule was never wired into CI, so the regression slipped through.

#### Linked issue

Closes #10851

#### Changes

- `lib/adapters/fetch.js`: replace `utils.global ?? globalThis` with an explicit `!== undefined && !== null` ternary so the source parses under ES2018.
- `.github/workflows/run-ci.yml`: run `npm run lint` in the `build-and-run-vitest` job, so the existing `ecmaVersion: 2018` rule is actually enforced on PRs.
- `tests/unit/syntaxCompat.test.js`: new vitest unit test that parses every `lib/**/*.js` file with acorn at `ecmaVersion: 2018` defence in depth so any future ES2019+ syntax in `lib/` fails a named test, not just a generic lint error.
- `eslint.config.js`: add `globalThis: 'readonly'` to the lib globals blocks (the bare `globalThis` reference was previously masked by the `??` parse error; once parsing succeeds, `no-undef` flags it).
- `package.json` / `package-lock.json`: add `acorn ^8.16.0` as a `devDependency` for the new test.

#### Checklist

- [x] Tests added or updated (or N/A with reason) — new `tests/unit/syntaxCompat.test.js` covers the regression class
- [x] Docs / types updated if public API changed (`index.d.ts` and `index.d.cts`) — N/A, no public API change
- [x] No breaking changes (or called out explicitly above) runtime behaviour preserved; the ternary preserves the original nullish semantics

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores ES2018 compatibility in the fetch adapter to fix “Unexpected token ??” build errors when bundling `axios` with `webpack` 4 / `vue` 2.7. CI now enforces ES2018 syntax and adds a parsing test to prevent regressions. Addresses #10851.

## Description

- Summary of changes
  - Replaced `??` in `lib/adapters/fetch.js` with an ES2018-safe ternary.
  - Added `npm run lint` to CI to enforce `ecmaVersion: 2018`.
  - New test `tests/unit/syntaxCompat.test.js` parses all `lib/**/*.js` with `acorn` at ES2018.
  - Declared `globalThis: 'readonly'` in `eslint.config.js` for lib targets.
  - Added `acorn` as a devDependency.

- Reasoning
  - `lib/` is intended to stay ES2018. `??` is ES2020 and breaks `webpack` 4 builds.
  - Lint and parsing tests catch future syntax regressions early.

- Additional context
  - No runtime behavior change; ternary preserves nullish semantics.
  - Closes #10851.

## Docs

- Add a note in `/docs/` about `lib/` targeting ES2018.
- Mention compatibility with `webpack` 4 and `vue` 2.7 when bundling `axios` source.

## Testing

- Added `tests/unit/syntaxCompat.test.js` (acorn ES2018 parse over all `lib/**/*.js`).
- CI now runs `npm run lint`.
- No additional unit tests needed for runtime behavior; existing suites should remain green.

## Semantic version impact

- Patch: internal syntax fix and CI/test hardening. No API changes.

<sup>Written for commit ab8ecfb5a9a0db4f80c76febb6d5ede1ac3ea13e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

