### PR TITLE
feat: add Undici adapter (follow-up)

### DIFF
--- a/README.md
+++ b/README.md
@@ -805,7 +805,7 @@ These config options are available for requests. Only `url` is required. Request
   },
   // Also, you can set the name of the built-in adapter, or provide an array with their names
   // to choose the first available in the environment
-  adapter: 'xhr', // 'fetch' | 'http' | ['xhr', 'http', 'fetch']
+  adapter: 'xhr', // 'fetch' | 'http' | 'undici' | ['xhr', 'http', 'fetch']
 
   // `auth` indicates that HTTP Basic auth should be used, and supplies credentials.
   // This will set an `Authorization` header, overwriting any existing

--- a/index.d.cts
+++ b/index.d.cts
@@ -464,7 +464,7 @@ declare namespace axios {
 
   type Milliseconds = number;
 
-  type AxiosAdapterName = 'fetch' | 'xhr' | 'http' | (string & {});
+  type AxiosAdapterName = 'fetch' | 'xhr' | 'http' | 'undici' | (string & {});
 
   type AxiosAdapterConfig = AxiosAdapter | AxiosAdapterName;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -353,7 +353,7 @@ export interface AxiosProgressEvent {
 
 type Milliseconds = number;
 
-type AxiosAdapterName = StringLiteralsOrString<'xhr' | 'http' | 'fetch'>;
+type AxiosAdapterName = StringLiteralsOrString<'xhr' | 'http' | 'fetch' | 'undici'>;
 
 type AxiosAdapterConfig = AxiosAdapter | AxiosAdapterName;
 

--- a/lib/adapters/adapters.js
+++ b/lib/adapters/adapters.js
@@ -2,7 +2,8 @@ import utils from '../utils.js';
 import httpAdapter from './http.js';
 import xhrAdapter from './xhr.js';
 import * as fetchAdapter from './fetch.js';
-import AxiosError from '../core/AxiosError.js';
+import undiciAdapter from './undici.js';
+import AxiosError from "../core/AxiosError.js";
 
 /**
  * Known adapters mapping.
@@ -19,6 +20,7 @@ const knownAdapters = {
   fetch: {
     get: fetchAdapter.getFetch,
   },
+  undici: undiciAdapter
 };
 
 // Assign adapter names for easier debugging and identification

--- a/lib/adapters/fetch.js
+++ b/lib/adapters/fetch.js
@@ -358,6 +358,16 @@ const factory = (env) => {
         ) {
           headers.delete('content-type');
         }
+
+        // Convert existing FormData instance to instance of
+        // environment FormData constructor
+        if (typeof env.FormData !== 'undefined' && data[Symbol.iterator]) {
+          const formData = new env.FormData();
+          for (const entry of data) {
+            formData.append(...entry);
+          }
+          data = formData;
+        }
       }
 
       // Set User-Agent header if not already set (fetch defaults to 'node' in Node.js)

--- a/lib/adapters/undici.js
+++ b/lib/adapters/undici.js
@@ -1,5 +1,4 @@
 import {getFetch} from './fetch.js';
-import { Agent, interceptors } from 'undici';
 import AxiosError from '../core/AxiosError.js';
 import utils from '../utils.js';
 
@@ -27,7 +26,7 @@ const factory = async (config) => {
     env: {
       fetch: async (request, fetchOptions = {}) => {
 
-        const dispatcher = new Agent().compose(interceptors.redirect({
+        const dispatcher = new undici.Agent().compose(undici.interceptors.redirect({
           maxRedirections: typeof config.maxRedirects === 'number' ? config.maxRedirects : 21,
           throwOnMaxRedirect: true
         }));

--- a/lib/adapters/undici.js
+++ b/lib/adapters/undici.js
@@ -2,6 +2,8 @@ import {getFetch} from './fetch.js';
 import AxiosError from '../core/AxiosError.js';
 import utils from '../utils.js';
 
+let undiciAgent;
+
 const factory = async (config) => {
 
   let undici;
@@ -26,18 +28,10 @@ const factory = async (config) => {
     env: {
       fetch: async (request, fetchOptions = {}) => {
 
-        const dispatcher = new undici.Agent().compose(undici.interceptors.redirect({
-          maxRedirections: typeof config.maxRedirects === 'number' ? config.maxRedirects : 21,
-          throwOnMaxRedirect: true
-        }));
-
         if (useFetch) {
           let response;
-          try {
-            response = await undici.fetch(request, {
-              ...fetchOptions,
-              dispatcher
-            });
+          try {;
+            response = await undici.fetch(request, fetchOptions);
           } catch (error) {
             if (error.cause && error.cause.message === 'redirect count exceeded') {
               throw new AxiosError(
@@ -60,15 +54,20 @@ const factory = async (config) => {
           return response;
         }
 
+        if (!undiciAgent) {
+          undiciAgent = new undici.Agent();
+        }
         let response;
-
         try {
           response = await undici.request(request.url, {
             signal: request.signal,
             method: request.method,
             headers: request.headers,
             body: request.body,
-            dispatcher
+            dispatcher: undiciAgent.compose(undici.interceptors.redirect({
+              maxRedirections: typeof config.maxRedirects === 'number' ? config.maxRedirects : 21,
+              throwOnMaxRedirect: true
+            }))
           });
         } catch (error) {
           if (error.message?.includes('ENOTFOUND')) {

--- a/lib/adapters/undici.js
+++ b/lib/adapters/undici.js
@@ -101,7 +101,8 @@ const factory = async (config) => {
         };
       },
       Request: undici.Request,
-      Response: undici.Response
+      Response: undici.Response,
+      FormData: undici.FormData
     }
   });
 

--- a/lib/adapters/undici.js
+++ b/lib/adapters/undici.js
@@ -2,13 +2,18 @@ import {getFetch} from './fetch.js';
 import AxiosError from '../core/AxiosError.js';
 import utils from '../utils.js';
 
+let undici;
+
 const factory = async (config) => {
 
-  let undici;
-  try {
-    undici = await import('undici');
-  } catch (e) {
-    undici = null;
+  if (undici) {
+    await undici;
+  } else {
+    try {
+      undici = await import('undici');
+    } catch (e) {
+      throw new Error('Cannot find Undici module for Axios adapter, did you forget to install it?');
+    }
   }
 
   const responseType = config.responseType ? (config.responseType + '').toLowerCase() : 'text';

--- a/lib/adapters/undici.js
+++ b/lib/adapters/undici.js
@@ -71,6 +71,9 @@ const factory = async (config) => {
             dispatcher
           });
         } catch (error) {
+          if (error.message?.includes('ENOTFOUND')) {
+            throw new TypeError('Load failed', {cause: error});
+          }
           if (error.message === 'max redirects') {
             throw new AxiosError(
               'Maximum number of redirects exceeded',

--- a/lib/adapters/undici.js
+++ b/lib/adapters/undici.js
@@ -20,10 +20,7 @@ const factory = async (config) => {
     responseType === 'stream' ||
     responseType === 'response' ||
     responseType === 'formdata' ||
-    responseType === 'blob' ||
-    utils.isSpecCompliantForm(config.data) ||
-    utils.isBlob(config.data) ||
-    utils.isReadableStream(config.data)
+    responseType === 'blob'
   );
 
   const adapter = getFetch({

--- a/lib/adapters/undici.js
+++ b/lib/adapters/undici.js
@@ -2,8 +2,6 @@ import {getFetch} from './fetch.js';
 import AxiosError from '../core/AxiosError.js';
 import utils from '../utils.js';
 
-let undiciAgent;
-
 const factory = async (config) => {
 
   let undici;
@@ -54,9 +52,6 @@ const factory = async (config) => {
           return response;
         }
 
-        if (!undiciAgent) {
-          undiciAgent = new undici.Agent();
-        }
         let response;
         try {
           response = await undici.request(request.url, {
@@ -64,7 +59,7 @@ const factory = async (config) => {
             method: request.method,
             headers: request.headers,
             body: request.body,
-            dispatcher: undiciAgent.compose(undici.interceptors.redirect({
+            dispatcher: undici.getGlobalDispatcher().compose(undici.interceptors.redirect({
               maxRedirections: typeof config.maxRedirects === 'number' ? config.maxRedirects : 21,
               throwOnMaxRedirect: true
             }))

--- a/lib/adapters/undici.js
+++ b/lib/adapters/undici.js
@@ -1,0 +1,114 @@
+import {getFetch} from './fetch.js';
+import { Agent, interceptors } from 'undici';
+import AxiosError from '../core/AxiosError.js';
+import utils from '../utils.js';
+
+const factory = async (config) => {
+
+  let undici;
+  try {
+    undici = await import('undici');
+  } catch (e) {
+    undici = null;
+  }
+
+  const responseType = config.responseType ? (config.responseType + '').toLowerCase() : 'text';
+  const hasMaxContentLength = utils.isNumber(config.maxContentLength) && config.maxContentLength > -1;
+  const useFetch = (
+    !!config.onDownloadProgress ||
+    hasMaxContentLength ||
+    responseType === 'stream' ||
+    responseType === 'response' ||
+    responseType === 'formdata' ||
+    responseType === 'blob' ||
+    utils.isSpecCompliantForm(config.data) ||
+    utils.isBlob(config.data) ||
+    utils.isReadableStream(config.data)
+  );
+
+  const adapter = getFetch({
+    env: {
+      fetch: async (request, fetchOptions = {}) => {
+
+        const dispatcher = new Agent().compose(interceptors.redirect({
+          maxRedirections: typeof config.maxRedirects === 'number' ? config.maxRedirects : 21,
+          throwOnMaxRedirect: true
+        }));
+
+        if (useFetch) {
+          let response;
+          try {
+            response = await undici.fetch(request, {
+              ...fetchOptions,
+              dispatcher
+            });
+          } catch (error) {
+            if (error.cause && error.cause.message === 'redirect count exceeded') {
+              throw new AxiosError(
+                'Maximum number of redirects exceeded',
+                AxiosError.ERR_FR_TOO_MANY_REDIRECTS
+              )
+            }
+            throw error;
+          }
+          if (responseType === 'formdata') {
+            const originalFormData = response.formData.bind(response);
+            response.formData = async () => {
+              const formData = new FormData();
+              for (const entry of await originalFormData()) {
+                formData.append(...entry);
+              }
+              return formData;
+            };
+          }
+          return response;
+        }
+
+        let response;
+
+        try {
+          response = await undici.request(request.url, {
+            signal: request.signal,
+            method: request.method,
+            headers: request.headers,
+            body: request.body,
+            dispatcher
+          });
+        } catch (error) {
+          if (error.message === 'max redirects') {
+            throw new AxiosError(
+              'Maximum number of redirects exceeded',
+              AxiosError.ERR_FR_TOO_MANY_REDIRECTS
+            )
+          }
+          throw error;
+        }
+
+        const asResponse = () => new undici.Response(response.body, {
+          status: response.statusCode,
+          statusText: response.statusText,
+          headers: response.headers,
+        });
+
+        return {
+          status: response.statusCode,
+          statusText: response.statusText,
+          headers: response.headers,
+          body: response.body,
+          text: () => response.body.text(),
+          json: () => response.body.json(),
+          arrayBuffer: () => response.body.arrayBuffer(),
+          blob: () => asResponse().blob(),
+          formData: () => asResponse().formData()
+        };
+      },
+      Request: undici.Request,
+      Response: undici.Response
+    }
+  });
+
+  return adapter(config);
+
+};
+
+export default factory;

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
         "selfsigned": "^5.5.0",
         "stream-throttle": "^0.1.3",
         "typescript": "^5.9.3",
+        "undici": "^8.3.0",
         "vitest": "^4.1.7"
       }
     },
@@ -9383,6 +9384,16 @@
       "license": "MIT",
       "dependencies": {
         "fastest-levenshtein": "^1.0.7"
+      }
+    },
+    "node_modules/undici": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.3.0.tgz",
+      "integrity": "sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -181,7 +181,16 @@
     "selfsigned": "^5.5.0",
     "stream-throttle": "^0.1.3",
     "typescript": "^5.9.3",
+    "undici": "^8.3.0",
     "vitest": "^4.1.7"
+  },
+  "peerDependencies": {
+    "undici": "^8.0.0"
+  },
+  "peerDependenciesMeta": {
+    "undici": {
+      "optional": true
+    }
   },
   "commitlint": {
     "rules": {

--- a/tests/unit/adapters/undici.test.js
+++ b/tests/unit/adapters/undici.test.js
@@ -1,0 +1,1034 @@
+import { describe, it } from 'vitest';
+import assert from 'assert';
+import {
+  startHTTPServer,
+  stopHTTPServer,
+  setTimeoutAsync,
+  makeReadableStream,
+  generateReadable,
+  makeEchoStream,
+} from '../../setup/server.js';
+import axios from '../../../index.js';
+import stream from 'stream';
+import AxiosError from '../../../lib/core/AxiosError.js';
+import util from 'util';
+import NodeFormData from 'form-data';
+import { VERSION } from '../../../lib/env/data.js';
+
+const SERVER_PORT = 8010;
+const LOCAL_SERVER_URL = `http://localhost:${SERVER_PORT}`;
+
+const pipelineAsync = util.promisify(stream.pipeline);
+
+const undiciAxios = axios.create({
+  baseURL: LOCAL_SERVER_URL,
+  adapter: 'undici',
+});
+
+describe('supports undici with nodejs', () => {
+  it('should sanitize request headers containing CRLF characters', async () => {
+    const server = await startHTTPServer(
+      (req, res) => {
+        res.setHeader('Content-Type', 'application/json');
+        res.end(
+          JSON.stringify({
+            xTest: req.headers['x-test'],
+            injected: req.headers.injected ?? null,
+          })
+        );
+      },
+      {
+        port: SERVER_PORT,
+      }
+    );
+
+    try {
+      const { data } = await undiciAxios.get(`${LOCAL_SERVER_URL}/`, {
+        headers: {
+          'x-test': '\tok\r\nInjected: yes ',
+        },
+      });
+
+      assert.strictEqual(data.xTest, 'okInjected: yes');
+      assert.strictEqual(data.injected, null);
+    } finally {
+      await stopHTTPServer(server);
+    }
+  });
+
+  it('should allow request interceptors to encode Unicode header values before undici sends them', async () => {
+    const server = await startHTTPServer(
+      (req, res) => {
+        res.setHeader('Content-Type', 'application/json');
+        res.end(
+          JSON.stringify({
+            oprtName: req.headers.oprtname,
+          })
+        );
+      },
+      {
+        port: SERVER_PORT,
+      }
+    );
+
+    const instance = axios.create({
+      baseURL: LOCAL_SERVER_URL,
+      adapter: 'undici',
+    });
+
+    instance.interceptors.request.use((config) => {
+      config.headers.oprtName = encodeURIComponent(config.headers.oprtName);
+      return config;
+    });
+
+    try {
+      const { data } = await instance.get('/', {
+        headers: {
+          oprtName: '请求用户',
+        },
+      });
+
+      assert.strictEqual(data.oprtName, encodeURIComponent('请求用户'));
+    } finally {
+      await stopHTTPServer(server);
+    }
+  });
+
+  it('should sanitize unencoded Unicode headers before passing them to undici', async () => {
+    const server = await startHTTPServer(
+      (req, res) => {
+        res.setHeader('Content-Type', 'application/json');
+        res.end(
+          JSON.stringify({
+            xTest: req.headers['x-test'],
+          })
+        );
+      },
+      {
+        port: SERVER_PORT,
+      }
+    );
+
+    try {
+      const { data } = await undiciAxios.get(`${LOCAL_SERVER_URL}/`, {
+        headers: {
+          'x-test': '请求用户',
+        },
+      });
+
+      assert.strictEqual(data.xTest, '');
+    } finally {
+      await stopHTTPServer(server);
+    }
+  });
+
+  describe('responses', () => {
+    it('should support text response type', async () => {
+      const originalData = 'my data';
+
+      const server = await startHTTPServer((req, res) => res.end(originalData), {
+        port: SERVER_PORT,
+      });
+
+      try {
+        const { data } = await undiciAxios.get(`http://localhost:${server.address().port}/`, {
+          responseType: 'text',
+        });
+
+        assert.deepStrictEqual(data, originalData);
+      } finally {
+        await stopHTTPServer(server);
+      }
+    });
+
+    it('should support arraybuffer response type', async () => {
+      const originalData = 'my data';
+
+      const server = await startHTTPServer((req, res) => res.end(originalData), {
+        port: SERVER_PORT,
+      });
+
+      try {
+        const { data } = await undiciAxios.get(`http://localhost:${server.address().port}/`, {
+          responseType: 'arraybuffer',
+        });
+
+        assert.deepStrictEqual(
+          data,
+          Uint8Array.from(await new TextEncoder().encode(originalData)).buffer
+        );
+      } finally {
+        await stopHTTPServer(server);
+      }
+    });
+
+    it('should support blob response type', async () => {
+      const originalData = 'my data';
+
+      const server = await startHTTPServer((req, res) => res.end(originalData), {
+        port: SERVER_PORT,
+      });
+
+      try {
+        const { data } = await undiciAxios.get(`http://localhost:${server.address().port}/`, {
+          responseType: 'blob',
+        });
+
+        assert.deepStrictEqual(data, new Blob([originalData]));
+      } finally {
+        await stopHTTPServer(server);
+      }
+    });
+
+    it('should support stream response type', async () => {
+      const originalData = 'my data';
+
+      const server = await startHTTPServer((req, res) => res.end(originalData), {
+        port: SERVER_PORT,
+      });
+
+      try {
+        const { data } = await undiciAxios.get(`http://localhost:${server.address().port}/`, {
+          responseType: 'stream',
+        });
+
+        assert.ok(data instanceof ReadableStream, 'data is not instanceof ReadableStream');
+
+        const response = new Response(data);
+
+        assert.deepStrictEqual(await response.text(), originalData);
+      } finally {
+        await stopHTTPServer(server);
+      }
+    });
+
+    it('should support formData response type', async () => {
+      const originalData = new FormData();
+
+      originalData.append('x', '123');
+
+      const server = await startHTTPServer(
+        async (req, res) => {
+          const response = await new Response(originalData);
+
+          res.setHeader('Content-Type', response.headers.get('Content-Type'));
+
+          res.end(await response.text());
+        },
+        { port: SERVER_PORT }
+      );
+
+      try {
+        const { data } = await undiciAxios.get(`http://localhost:${server.address().port}/`, {
+          responseType: 'formdata',
+        });
+
+        assert.ok(data instanceof FormData, 'data is not instanceof FormData');
+
+        assert.deepStrictEqual(
+          Object.fromEntries(data.entries()),
+          Object.fromEntries(originalData.entries())
+        );
+      } finally {
+        await stopHTTPServer(server);
+      }
+    }, 5000);
+
+    it('should support json response type', async () => {
+      const originalData = { x: 'my data' };
+
+      const server = await startHTTPServer((req, res) => res.end(JSON.stringify(originalData)), {
+        port: SERVER_PORT,
+      });
+
+      try {
+        const { data } = await undiciAxios.get(`http://localhost:${server.address().port}/`, {
+          responseType: 'json',
+        });
+
+        assert.deepStrictEqual(data, originalData);
+      } finally {
+        await stopHTTPServer(server);
+      }
+    });
+  });
+
+  describe('progress', () => {
+    describe('upload', () => {
+      it('should support upload progress capturing', async () => {
+        const server = await startHTTPServer(
+          {
+            rate: 100 * 1024,
+          },
+          { port: SERVER_PORT }
+        );
+
+        try {
+          let content = '';
+          const count = 10;
+          const chunk = 'test';
+          const chunkLength = Buffer.byteLength(chunk);
+          const contentLength = count * chunkLength;
+
+          const readable = stream.Readable.from(
+            (async function* () {
+              let i = count;
+
+              while (i-- > 0) {
+                await setTimeoutAsync(1100);
+                content += chunk;
+                yield chunk;
+              }
+            })()
+          );
+
+          const samples = [];
+
+          const { data } = await undiciAxios.post(
+            `http://localhost:${server.address().port}/`,
+            readable,
+            {
+              onUploadProgress: ({ loaded, total, progress, bytes, upload }) => {
+                console.log(
+                  `Upload Progress ${loaded} from ${total} bytes (${(progress * 100).toFixed(1)}%)`
+                );
+
+                samples.push({
+                  loaded,
+                  total,
+                  progress,
+                  bytes,
+                  upload,
+                });
+              },
+              headers: {
+                'Content-Length': contentLength,
+              },
+              responseType: 'text',
+            }
+          );
+
+          await setTimeoutAsync(500);
+
+          assert.strictEqual(data, content);
+
+          assert.deepStrictEqual(
+            samples,
+            Array.from(
+              (function* () {
+                for (let i = 1; i <= 10; i++) {
+                  yield {
+                    loaded: chunkLength * i,
+                    total: contentLength,
+                    progress: (chunkLength * i) / contentLength,
+                    bytes: 4,
+                    upload: true,
+                  };
+                }
+              })()
+            )
+          );
+        } finally {
+          await stopHTTPServer(server);
+        }
+      }, 15000);
+
+      it('should not fail with get method', async () => {
+        const server = await startHTTPServer((req, res) => res.end('OK'), { port: SERVER_PORT });
+
+        try {
+          const { data } = await undiciAxios.get(`http://localhost:${server.address().port}/`, {
+            onUploadProgress() {},
+          });
+
+          assert.strictEqual(data, 'OK');
+        } finally {
+          await stopHTTPServer(server);
+        }
+      });
+    });
+
+    describe('download', () => {
+      it('should support download progress capturing', async () => {
+        const server = await startHTTPServer(
+          {
+            rate: 100 * 1024,
+          },
+          {
+            port: SERVER_PORT,
+          }
+        );
+
+        try {
+          let content = '';
+          const count = 10;
+          const chunk = 'test';
+          const chunkLength = Buffer.byteLength(chunk);
+          const contentLength = count * chunkLength;
+
+          const readable = stream.Readable.from(
+            (async function* () {
+              let i = count;
+
+              while (i-- > 0) {
+                await setTimeoutAsync(1100);
+                content += chunk;
+                yield chunk;
+              }
+            })()
+          );
+
+          const samples = [];
+
+          const { data } = await undiciAxios.post(
+            `http://localhost:${server.address().port}/`,
+            readable,
+            {
+              onDownloadProgress: ({ loaded, total, progress, bytes, download }) => {
+                console.log(
+                  `Download Progress ${loaded} from ${total} bytes (${(progress * 100).toFixed(1)}%)`
+                );
+
+                samples.push({
+                  loaded,
+                  total,
+                  progress,
+                  bytes,
+                  download,
+                });
+              },
+              headers: {
+                'Content-Length': contentLength,
+              },
+              responseType: 'text',
+              maxRedirects: 0,
+            }
+          );
+
+          await setTimeoutAsync(500);
+
+          assert.strictEqual(data, content);
+
+          assert.deepStrictEqual(
+            samples,
+            Array.from(
+              (function* () {
+                for (let i = 1; i <= 10; i++) {
+                  yield {
+                    loaded: chunkLength * i,
+                    total: contentLength,
+                    progress: (chunkLength * i) / contentLength,
+                    bytes: 4,
+                    download: true,
+                  };
+                }
+              })()
+            )
+          );
+        } finally {
+          await stopHTTPServer(server);
+        }
+      }, 15000);
+    });
+  });
+
+  it('should support basic auth', async () => {
+    const server = await startHTTPServer((req, res) => res.end(req.headers.authorization), {
+      port: SERVER_PORT,
+    });
+
+    try {
+      const user = 'foo';
+      const headers = { Authorization: 'Bearer 1234' };
+      const res = await undiciAxios.get(`http://${user}@localhost:${server.address().port}/`, {
+        headers,
+      });
+
+      const base64 = Buffer.from(`${user}:`, 'utf8').toString('base64');
+      assert.equal(res.data, `Basic ${base64}`);
+    } finally {
+      await stopHTTPServer(server);
+    }
+  });
+
+  it('should support stream.Readable as a payload', async () => {
+    const server = await startHTTPServer(async (req, res) => res.end('OK'), { port: SERVER_PORT });
+
+    try {
+      const { data } = await undiciAxios.post(
+        `http://localhost:${server.address().port}/`,
+        stream.Readable.from('OK')
+      );
+
+      assert.strictEqual(data, 'OK');
+    } finally {
+      await stopHTTPServer(server);
+    }
+  });
+
+  describe('request aborting', () => {
+    it('should be able to abort the request stream', async () => {
+      const server = await startHTTPServer(
+        {
+          rate: 100000,
+          useBuffering: true,
+        },
+        { port: SERVER_PORT }
+      );
+
+      try {
+        const controller = new AbortController();
+
+        setTimeout(() => {
+          controller.abort();
+        }, 500);
+
+        await assert.rejects(async () => {
+          await undiciAxios.post(
+            `http://localhost:${server.address().port}/`,
+            makeReadableStream(),
+            {
+              responseType: 'stream',
+              signal: controller.signal,
+            }
+          );
+        }, /CanceledError/);
+      } finally {
+        await stopHTTPServer(server);
+      }
+    });
+
+    it('should be able to abort the response stream', async () => {
+      const server = await startHTTPServer(
+        (req, res) => {
+          pipelineAsync(generateReadable(10000, 10), res).catch(() => {
+            // Client-side abort intentionally closes the stream early in this test.
+          });
+        },
+        { port: SERVER_PORT }
+      );
+
+      try {
+        const controller = new AbortController();
+
+        setTimeout(() => {
+          controller.abort(new Error('test'));
+        }, 800);
+
+        const { data } = await undiciAxios.get(`http://localhost:${server.address().port}/`, {
+          responseType: 'stream',
+          signal: controller.signal,
+        });
+
+        await assert.rejects(async () => {
+          await data.pipeTo(makeEchoStream());
+        }, /^(AbortError|CanceledError):/);
+      } finally {
+        await stopHTTPServer(server);
+      }
+    });
+  });
+
+  it('should support a timeout', async () => {
+    const server = await startHTTPServer(
+      async (req, res) => {
+        await setTimeoutAsync(1000);
+        res.end('OK');
+      },
+      { port: 0 }
+    );
+
+    try {
+      const timeout = 500;
+      const ts = Date.now();
+
+      await assert.rejects(async () => {
+        await undiciAxios(`http://localhost:${server.address().port}/`, {
+          timeout,
+        });
+      }, /timeout/);
+
+      const passed = Date.now() - ts;
+
+      assert.ok(passed >= timeout - 5, `early cancellation detected (${passed} ms)`);
+    } finally {
+      await stopHTTPServer(server);
+    }
+  });
+
+  describe('undici adapter - timeout normalization', () => {
+    it('should reject with an AxiosError(ETIMEDOUT) on timeout', async () => {
+      const server = await startHTTPServer(
+        async (req, res) => {
+          await setTimeoutAsync(1000);
+          res.end('OK');
+        },
+        { port: 0 }
+      );
+
+      try {
+        await assert.rejects(
+          () =>
+            undiciAxios(`http://localhost:${server.address().port}/`, {
+              timeout: 200,
+            }),
+          (err) => {
+            assert.strictEqual(err.name, 'AxiosError');
+            assert.strictEqual(err.code, 'ETIMEDOUT');
+            assert.match(err.message, /timeout of 200ms exceeded/);
+            return true;
+          }
+        );
+      } finally {
+        await stopHTTPServer(server);
+      }
+    });
+
+    it('should not classify a user-initiated abort as a timeout', async () => {
+      const safariFetch = (url, init) => {
+        const signal = getFetchSignal(url, init);
+
+        return new Promise((_resolve, reject) => {
+          const onAbort = () => {
+            signal.removeEventListener('abort', onAbort);
+            reject(createBrokenDOMExceptionLikeError());
+          };
+
+          if (signal.aborted) return onAbort();
+          signal.addEventListener('abort', onAbort);
+        });
+      };
+
+      const controller = new AbortController();
+
+      const request = undiciAxios.get('/', {
+        signal: controller.signal,
+        env: { fetch: safariFetch },
+      });
+
+      controller.abort();
+
+      await assert.rejects(
+        () => request,
+        (err) => {
+          assert.strictEqual(err.name, 'CanceledError');
+          assert.strictEqual(err.code, 'ERR_CANCELED');
+          assert.strictEqual(axios.isCancel(err), true);
+          return true;
+        }
+      );
+    });
+  });
+
+  it('should combine baseURL and url', async () => {
+    const server = await startHTTPServer(async (req, res) => res.end('OK'), { port: SERVER_PORT });
+    try {
+      const res = await undiciAxios('/foo');
+
+      assert.equal(res.config.baseURL, LOCAL_SERVER_URL);
+      assert.equal(res.config.url, '/foo');
+    } finally {
+      await stopHTTPServer(server);
+    }
+  });
+
+  it('should send QUERY requests with a body through the undici adapter', async () => {
+    const server = await startHTTPServer(
+      (req, res) => {
+        let body = '';
+        req.on('data', (chunk) => {
+          body += chunk;
+        });
+        req.on('end', () => {
+          res.setHeader('Content-Type', 'application/json');
+          res.end(JSON.stringify({ method: req.method, url: req.url, body }));
+        });
+      },
+      { port: 0 }
+    );
+
+    try {
+      const { data } = await undiciAxios.query(`http://localhost:${server.address().port}/search`, {
+        selector: 'field1',
+      });
+
+      assert.strictEqual(data.method, 'QUERY');
+      assert.strictEqual(data.url, '/search');
+      assert.deepStrictEqual(JSON.parse(data.body), { selector: 'field1' });
+    } finally {
+      await stopHTTPServer(server);
+    }
+  });
+
+  it('should support params', async () => {
+    const server = await startHTTPServer((req, res) => res.end(req.url), { port: SERVER_PORT });
+    try {
+      const { data } = await undiciAxios.get(`http://localhost:${server.address().port}/?test=1`, {
+        params: {
+          foo: 1,
+          bar: 2,
+        },
+      });
+
+      assert.strictEqual(data, '/?test=1&foo=1&bar=2');
+    } finally {
+      await stopHTTPServer(server);
+    }
+  });
+
+  it('should handle failed error from stream response with ENOTFOUND cause', async () => {
+    try {
+      await undiciAxios('http://notExistsUrl.in.nowhere', {
+        responseType: 'stream',
+      });
+      assert.fail('should fail');
+    } catch (err) {
+      assert.strictEqual(err.cause && err.cause.code, 'ENOTFOUND');
+    }
+  });
+
+  it('should handle fetch failed error as an AxiosError with ERR_NETWORK code', async () => {
+    try {
+      await undiciAxios('http://notExistsUrl.in.nowhere');
+      assert.fail('should fail');
+    } catch (err) {
+      assert.strictEqual(err.cause && err.cause.code, 'ENOTFOUND');
+    }
+  });
+
+  it('should get response headers', async () => {
+    const server = await startHTTPServer(
+      (req, res) => {
+        res.setHeader('foo', 'bar');
+        res.end(req.url);
+      },
+      { port: SERVER_PORT }
+    );
+
+    try {
+      const { headers } = await undiciAxios.get(`http://localhost:${server.address().port}/`, {
+        responseType: 'stream',
+      });
+
+      assert.strictEqual(headers.get('foo'), 'bar');
+    } finally {
+      await stopHTTPServer(server);
+    }
+  });
+
+  describe('undici adapter - Content-Type handling', () => {
+    it('should set correct Content-Type for FormData automatically', async () => {
+      const form = new NodeFormData();
+      form.append('foo', 'bar');
+
+      const server = await startHTTPServer(
+        (req, res) => {
+          const contentType = req.headers['content-type'];
+          assert.match(contentType, /^multipart\/form-data; boundary=/i);
+          res.end('OK');
+        },
+        { port: SERVER_PORT }
+      );
+
+      try {
+        await undiciAxios.post(`http://localhost:${server.address().port}/form`, form);
+      } finally {
+        await stopHTTPServer(server);
+      }
+    });
+
+    it('should remove manually set Content-Type without boundary for FormData', async () => {
+      const form = new FormData();
+      form.append('foo', 'bar');
+
+      const server = await startHTTPServer(
+        (req, res) => {
+          const contentType = req.headers['content-type'];
+          assert.match(contentType, /^multipart\/form-data; boundary=/i);
+          res.end('OK');
+        },
+        { port: SERVER_PORT }
+      );
+
+      try {
+        await undiciAxios.post(`http://localhost:${server.address().port}/form`, form, {
+          headers: { 'Content-Type': 'multipart/form-data' },
+        });
+      } finally {
+        await stopHTTPServer(server);
+      }
+    });
+
+    it('should preserve Content-Type if it already has boundary', async () => {
+      const form = new FormData();
+      form.append('foo', 'bar');
+
+      const customBoundary = '----CustomBoundary123';
+
+      const server = await startHTTPServer(
+        (req, res) => {
+          const contentType = req.headers['content-type'];
+          assert.ok(contentType.includes(customBoundary));
+          res.end('OK');
+        },
+        { port: SERVER_PORT }
+      );
+
+      try {
+        await undiciAxios.post(`http://localhost:${server.address().port}/form`, form, {
+          headers: {
+            'Content-Type': `multipart/form-data; boundary=${customBoundary}`,
+          },
+        });
+      } finally {
+        await stopHTTPServer(server);
+      }
+    });
+  });
+
+  describe('undici adapter - User-Agent header', () => {
+    it('should set User-Agent header to axios/<version> by default', async () => {
+      const server = await startHTTPServer(
+        (req, res) => {
+          res.setHeader('Content-Type', 'application/json');
+          res.end(JSON.stringify({ userAgent: req.headers['user-agent'] }));
+        },
+        { port: SERVER_PORT }
+      );
+
+      try {
+        const { data } = await undiciAxios.post(`http://localhost:${server.address().port}/`, {
+          payload: 'test',
+        });
+
+        assert.strictEqual(data.userAgent, `axios/${VERSION}`);
+      } finally {
+        await stopHTTPServer(server);
+      }
+    });
+
+    it('should not override a user-provided User-Agent header', async () => {
+      const customUA = 'my-custom-agent/1.0';
+
+      const server = await startHTTPServer(
+        (req, res) => {
+          res.setHeader('Content-Type', 'application/json');
+          res.end(JSON.stringify({ userAgent: req.headers['user-agent'] }));
+        },
+        { port: SERVER_PORT }
+      );
+
+      try {
+        const { data } = await undiciAxios.post(
+          `http://localhost:${server.address().port}/`,
+          { payload: 'test' },
+          { headers: { 'User-Agent': customUA } }
+        );
+
+        assert.strictEqual(data.userAgent, customUA);
+      } finally {
+        await stopHTTPServer(server);
+      }
+    });
+  });
+
+  describe('size limits', () => {
+    it('should reject an outbound body that exceeds maxBodyLength with ERR_BAD_REQUEST', async () => {
+      const server = await startHTTPServer(
+        (req, res) => {
+          res.end('ok');
+        },
+        { port: SERVER_PORT }
+      );
+
+      try {
+        await assert.rejects(
+          undiciAxios.post(`${LOCAL_SERVER_URL}/`, 'A'.repeat(2048), {
+            maxBodyLength: 1024,
+          }),
+          (err) => {
+            assert.strictEqual(err.code, 'ERR_BAD_REQUEST');
+            assert.match(err.message, /Request body larger than maxBodyLength limit/);
+            return true;
+          }
+        );
+      } finally {
+        await stopHTTPServer(server);
+      }
+    });
+
+    it('should reject a response whose Content-Length exceeds maxContentLength with ERR_BAD_RESPONSE', async () => {
+      const payload = 'A'.repeat(8 * 1024);
+      const server = await startHTTPServer(
+        (req, res) => {
+          res.setHeader('Content-Length', Buffer.byteLength(payload));
+          res.end(payload);
+        },
+        { port: SERVER_PORT }
+      );
+
+      try {
+        await assert.rejects(
+          undiciAxios.get(`${LOCAL_SERVER_URL}/`, {
+            maxContentLength: 1024,
+          }),
+          (err) => {
+            assert.strictEqual(err.code, 'ERR_BAD_RESPONSE');
+            assert.match(err.message, /maxContentLength size of 1024 exceeded/);
+            return true;
+          }
+        );
+      } finally {
+        await stopHTTPServer(server);
+      }
+    });
+
+    it('should reject a chunked response that exceeds maxContentLength during streaming', async () => {
+      const server = await startHTTPServer(
+        (req, res) => {
+          // Omit content-length so the cheap pre-check cannot fire; force
+          // the stream-based enforcement path.
+          res.setHeader('Transfer-Encoding', 'chunked');
+          const chunk = 'B'.repeat(1024);
+          let sent = 0;
+          const writeNext = () => {
+            if (sent >= 8) {
+              return res.end();
+            }
+            sent++;
+            res.write(chunk, writeNext);
+          };
+          writeNext();
+        },
+        { port: SERVER_PORT }
+      );
+
+      try {
+        await assert.rejects(
+          undiciAxios.get(`${LOCAL_SERVER_URL}/`, {
+            maxContentLength: 512,
+          }),
+          (err) => {
+            assert.strictEqual(err.code, 'ERR_BAD_RESPONSE');
+            assert.match(err.message, /maxContentLength size of 512 exceeded/);
+            return true;
+          }
+        );
+      } finally {
+        await stopHTTPServer(server);
+      }
+    });
+
+    it('should reject a data: URL whose decoded size exceeds maxContentLength (base64)', async () => {
+      const payload = 'A'.repeat(4096);
+      const dataUrl =
+        'data:application/octet-stream;base64,' + Buffer.from(payload).toString('base64');
+
+      // Use a dedicated instance without baseURL — combineURLs would otherwise
+      // prepend baseURL to a data: URL and neutralise the pre-check.
+      const bareAxios = axios.create({ adapter: 'undici' });
+
+      await assert.rejects(bareAxios.get(dataUrl, { maxContentLength: 16 }), (err) => {
+        assert.strictEqual(err.code, 'ERR_BAD_RESPONSE');
+        assert.match(err.message, /maxContentLength size of 16 exceeded/);
+        return true;
+      });
+    });
+
+    it('should reject a data: URL whose body size exceeds maxContentLength (non-base64)', async () => {
+      const dataUrl = 'data:text/plain,' + 'X'.repeat(4096);
+
+      const bareAxios = axios.create({ adapter: 'undici' });
+
+      await assert.rejects(bareAxios.get(dataUrl, { maxContentLength: 16 }), (err) => {
+        assert.strictEqual(err.code, 'ERR_BAD_RESPONSE');
+        assert.match(err.message, /maxContentLength size of 16 exceeded/);
+        return true;
+      });
+    });
+
+    it('should allow a response at or below maxContentLength', async () => {
+      const payload = 'ok';
+      const server = await startHTTPServer(
+        (req, res) => {
+          res.end(payload);
+        },
+        { port: SERVER_PORT }
+      );
+
+      try {
+        const { data } = await undiciAxios.get(`${LOCAL_SERVER_URL}/`, {
+          maxContentLength: 1024,
+        });
+        assert.strictEqual(data, payload);
+      } finally {
+        await stopHTTPServer(server);
+      }
+    });
+
+    it('should allow a body at or below maxBodyLength', async () => {
+      const payload = 'hello';
+      let received;
+      const server = await startHTTPServer(
+        (req, res) => {
+          const chunks = [];
+          req.on('data', (c) => chunks.push(c));
+          req.on('end', () => {
+            received = Buffer.concat(chunks).toString();
+            res.end('ok');
+          });
+        },
+        { port: SERVER_PORT }
+      );
+
+      try {
+        await undiciAxios.post(`${LOCAL_SERVER_URL}/`, payload, {
+          maxBodyLength: 1024,
+        });
+        assert.strictEqual(received, payload);
+      } finally {
+        await stopHTTPServer(server);
+      }
+    });
+  });
+
+  it('should support max redirects', async () => {
+    const server = await startHTTPServer(
+      (() => {
+        let i = 1;
+        return (req, res) => {
+          res.setHeader('Location', '/' + i);
+          res.statusCode = 302;
+          res.end();
+          i++;
+        };
+      })(),
+      { port: SERVER_PORT }
+    );
+
+    try {
+      try {
+        await undiciAxios.get(`http://localhost:${server.address().port}/`, {
+          maxRedirects: 3,
+        });
+        assert.fail('should fail with too many redirects');
+      } catch (error) {
+        assert.equal(error.code, AxiosError.ERR_FR_TOO_MANY_REDIRECTS);
+        assert.equal(error.message, 'Maximum number of redirects exceeded');
+      }
+
+      try {
+        await undiciAxios.get(`http://localhost:${server.address().port}/`, {
+          responseType: 'stream',
+          maxRedirects: 3,
+        });
+        assert.fail('should fail with too many redirects');
+      } catch (error) {
+        assert.equal(error.code, AxiosError.ERR_FR_TOO_MANY_REDIRECTS);
+        assert.equal(error.message, 'Maximum number of redirects exceeded');
+      }
+    } finally {
+      await stopHTTPServer(server);
+    }
+  });
+});

--- a/tests/unit/adapters/undici.test.js
+++ b/tests/unit/adapters/undici.test.js
@@ -995,9 +995,9 @@ describe('supports undici with nodejs', () => {
   });
 
   it('should support max redirects', async () => {
+    let i = 1;
     const server = await startHTTPServer(
       (() => {
-        let i = 1;
         return (req, res) => {
           res.setHeader('Location', '/' + i);
           res.statusCode = 302;
@@ -1015,10 +1015,13 @@ describe('supports undici with nodejs', () => {
         });
         assert.fail('should fail with too many redirects');
       } catch (error) {
+        assert.equal(i, 5);
         assert.equal(error.code, AxiosError.ERR_FR_TOO_MANY_REDIRECTS);
         assert.equal(error.message, 'Maximum number of redirects exceeded');
+        i = 1;
       }
 
+      // option is ignored in undici.fetch
       try {
         await undiciAxios.get(`http://localhost:${server.address().port}/`, {
           responseType: 'stream',
@@ -1026,6 +1029,7 @@ describe('supports undici with nodejs', () => {
         });
         assert.fail('should fail with too many redirects');
       } catch (error) {
+        assert.equal(i, 22);
         assert.equal(error.code, AxiosError.ERR_FR_TOO_MANY_REDIRECTS);
         assert.equal(error.message, 'Maximum number of redirects exceeded');
       }

--- a/tests/unit/adapters/undici.test.js
+++ b/tests/unit/adapters/undici.test.js
@@ -683,6 +683,7 @@ describe('supports undici with nodejs', () => {
       });
       assert.fail('should fail');
     } catch (err) {
+      assert.strictEqual(String(err), 'AxiosError: Network Error');
       assert.strictEqual(err.cause && err.cause.code, 'ENOTFOUND');
     }
   });
@@ -692,6 +693,7 @@ describe('supports undici with nodejs', () => {
       await undiciAxios('http://notExistsUrl.in.nowhere');
       assert.fail('should fail');
     } catch (err) {
+      assert.strictEqual(String(err), 'AxiosError: Network Error');
       assert.strictEqual(err.cause && err.cause.code, 'ENOTFOUND');
     }
   });

--- a/tests/unit/adapters/undici.test.js
+++ b/tests/unit/adapters/undici.test.js
@@ -451,6 +451,121 @@ describe('supports undici with nodejs', () => {
     }
   });
 
+  it('should decode basic auth credentials from the request URL', async () => {
+    const server = await startHTTPServer(
+      (req, res) => {
+        res.end(req.headers.authorization);
+      },
+      { port: SERVER_PORT }
+    );
+
+    try {
+      const response = await undiciAxios.get(
+        `http://my%40email.com:pa%24ss@localhost:${server.address().port}/`
+      );
+      const base64 = Buffer.from('my@email.com:pa$ss', 'utf8').toString('base64');
+      assert.strictEqual(response.data, `Basic ${base64}`);
+    } finally {
+      await stopHTTPServer(server);
+    }
+  });
+
+  it('should UTF-8 encode basic auth credentials from the request URL', async () => {
+    const server = await startHTTPServer(
+      (req, res) => {
+        res.end(req.headers.authorization);
+      },
+      { port: SERVER_PORT }
+    );
+
+    try {
+      const response = await undiciAxios.get(
+        `http://%E7%94%A8%E6%88%B7:pa%C3%9F@localhost:${server.address().port}/`
+      );
+      const base64 = Buffer.from('\u7528\u6237:pa\u00df', 'utf8').toString('base64');
+      assert.strictEqual(response.data, `Basic ${base64}`);
+    } finally {
+      await stopHTTPServer(server);
+    }
+  });
+
+  it('keeps malformed URL credentials percent-encoding and does not throw', async () => {
+    const server = await startHTTPServer(
+      (req, res) => {
+        res.end(req.headers.authorization);
+      },
+      { port: SERVER_PORT }
+    );
+
+    try {
+      const response = await undiciAxios.get(`http://user%:foo%zz@localhost:${server.address().port}/`);
+      const base64 = Buffer.from('user%:foo%zz', 'utf8').toString('base64');
+      assert.strictEqual(response.data, `Basic ${base64}`);
+    } finally {
+      await stopHTTPServer(server);
+    }
+  });
+
+  it('should support password-only basic auth credentials from the request URL', async () => {
+    const server = await startHTTPServer(
+      (req, res) => {
+        res.end(req.headers.authorization);
+      },
+      { port: SERVER_PORT }
+    );
+
+    try {
+      const response = await undiciAxios.get(`http://:secret@localhost:${server.address().port}/`);
+      const base64 = Buffer.from(':secret', 'utf8').toString('base64');
+      assert.strictEqual(response.data, `Basic ${base64}`);
+    } finally {
+      await stopHTTPServer(server);
+    }
+  });
+
+  it('should prefer config auth over basic auth credentials from the request URL', async () => {
+    const server = await startHTTPServer(
+      (req, res) => {
+        res.end(req.headers.authorization);
+      },
+      { port: SERVER_PORT }
+    );
+
+    try {
+      const auth = { username: 'config-user', password: 'config-pass' };
+      const response = await undiciAxios.get(
+        `http://url-user:url-pass@localhost:${server.address().port}/`,
+        { auth }
+      );
+      const base64 = Buffer.from('config-user:config-pass', 'utf8').toString('base64');
+      assert.strictEqual(response.data, `Basic ${base64}`);
+    } finally {
+      await stopHTTPServer(server);
+    }
+  });
+
+  it('should support basic auth with a header', async () => {
+    const server = await startHTTPServer(
+      (req, res) => {
+        res.end(req.headers.authorization);
+      },
+      { port: SERVER_PORT }
+    );
+
+    try {
+      const auth = { username: 'foo', password: 'bar' };
+      const headers = { AuThOrIzAtIoN: 'Bearer 1234' }; // wonky casing to ensure caseless comparison
+      const response = await undiciAxios.get(`http://localhost:${server.address().port}/`, {
+        auth,
+        headers,
+      });
+      const base64 = Buffer.from('foo:bar', 'utf8').toString('base64');
+      assert.strictEqual(response.data, `Basic ${base64}`);
+    } finally {
+      await stopHTTPServer(server);
+    }
+  });
+
   it('should support stream.Readable as a payload', async () => {
     const server = await startHTTPServer(async (req, res) => res.end('OK'), { port: SERVER_PORT });
 


### PR DESCRIPTION
## Summary

This PR is a follow-up to https://github.com/axios/axios/pull/6915, with up-to-date changes and minimal implementation using custom Fetch adapter.

Test suite is adapted from original PR and adjusted with latest fetch test suite changes, but there are 3 tests that are currently failing. I’ve marked them with comments so we can easily see and discuss potential changes.

This is the content diff between two test suites: https://www.diffchecker.com/hXpATVrd/

I’ve tried to omit what isn’t necessary for Undici test, but I don’t know if I missed something important.

Things currently not fleshed out:

* [ ] Documentation regarding usage
  * It’s on developers to install Undici as package, so we should probably throw if Undici is not available
* [ ] Which versions of Undici are we supporting
  * I’m voting for latest and anything not compatible throws error
* [ ] Types for request options
  * `undici.fetch` and `undici.request` implementation have different options so maybe we should pick subset of common options (currently `fetchOptions` is used)
* [ ] [Specification compliance](https://github.com/nodejs/undici#specification-compliance) section
  * Specifically part regarding GC and response body consumption
* [ ] Errors
  * `undici.fetch` and `undici.request` have different errors for same requests (fetch needs to follow Fetch specification), so I’ve tried to remove differences by discarding Fetch-specific logic regarding network error
  * Is there anything here that needs to be carefully considered?

## Linked issue

Issue https://github.com/axios/axios/issues/10885 tracks all the necessary changes.

#### Checklist

- [x] Tests added or updated (or N/A with reason)
- [x] Docs / types updated if public API changed (`index.d.ts` and `index.d.cts`)
- [x] No breaking changes (or called out explicitly above)





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Node-only `undici` adapter that preserves Axios behavior for redirects, timeouts, progress, streaming, size limits, and FormData. It lazy-loads `undici`, uses `undici.request` by default, and switches to `undici.fetch` only when needed.

## Description

- Summary of changes
  - Added `lib/adapters/undici.js` and registered it as `'undici'`; updated README and types.
  - Lazy-imports `undici` with a clear resolver error; adds optional peer dep `undici@^8` (Node >= 22.19) and dev dep.
  - Defaults to `undici.request`; uses `undici.fetch` only for progress, `maxContentLength`, or `responseType` `stream`/`response`/`formdata`/`blob`.
  - FormData: converts request `FormData` to environment/`undici.FormData`; bridges `response.formData()` to native `FormData`; also normalizes request `FormData` in the `fetch` adapter.
  - Redirects: enforces `maxRedirects` via Undici’s global dispatcher + redirect interceptor; normalizes to `AxiosError.ERR_FR_TOO_MANY_REDIRECTS` in both code paths.
  - Errors/timeouts: normalizes timeouts to `ETIMEDOUT`; maps `ENOTFOUND` to `AxiosError: Network Error` with `cause`.
  - Limits/headers: enforces `maxBodyLength`/`maxContentLength` (incl. chunked and `data:` URLs); sanitizes headers; sets default `User-Agent` to `axios/<version>` unless provided.
- Reasoning
  - Use `undici` efficiently in Node while preserving Axios semantics.
- Additional context
  - Tracks https://github.com/axios/axios/issues/10885.

## Docs

Add a new `/docs/` page for the `undici` adapter: installation (`npm i undici`), usage (`adapter: 'undici'`), Node-only scope and minimum Node version, lazy import and resolver error, when `request` vs `fetch` is used, redirect/timeout behavior, progress/streaming and size limits, default/overrideable `User-Agent`, and request/response `FormData` handling.

## Testing

Added `tests/unit/adapters/undici.test.js` covering:
- Response types (text/json/arraybuffer/blob/stream/formdata), params, QUERY with body, header sanitization (incl. Unicode).
- FormData: auto `Content-Type`, removing manual header without boundary, preserving custom boundary, and request conversion to env/`undici.FormData`.
- Abort vs timeout behavior (timeouts normalized to `ETIMEDOUT`); cancel classification.
- Size limits for `maxBodyLength`/`maxContentLength` (incl. chunked and `data:` URLs).
- Redirect handling via global dispatcher with consistent `ERR_FR_TOO_MANY_REDIRECTS` across `request` and `fetch`.
- Expanded basic auth cases: URL credentials decoding, UTF‑8 encoding, malformed credentials preserved, password‑only, config auth preferred over URL, and header precedence.

## Semantic version impact

Minor: adds a new adapter and type literal (`'undici'`) without breaking existing APIs.

<sup>Written for commit f60469b5ea4d8c7e9599a8ef109c9cd17db72092. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/axios/axios/pull/10893?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->







