### PR TITLE
fix: resolveConfig arrow function breaks under webpack + babel transforms

### DIFF
--- a/lib/helpers/resolveConfig.js
+++ b/lib/helpers/resolveConfig.js
@@ -7,7 +7,7 @@ import mergeConfig from "../core/mergeConfig.js";
 import AxiosHeaders from "../core/AxiosHeaders.js";
 import buildURL from "./buildURL.js";
 
-export default (config) => {
+function resolveConfig(config) {
   const newConfig = mergeConfig({}, config);
 
   let { data, withXSRFToken, xsrfHeaderName, xsrfCookieName, headers, auth } = newConfig;
@@ -37,7 +37,7 @@ export default (config) => {
         }
       });
     }
-  }  
+  }
 
   // Add xsrf header
   // This is only done if running in a standard browser environment.
@@ -58,4 +58,6 @@ export default (config) => {
 
   return newConfig;
 }
+
+export default resolveConfig;
 


### PR DESCRIPTION
Ran into this while bundling an app with webpack 5 + babel. The arrow function used as the default export in `resolveConfig.js` causes `__WEBPACK_DEFAULT_EXPORT__` to resolve to `undefined` under certain babel plugin configurations.

Converting it to a named function export resolves the issue without any behavioral changes. Every other helper in `lib/helpers/` already uses named function declarations — `resolveConfig.js` was the only outlier.

Tested with the repro case from #10675.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bundling bug where `resolveConfig`’s default export could become undefined under `webpack` 5 + `babel` transforms by converting the arrow default export into a named function export. No behavior changes; aligns with other helpers.

**Description**
- Summary of changes: Convert arrow default export to a named function (`resolveConfig`) and default-export it; minor whitespace cleanup.
- Reasoning: Certain `babel` plugin setups with `webpack` 5 produced `undefined` for the default export of arrow functions; named function export avoids this and matches existing helper patterns.
- Additional context: Only `lib/helpers/resolveConfig.js` was using an arrow default export; others already use named functions.

**Docs**
- No docs update needed. If we keep bundling notes, add a short tip in `/docs/` troubleshooting about avoiding arrow default exports with some `babel` + `webpack` setups.

**Testing**
- No tests added or modified; behavior is unchanged and existing tests cover config resolution.
- Optional: Add a CI smoke test that bundles a tiny entry importing `resolveConfig` with `webpack` + `babel` to prevent regressions.

**Semantic version impact**
- Patch: bug fix with no public API or behavioral changes.

<sup>Written for commit 2a82150ee023999639a70b7de2372fabc9ca886d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

