### PR TITLE
feat(http): add sensitiveHeaders option to strip custom headers on cross-origin redirects

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -159,9 +159,12 @@ const http2Sessions = new Http2Sessions();
  *
  * @returns {Object<string, any>}
  */
-function dispatchBeforeRedirect(options, responseDetails) {
+function dispatchBeforeRedirect(options, responseDetails, requestDetails) {
   if (options.beforeRedirects.proxy) {
     options.beforeRedirects.proxy(options);
+  }
+  if (options.beforeRedirects.sensitiveHeaders) {
+    options.beforeRedirects.sensitiveHeaders(options, requestDetails);
   }
   if (options.beforeRedirects.config) {
     options.beforeRedirects.config(options, responseDetails);
@@ -646,6 +649,23 @@ export default isHttpAdapterSupported && function httpAdapter(config) {
         }
         if (config.beforeRedirect) {
           options.beforeRedirects.config = config.beforeRedirect;
+        }
+        if (config.sensitiveHeaders?.length) {
+          const sensitiveHeaders = config.sensitiveHeaders.map((h) => h.toLowerCase());
+          options.beforeRedirects.sensitiveHeaders = function (redirectOptions, requestDetails) {
+            if (!requestDetails) return;
+            try {
+              const currentOrigin = new URL(requestDetails.url).origin;
+              const redirectOrigin = new URL(redirectOptions.href).origin;
+              if (currentOrigin !== redirectOrigin) {
+                sensitiveHeaders.forEach((header) => {
+                  delete redirectOptions.headers[header];
+                });
+              }
+            } catch {
+              // ignore malformed URLs
+            }
+          };
         }
         transport = isHttpsRequest ? httpsFollow : httpFollow;
       }


### PR DESCRIPTION
Found this while auditing redirect behavior in a service that uses `X-API-Key` for authentication. Standard headers like `Authorization` are stripped correctly on cross-origin redirects, but any custom auth-style headers survive to the redirect destination.

This adds a `sensitiveHeaders` config option — an array of header names that get stripped when a redirect crosses origins. Passes the current URL down through the existing `beforeRedirects` dispatch so the cross-origin check has context.

```js
axios.get(url, {
  sensitiveHeaders: ['X-API-Key', 'X-AWS-Token']
})
```

Opt-in only, no behavior change for existing code.

Refs #10711.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `sensitiveHeaders` request option to strip chosen headers on cross-origin redirects in `axios`. This is opt-in and does not change existing behavior.

**Description**
- Summary of changes
  - Added `config.sensitiveHeaders` (array of header names, case-insensitive).
  - Hooked into `beforeRedirects` pipeline to remove those headers when origin changes.
  - Updated `dispatchBeforeRedirect` to receive `requestDetails` for origin comparison.
  - Safe-guards for malformed URLs; no-op on same-origin redirects.
- Reasoning
  - Prevents leaking custom auth headers (e.g., `X-API-Key`) to cross-origin targets; only standard headers like `Authorization` were stripped before.
- Additional context
  - Example: `axios.get(url, { sensitiveHeaders: ['X-API-Key', 'X-AWS-Token'] })`.

**Docs**
- Add a new subsection in `/docs/` for `sensitiveHeaders` under request config:
  - What it does and when it applies (only on redirects, only cross-origin).
  - Case-insensitive matching behavior.
  - Short example and interplay with `beforeRedirect`.

**Testing**
- No tests appear to be added in this PR.
- Recommended tests:
  - Cross-origin redirect strips headers listed in `sensitiveHeaders`.
  - Same-origin redirect preserves those headers.
  - Header name matching is case-insensitive.
  - Malformed URLs do not throw and result in no stripping.
  - No behavior change when `sensitiveHeaders` is absent or empty.

**Semantic version impact**
- Minor: additive, opt-in feature with no breaking changes to public APIs.

<sup>Written for commit 34ef0e1c792bd5c0ed262e461d6fef9dd4e1601c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

