### PR TITLE
chore: update to using h2

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -3,11 +3,11 @@ Before opening: please search existing issues to avoid duplicates, and confirm t
 For usage questions, please use Stack Overflow (https://stackoverflow.com/questions/tagged/axios) instead.
 -->
 
-#### Describe the issue
+## Describe the issue
 
 A clear description of the bug or feature request.
 
-#### Example code
+## Example code
 
 <!-- A minimal snippet that reproduces the issue. Remove any secrets/tokens. -->
 
@@ -15,15 +15,15 @@ A clear description of the bug or feature request.
 
 ```
 
-#### Expected behavior
+## Expected behavior
 
 What you expected to happen.
 
-#### Actual behavior
+## Actual behavior
 
 What actually happened (include error messages or stack traces if relevant).
 
-#### Environment
+## Environment
 
 - Axios version:
 - Adapter: <!-- xhr | http | fetch -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,15 +5,15 @@ Thanks for contributing to axios! A few quick notes:
 - If you leave the description blank, our AI agent will draft one — feel free to edit afterwards.
 -->
 
-#### Summary
+## Summary
 
 <!-- What does this PR do, and why? -->
 
-#### Linked issue
+## Linked issue
 
 <!-- e.g. Closes #1234 -->
 
-#### Changes
+## Changes
 
 <!-- Bullet list of the notable changes. Keep it short. -->
 


### PR DESCRIPTION
#### Summary

Update templates

#### Linked issue

n/a

#### Changes

-

#### Checklist

- [ ] Tests added or updated (or N/A with reason)
- [ ] Docs / types updated if public API changed (`index.d.ts` and `index.d.cts`)
- [ ] No breaking changes (or called out explicitly above)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes GitHub issue and PR templates to use H2 headings for clearer structure and consistency. No code or runtime changes.

## Description

- Summary of changes
  - Switched template headings from H4 (`####`) to H2 (`##`) in `.github/ISSUE_TEMPLATE.md` and `.github/PULL_REQUEST_TEMPLATE.md`.
  - Kept section names the same; only heading level changed.
- Reasoning
  - Improve readability and scanning.
  - Align with common GitHub template conventions.
- Additional context
  - No linked issue. Repo behavior is unchanged.

## Docs

Update `/docs/` contribution guidelines to reflect the H2 section headings shown in the updated templates.

## Testing

No tests added. Not needed since changes affect only GitHub templates and have no impact on code or behavior.

## Semantic version impact

None. No public API or package changes; no release required.

<sup>Written for commit 93714d7b080d1335b7f9e43df6653f4c108ce305. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

