### PR TITLE
fix: remove all caches

### DIFF
--- a/.github/workflows/lockfile-lint.yml
+++ b/.github/workflows/lockfile-lint.yml
@@ -29,6 +29,8 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24.x
+          registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
 
       - name: Run lockfile-lint
         # Validates that every resolved URL uses HTTPS on registry.npmjs.org

--- a/.github/workflows/moderator.yml
+++ b/.github/workflows/moderator.yml
@@ -16,9 +16,12 @@ jobs:
       models: read
       contents: read
     steps:
+      - name: Checkout repo
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+
+      - name: Run AI Moderator
       - uses: github/ai-moderator@81159c370785e295c97461ade67d7c33576e9319 # v1.1.4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,15 +18,19 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24.x
           registry-url: 'https://registry.npmjs.org'
           package-manager-cache: false
+
       - name: Install dependencies
         run: npm ci --ignore-scripts
+
       - name: Build project
         run: npm run build
+
       - name: Publish to NPM
         run: npm publish --provenance --access public

--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -28,23 +28,32 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+
       - name: Setup node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24.x
-          cache: npm
+          registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
+
       - name: Install dependencies
         run: npm ci --ignore-scripts
+
       - name: Build project
         run: npm run build
+
       - name: Install Playwright with deps
         run: npx playwright install --with-deps
+
       - name: Run unit tests
         run: npm run test:vitest:unit
+
       - name: Run browser tests
         run: npm run test:vitest:browser:headless
+
       - name: Pack npm tarball
         run: npm pack
+
       - name: Upload npm pack artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -66,23 +75,28 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+
       - name: Setup node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node-version }}
-          cache: npm
-          cache-dependency-path: tests/smoke/cjs/package-lock.json
+          registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
+
       - name: Download npm pack artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: axios-tarball
           path: artifacts
+
       - name: Install CJS smoke test dependencies
         working-directory: tests/smoke/cjs
         run: npm install --ignore-scripts
+
       - name: Install packed axios
         working-directory: tests/smoke/cjs
         run: npm install --no-save ../../../artifacts/axios-*.tgz
+
       - name: Run CJS smoke tests
         working-directory: tests/smoke/cjs
         run: npm run test:smoke:cjs:mocha
@@ -100,23 +114,28 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+
       - name: Setup node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node-version }}
-          cache: npm
-          cache-dependency-path: tests/smoke/esm/package-lock.json
+          registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
+
       - name: Download npm pack artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: axios-tarball
           path: artifacts
+
       - name: Install ESM smoke test dependencies
         working-directory: tests/smoke/esm
         run: npm install --ignore-scripts
+
       - name: Install packed axios
         working-directory: tests/smoke/esm
         run: npm install --no-save ../../../artifacts/axios-*.tgz
+
       - name: Run ESM smoke tests
         working-directory: tests/smoke/esm
         run: npm run test:smoke:esm:vitest
@@ -134,23 +153,28 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+
       - name: Setup node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node-version }}
-          cache: npm
-          cache-dependency-path: tests/module/cjs/package-lock.json
+          registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
+
       - name: Download npm pack artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: axios-tarball
           path: artifacts
+
       - name: Install CJS module test dependencies
         working-directory: tests/module/cjs
         run: npm install --ignore-scripts
+
       - name: Install packed axios
         working-directory: tests/module/cjs
         run: npm install --no-save ../../../artifacts/axios-*.tgz
+
       - name: Run CJS module tests
         working-directory: tests/module/cjs
         run: npm run test:module:cjs
@@ -168,23 +192,28 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+
       - name: Setup node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node-version }}
-          cache: npm
-          cache-dependency-path: tests/module/esm/package-lock.json
+          registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
+
       - name: Download npm pack artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: axios-tarball
           path: artifacts
+
       - name: Install ESM module test dependencies
         working-directory: tests/module/esm
         run: npm install --ignore-scripts
+
       - name: Install packed axios
         working-directory: tests/module/esm
         run: npm install --no-save ../../../artifacts/axios-*.tgz
+
       - name: Run ESM module tests
         working-directory: tests/module/esm
         run: npm run test:module:esm
@@ -198,13 +227,18 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+
       - name: Setup bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          no-cache: true
+
       - name: Download npm pack artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: axios-tarball
           path: artifacts
+
       - name: Install packed axios
         env:
           TMPDIR: ${{ runner.temp }}
@@ -214,6 +248,7 @@ jobs:
           mv artifacts/axios-*.tgz artifacts/axios.tgz
           cd tests/smoke/bun
           bun add file:../../../artifacts/axios.tgz
+
       - name: Run Bun smoke tests
         working-directory: tests/smoke/bun
         run: bun test
@@ -227,18 +262,25 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+
       - name: Setup deno
         uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
+        with:
+          cache: false
+
       - name: Download npm pack artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: axios-tarball
           path: artifacts
+
       - name: Prepare packed axios dist
         run: mkdir -p dist && tar -xzf artifacts/axios-*.tgz -C artifacts && cp -R artifacts/package/dist/. ./dist
+
       - name: Install Deno smoke test dependencies
         working-directory: tests/smoke/deno
         run: deno install
+
       - name: Run Deno smoke tests
         working-directory: tests/smoke/deno
         run: deno task test
@@ -256,17 +298,22 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24.x
-          cache: npm
+          registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
+
       - name: Install dependencies
         run: npm ci --ignore-scripts
+
       - name: Configure git identity
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
       - name: Bump version with NPM version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -288,12 +335,15 @@ jobs:
           VERSION=$(node -p "require('./package.json').version")
           echo "newTag=$VERSION" >> "$GITHUB_OUTPUT"
           echo "newBranch=release-v1x/version-$VERSION" >> "$GITHUB_OUTPUT"
+
       - name: Run preversion
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npm run preversion
+
       - name: Build project
         run: npm run build
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:

--- a/.github/workflows/run-ci.yml
+++ b/.github/workflows/run-ci.yml
@@ -20,27 +20,38 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+
       - name: Setup node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24.x
-          cache: npm
+          registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
+
       - name: Install dependencies
         run: npm ci --ignore-scripts
+
       - name: Lint
         run: npm run lint
+
       - name: Build project
         run: npm run build
+
       - name: Install Playwright with deps
         run: npx playwright install --with-deps
+
       - name: Run unit tests
         run: npm run test:vitest:unit
+
       - name: Run browser tests
         run: npm run test:vitest:browser:headless
+
       - name: Pack npm tarball
         run: npm pack
+
       - name: Dependency Review
         uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
+
       - name: Upload npm pack artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -62,23 +73,28 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+
       - name: Setup node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node-version }}
-          cache: npm
-          cache-dependency-path: tests/smoke/cjs/package-lock.json
+          registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
+
       - name: Download npm pack artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: axios-tarball
           path: artifacts
+
       - name: Install CJS smoke test dependencies
         working-directory: tests/smoke/cjs
         run: npm install --ignore-scripts
+
       - name: Install packed axios
         working-directory: tests/smoke/cjs
         run: npm install --no-save ../../../artifacts/axios-*.tgz
+
       - name: Run CJS smoke tests
         working-directory: tests/smoke/cjs
         run: npm run test:smoke:cjs:mocha
@@ -96,23 +112,28 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+
       - name: Setup node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node-version }}
-          cache: npm
-          cache-dependency-path: tests/smoke/esm/package-lock.json
+          registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
+
       - name: Download npm pack artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: axios-tarball
           path: artifacts
+
       - name: Install ESM smoke test dependencies
         working-directory: tests/smoke/esm
         run: npm install --ignore-scripts
+
       - name: Install packed axios
         working-directory: tests/smoke/esm
         run: npm install --no-save ../../../artifacts/axios-*.tgz
+
       - name: Run ESM smoke tests
         working-directory: tests/smoke/esm
         run: npm run test:smoke:esm:vitest
@@ -130,23 +151,28 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+
       - name: Setup node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node-version }}
-          cache: npm
-          cache-dependency-path: tests/module/cjs/package-lock.json
+          registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
+
       - name: Download npm pack artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: axios-tarball
           path: artifacts
+
       - name: Install CJS module test dependencies
         working-directory: tests/module/cjs
         run: npm install --ignore-scripts
+
       - name: Install packed axios
         working-directory: tests/module/cjs
         run: npm install --no-save ../../../artifacts/axios-*.tgz
+
       - name: Run CJS module tests
         working-directory: tests/module/cjs
         run: npm run test:module:cjs
@@ -164,23 +190,28 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+
       - name: Setup node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node-version }}
-          cache: npm
-          cache-dependency-path: tests/module/esm/package-lock.json
+          registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
+
       - name: Download npm pack artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: axios-tarball
           path: artifacts
+
       - name: Install ESM module test dependencies
         working-directory: tests/module/esm
         run: npm install --ignore-scripts
+
       - name: Install packed axios
         working-directory: tests/module/esm
         run: npm install --no-save ../../../artifacts/axios-*.tgz
+
       - name: Run ESM module tests
         working-directory: tests/module/esm
         run: npm run test:module:esm
@@ -194,13 +225,18 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+
       - name: Setup bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          no-cache: true
+
       - name: Download npm pack artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: axios-tarball
           path: artifacts
+
       - name: Install packed axios
         env:
           TMPDIR: ${{ runner.temp }}
@@ -210,6 +246,7 @@ jobs:
           mv artifacts/axios-*.tgz artifacts/axios.tgz
           cd tests/smoke/bun
           bun add file:../../../artifacts/axios.tgz
+
       - name: Run Bun smoke tests
         working-directory: tests/smoke/bun
         run: bun test
@@ -223,18 +260,25 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+
       - name: Setup deno
         uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
+        with:
+          cache: false
+
       - name: Download npm pack artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: axios-tarball
           path: artifacts
+
       - name: Prepare packed axios dist
         run: mkdir -p dist && tar -xzf artifacts/axios-*.tgz -C artifacts && cp -R artifacts/package/dist/. ./dist
+
       - name: Install Deno smoke test dependencies
         working-directory: tests/smoke/deno
         run: deno install
+
       - name: Run Deno smoke tests
         working-directory: tests/smoke/deno
         run: deno task test

--- a/.github/workflows/verify-build-reproducibility.yml
+++ b/.github/workflows/verify-build-reproducibility.yml
@@ -32,7 +32,8 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24.x
-          cache: npm
+          registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
 
       - name: Install (pass 1)
         run: npm ci --ignore-scripts


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Disable all package manager caches in GitHub Actions to improve build reproducibility and eliminate flaky CI due to stale caches. Also standardizes the npm registry configuration and disables Bun/Deno caches.

- **Changes**
  - Remove `cache: npm` and `cache-dependency-path` from all `actions/setup-node` steps.
  - Set `registry-url: 'https://registry.npmjs.org'` and `package-manager-cache: false` for all Node jobs.
  - Add `no-cache: true` to `oven-sh/setup-bun` and `cache: false` to `denoland/setup-deno`.
  - Update lockfile-lint to use the npm registry without caching.
  - Minor workflow cleanups: clearer step names and consistent install/build/test order.

- **Notes**
  - Docs: Suggest updating `/docs/ci.md` (or equivalent) to state that CI caching is disabled for reproducibility, and initial installs may be slower.
  - Testing: No code tests changed. CI already runs unit, browser, smoke, and module tests across environments; this validates the change.
  - Semantic version impact: None. CI-only changes; no package release required.

<sup>Written for commit 5e0ceed3cfb5a40e539613232492966e629876d1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

