### PR TITLE
fix(core): keep default validateStatus when request passes undefined

### DIFF
--- a/PRE_RELEASE_CHANGELOG.md
+++ b/PRE_RELEASE_CHANGELOG.md
@@ -9,3 +9,8 @@
 ## Bug Fixes
 
 - **Types:** Add the missing readonly `name: 'CanceledError'` declaration to CommonJS `CanceledError` typings to match the ESM declarations. (**#10922**)
+- **Config Merge:** Added `transitional.validateStatusUndefinedResolves` (default `true`) so applications can opt into treating explicit `validateStatus: undefined` like an omitted option by setting it to `false`. `validateStatus: null` still accepts every response status. (**#10899**, closes **#6688**)
+
+## Release Tracking
+
+- ESM/CJS typings are updated for `transitional.validateStatusUndefinedResolves`; README/docs updates are tracked in `PRE_RELEASE_DOCS.md` for release preparation.

--- a/PRE_RELEASE_DOCS.md
+++ b/PRE_RELEASE_DOCS.md
@@ -37,3 +37,23 @@ axios.get('https://api.example.com/users', {
 ```
 
 - **Notes:** Add a security page row linking to the request-config section and add a `sensitiveHeaders` request-config entry marked Node.js only.
+
+### validateStatus undefined transitional option
+
+- **Change:** Document `transitional.validateStatusUndefinedResolves` for the `validateStatus: undefined` merge behavior.
+- **Source:** `PRE_RELEASE_CHANGELOG.md` Bug Fixes, #10899, closes #6688.
+- **Status:** Pending.
+- **Docs targets:** README request config section; `docs/pages/advanced/request-config.md` `validateStatus` section and request config example; translated request-config docs after English docs are finalized.
+- **Required content:** Explain that `validateStatus: undefined` keeps legacy behavior by default and resolves every response status because `transitional.validateStatusUndefinedResolves` defaults to `true`. Explain that setting `transitional.validateStatusUndefinedResolves` to `false` makes explicit `validateStatus: undefined` behave like the option was omitted, so axios uses the configured/default validator and rejects non-2xx responses by default. Mention that `validateStatus: null` still accepts every response status, and users who disable the transitional behavior should use `null` or `() => true` when they intentionally want all statuses to resolve.
+- **Examples:** Include a short opt-in example.
+
+```js
+axios.get('/user/12345', {
+  validateStatus: undefined,
+  transitional: {
+    validateStatusUndefinedResolves: false
+  }
+});
+```
+
+- **Notes:** This is release-prep documentation only; do not update README or docs pages in the feature/fix PR.

--- a/README.md
+++ b/README.md
@@ -891,8 +891,8 @@ These config options are available for requests. Only `url` is required. Request
   redact: ['authorization', 'password'],
 
   // `validateStatus` defines whether to resolve or reject the promise for a given
-  // HTTP response status code. If `validateStatus` returns `true` (or is set to `null`
-  // or `undefined`), Axios resolves the promise; otherwise, Axios rejects it.
+  // HTTP response status code. If `validateStatus` returns `true` (or is set to `null`),
+  // the promise will be resolved; otherwise, the promise will be rejected.
   validateStatus: function (status) {
     return status >= 200 && status < 300; // default
   },

--- a/README.md
+++ b/README.md
@@ -891,8 +891,8 @@ These config options are available for requests. Only `url` is required. Request
   redact: ['authorization', 'password'],
 
   // `validateStatus` defines whether to resolve or reject the promise for a given
-  // HTTP response status code. If `validateStatus` returns `true` (or is set to `null`),
-  // the promise will be resolved; otherwise, the promise will be rejected.
+  // HTTP response status code. If `validateStatus` returns `true` (or is set to `null`
+  // or `undefined`), Axios resolves the promise; otherwise, Axios rejects it.
   validateStatus: function (status) {
     return status >= 200 && status < 300; // default
   },

--- a/index.d.cts
+++ b/index.d.cts
@@ -397,6 +397,7 @@ declare namespace axios {
     clarifyTimeoutError?: boolean;
     legacyInterceptorReqResOrdering?: boolean;
     advertiseZstdAcceptEncoding?: boolean;
+    validateStatusUndefinedResolves?: boolean;
   }
 
   interface GenericAbortSignal {

--- a/index.d.ts
+++ b/index.d.ts
@@ -284,6 +284,7 @@ export interface TransitionalOptions {
   clarifyTimeoutError?: boolean;
   legacyInterceptorReqResOrdering?: boolean;
   advertiseZstdAcceptEncoding?: boolean;
+  validateStatusUndefinedResolves?: boolean;
 }
 
 export interface GenericAbortSignal {

--- a/lib/core/Axios.js
+++ b/lib/core/Axios.js
@@ -102,6 +102,7 @@ class Axios {
           clarifyTimeoutError: validators.transitional(validators.boolean),
           legacyInterceptorReqResOrdering: validators.transitional(validators.boolean),
           advertiseZstdAcceptEncoding: validators.transitional(validators.boolean),
+          validateStatusUndefinedResolves: validators.transitional(validators.boolean),
         },
         false
       );

--- a/lib/core/mergeConfig.js
+++ b/lib/core/mergeConfig.js
@@ -70,7 +70,7 @@ export default function mergeConfig(config1, config2) {
 
   // eslint-disable-next-line consistent-return
   function mergeDirectKeys(a, b, prop) {
-    if (utils.hasOwnProp(config2, prop)) {
+    if (!utils.isUndefined(b)) {
       return getMergedValue(a, b);
     } else if (utils.hasOwnProp(config1, prop)) {
       return getMergedValue(undefined, a);

--- a/lib/core/mergeConfig.js
+++ b/lib/core/mergeConfig.js
@@ -68,9 +68,31 @@ export default function mergeConfig(config1, config2) {
     }
   }
 
+  function getMergedTransitionalOption(prop) {
+    const transitional2 = utils.hasOwnProp(config2, 'transitional') ? config2.transitional : undefined;
+
+    if (!utils.isUndefined(transitional2)) {
+      if (utils.isPlainObject(transitional2)) {
+        if (utils.hasOwnProp(transitional2, prop)) {
+          return transitional2[prop];
+        }
+      } else {
+        return undefined;
+      }
+    }
+
+    const transitional1 = utils.hasOwnProp(config1, 'transitional') ? config1.transitional : undefined;
+
+    if (utils.isPlainObject(transitional1) && utils.hasOwnProp(transitional1, prop)) {
+      return transitional1[prop];
+    }
+
+    return undefined;
+  }
+
   // eslint-disable-next-line consistent-return
   function mergeDirectKeys(a, b, prop) {
-    if (!utils.isUndefined(b)) {
+    if (utils.hasOwnProp(config2, prop)) {
       return getMergedValue(a, b);
     } else if (utils.hasOwnProp(config1, prop)) {
       return getMergedValue(undefined, a);
@@ -119,6 +141,18 @@ export default function mergeConfig(config1, config2) {
     const configValue = merge(a, b, prop);
     (utils.isUndefined(configValue) && merge !== mergeDirectKeys) || (config[prop] = configValue);
   });
+
+  if (
+    utils.hasOwnProp(config2, 'validateStatus') &&
+    utils.isUndefined(config2.validateStatus) &&
+    getMergedTransitionalOption('validateStatusUndefinedResolves') === false
+  ) {
+    if (utils.hasOwnProp(config1, 'validateStatus')) {
+      config.validateStatus = getMergedValue(undefined, config1.validateStatus);
+    } else {
+      delete config.validateStatus;
+    }
+  }
 
   return config;
 }

--- a/lib/defaults/transitional.js
+++ b/lib/defaults/transitional.js
@@ -6,4 +6,5 @@ export default {
   clarifyTimeoutError: false,
   legacyInterceptorReqResOrdering: true,
   advertiseZstdAcceptEncoding: false,
+  validateStatusUndefinedResolves: true,
 };

--- a/tests/browser/requests.browser.test.js
+++ b/tests/browser/requests.browser.test.js
@@ -283,13 +283,20 @@ describe('requests (vitest browser)', () => {
     await expect(promise).resolves.toBeDefined();
   });
 
-  it('should resolve when validateStatus is undefined', async () => {
+  // https://github.com/axios/axios/issues/6688
+  it('should reject when validateStatus is undefined', async () => {
     const { request, promise } = startRequest('/foo', {
       validateStatus: undefined,
     });
 
     request.respondWith({ status: 500 });
-    await expect(promise).resolves.toBeDefined();
+    const reason = await promise.catch((error) => error);
+
+    expect(reason).toBeInstanceOf(Error);
+    expect(reason.message).toBe('Request failed with status code 500');
+    expect(reason.config.method).toBe('get');
+    expect(reason.config.url).toBe('/foo');
+    expect(reason.response.status).toBe(500);
   });
 
   // https://github.com/axios/axios/issues/378

--- a/tests/browser/requests.browser.test.js
+++ b/tests/browser/requests.browser.test.js
@@ -283,10 +283,20 @@ describe('requests (vitest browser)', () => {
     await expect(promise).resolves.toBeDefined();
   });
 
-  // https://github.com/axios/axios/issues/6688
-  it('should reject when validateStatus is undefined', async () => {
+  it('should resolve when validateStatus is undefined by default', async () => {
     const { request, promise } = startRequest('/foo', {
       validateStatus: undefined,
+    });
+
+    request.respondWith({ status: 500 });
+    await expect(promise).resolves.toBeDefined();
+  });
+
+  // https://github.com/axios/axios/issues/6688
+  it('should reject when validateStatus is undefined and the transitional option is disabled', async () => {
+    const { request, promise } = startRequest('/foo', {
+      validateStatus: undefined,
+      transitional: { validateStatusUndefinedResolves: false },
     });
 
     request.respondWith({ status: 500 });

--- a/tests/unit/core/mergeConfig.test.js
+++ b/tests/unit/core/mergeConfig.test.js
@@ -353,5 +353,10 @@ describe('core::mergeConfig', () => {
       expect(mergeConfig({ validateStatus: obj }, {}).validateStatus).toBe(obj);
       expect(mergeConfig({ validateStatus: null }, {}).validateStatus).toBe(null);
     });
+
+    it('keeps config1 value when config2 sets the key to undefined (issue #6688)', () => {
+      expect(mergeConfig(defaults, { validateStatus: undefined }).validateStatus).toBe(defaults.validateStatus);
+      expect(mergeConfig(defaults, { validateStatus: null }).validateStatus).toBe(null);
+    });
   });
 });

--- a/tests/unit/core/mergeConfig.test.js
+++ b/tests/unit/core/mergeConfig.test.js
@@ -354,8 +354,23 @@ describe('core::mergeConfig', () => {
       expect(mergeConfig({ validateStatus: null }, {}).validateStatus).toBe(null);
     });
 
-    it('keeps config1 value when config2 sets the key to undefined (issue #6688)', () => {
-      expect(mergeConfig(defaults, { validateStatus: undefined }).validateStatus).toBe(defaults.validateStatus);
+    it('keeps legacy undefined behavior by default', () => {
+      expect(mergeConfig(defaults, { validateStatus: undefined }).validateStatus).toBeUndefined();
+    });
+
+    it('keeps config1 value when the transitional option is disabled (issue #6688)', () => {
+      const validateStatus = () => false;
+
+      expect(
+        mergeConfig(
+          { validateStatus },
+          {
+            validateStatus: undefined,
+            transitional: { validateStatusUndefinedResolves: false },
+          }
+        ).validateStatus
+      ).toBe(validateStatus);
+
       expect(mergeConfig(defaults, { validateStatus: null }).validateStatus).toBe(null);
     });
   });


### PR DESCRIPTION
## Summary

Passing `validateStatus: undefined` in a request config turned off all status checking, so 4xx and 5xx resolved instead of rejecting, while not passing `validateStatus` kept the default 200-299 check. `mergeConfig` mapped `validateStatus` to `mergeDirectKeys`, which kept an explicit `undefined` from the request because it keyed on property presence, not the value. It now falls back to the default validator when that value is `undefined`. That matches not passing it. `validateStatus: null` still accepts every status, unchanged and documented.

Behavior change: code that passed `validateStatus: undefined` to disable status checking will now reject on 4xx and 5xx responses. Use `validateStatus: null` or `() => true` to keep the old behavior.

## Linked issue

Closes #6688

## Changes

- `lib/core/mergeConfig.js`: fall back to config1 when the request sets a direct key to `undefined`.
- `README.md`: remove the stale note that `undefined` resolves the promise; `null` still means accept every status.
- `tests/unit/core/mergeConfig.test.js`: regression test for explicit `undefined` and the `null` escape hatch.

#### Checklist

- [x] Tests added or updated (or N/A with reason)
- [x] Docs / types updated if public API changed (`index.d.ts` and `index.d.cts`)
- [ ] No breaking changes (or called out explicitly above)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces `transitional.validateStatusUndefinedResolves` to control how `validateStatus: undefined` is handled. Keeps legacy behavior (all statuses resolve) by default, with an opt-in to treat `undefined` like omitted so non-2xx reject. Fixes #6688.

## Description

- Summary of changes
  - Add `transitional.validateStatusUndefinedResolves` (default `true`) in `defaults` and validators.
  - Update `mergeConfig` to fall back to the base/default `validateStatus` only when this flag is `false`.
  - Add typings for the new transitional option in `index.d.ts`/`index.d.cts`.
  - Add pre-release changelog and docs notes.

- Reasoning
  - Previously, `validateStatus: undefined` disabled status checks. This flag lets apps opt in to treat `undefined` like the option was omitted, restoring default 200–299 rejection behavior.

- Additional context
  - `validateStatus: null` still accepts every status.
  - To explicitly accept all statuses when the flag is `false`, use `null` or `() => true`.

## Docs

Please update the `/docs/` request-config pages to document `transitional.validateStatusUndefinedResolves`, with a short example showing both default behavior and the opt-in that makes `validateStatus: undefined` use the default validator.

## Testing

- Browser tests: added a default case that resolves on `undefined`, plus a case that rejects when the transitional flag is set to `false`.
- Unit tests: added merge tests for legacy default vs. opt-in behavior.

## Semantic version impact

Minor: adds a backward-compatible transitional option and typings; default runtime behavior is unchanged.

<sup>Written for commit 6a64cd1a85cd70aa234e1c4d347f52f2843c78e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/axios/axios/pull/10899?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

