### PR TITLE
fix(progress): guard malformed XHR upload events

### DIFF
--- a/lib/helpers/progressEventReducer.js
+++ b/lib/helpers/progressEventReducer.js
@@ -7,6 +7,9 @@ export const progressEventReducer = (listener, isDownloadStream, freq = 3) => {
   const _speedometer = speedometer(50, 250);
 
   return throttle((e) => {
+    if (!e || typeof e.loaded !== 'number') {
+      return;
+    }
     const rawLoaded = e.loaded;
     const total = e.lengthComputable ? e.total : undefined;
     const loaded = total != null ? Math.min(rawLoaded, total) : rawLoaded;

--- a/tests/unit/helpers/progressEventReducer.test.js
+++ b/tests/unit/helpers/progressEventReducer.test.js
@@ -24,4 +24,27 @@ describe('helpers::progressEventReducer', () => {
     expect(last.upload).toBe(true);
     expect(last.bytes).toBe(20);
   });
+
+  it('should ignore malformed events that lack a numeric loaded value', () => {
+    const events = [];
+    const [onProgress, flush] = progressEventReducer((data) => {
+      events.push(data);
+    }, false, Number.POSITIVE_INFINITY);
+
+    onProgress(undefined);
+    onProgress(null);
+    onProgress({});
+    onProgress({ loaded: null, total: 100, lengthComputable: true });
+    onProgress({ loaded: 'abc', total: 100, lengthComputable: true });
+    flush();
+
+    expect(events.length).toBe(0);
+
+    onProgress({ lengthComputable: true, loaded: 50, total: 100 });
+    flush();
+
+    expect(events.length).toBe(1);
+    expect(events[0].loaded).toBe(50);
+    expect(events[0].bytes).toBe(50);
+  });
 });


### PR DESCRIPTION
<!--
Thanks for contributing to axios! A few quick notes:
- For non-trivial changes, please open an issue first so we can discuss the approach.
- Follow Conventional Commits in your commit messages (see CONTRIBUTING.md).
- If you leave the description blank, our AI agent will draft one — feel free to edit afterwards.
-->

## Summary

`onUploadProgress` crashes with `Cannot read property 'loaded' of undefined`
  on React Native 0.79+ because `progressEventReducer` reads `e.loaded`
  without guarding the event shape. This adds a defensive check.

  ## Linked issue

  Closes #6928

  ## Changes

  - `lib/helpers/progressEventReducer.js`: skip throttled callback when
    the incoming event is missing or `loaded` is not numeric.
  - `tests/unit/helpers/progressEventReducer.test.js`: cover `undefined`,
    `null`, `{}`, non-numeric `loaded`, and recovery on a subsequent
    valid event.

#### Checklist

- [x] Tests added or updated (or N/A with reason)
- [ ] Docs / types updated if public API changed (`index.d.ts` and `index.d.cts`)
- [x] No breaking changes (or called out explicitly above)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash in `onUploadProgress` on React Native 0.79+ by guarding malformed XHR progress events in `progressEventReducer`. Prevents "Cannot read property 'loaded' of undefined" and safely ignores invalid events.

## Description

- Summary of changes
  - Skip progress callbacks when the event is missing or `loaded` is not a number.
  - Continue normal processing for the next valid event.
- Reasoning
  - RN 0.79+ can emit undefined/malformed progress events; accessing `e.loaded` crashed.
- Additional context
  - Closes #6928.
  - No public API changes; behavior is now defensive under bad events.

## Docs

Add a troubleshooting note in `/docs/` for React Native uploads: `onUploadProgress` ignores malformed events to avoid crashes.

## Testing

- Added unit tests for `undefined`, `null`, `{}`, and non-numeric `loaded`.
- Verified no callbacks for malformed events and recovery on a subsequent valid event.

## Semantic version impact

- Patch: bug fix with no API or behavior changes for valid inputs.

<sup>Written for commit b47d2388abd18b9323d820aa4d64d8f3028165d2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

