### PR TITLE
docs: fix typos and grammar in advanced docs

### DIFF
--- a/docs/pages/advanced/error-handling.md
+++ b/docs/pages/advanced/error-handling.md
@@ -64,7 +64,7 @@ axios.get("/user/12345", {
 });
 ```
 
-Using the `toJSON` method, you can get a object with more information about the error.
+Using the `toJSON` method, you can get an object with more information about the error.
 
 ```js
 axios.get("/user/12345").catch(function (error) {

--- a/docs/pages/advanced/request-config.md
+++ b/docs/pages/advanced/request-config.md
@@ -33,7 +33,7 @@ The `allowAbsoluteUrls` determines whether or not absolute URLs will override a 
 
 ### `transformRequest`
 
-The `transformRequest` function allows you to modify the request data before it is sent to the server. This function is called with the request data as its only argument. This is only applicable for request methods `PUT`, `POST`, `PATCH` and `DELETE`. The last function in the array must return a string or an instance of Buffer, ArrayBuffer FormData or Stream.
+The `transformRequest` function allows you to modify the request data before it is sent to the server. This function is called with the request data as its only argument. This is only applicable for request methods `PUT`, `POST`, `PATCH` and `DELETE`. The last function in the array must return a string or an instance of Buffer, ArrayBuffer, FormData or Stream.
 
 ### `transformResponse`
 

--- a/docs/pages/advanced/x-www-form-urlencoded-format.md
+++ b/docs/pages/advanced/x-www-form-urlencoded-format.md
@@ -2,7 +2,7 @@
 
 ## URLSearchParams
 
-By default, axios serializes JavaScript objects to `JSON`. To send data in the [`application/x-www-form-urlencoded` format](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/POST) instead, you can use the [`URLSearchParams`](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) API, which is [supported](http://www.caniuse.com/#feat=urlsearchparams) in the vast majority of browsers,and [Node](https://nodejs.org/api/url.html#url_class_urlsearchparams) starting with v10 (released in 2018).
+By default, axios serializes JavaScript objects to `JSON`. To send data in the [`application/x-www-form-urlencoded` format](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/POST) instead, you can use the [`URLSearchParams`](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) API, which is [supported](http://www.caniuse.com/#feat=urlsearchparams) in the vast majority of browsers, and [Node](https://nodejs.org/api/url.html#url_class_urlsearchparams) starting with v10 (released in 2018).
 
 ```js
 const params = new URLSearchParams({ foo: 'bar' });


### PR DESCRIPTION
## Summary

Fixes three small typos / grammar issues in the English `docs/pages/advanced/` pages. Pure copy edits — no code or behavior changes.

## Changes

- `docs/pages/advanced/error-handling.md`: "get a object" → "get an object" (article agreement before vowel sound).
- `docs/pages/advanced/request-config.md`: add the missing comma in the `transformRequest` return type list — "Buffer, ArrayBuffer FormData or Stream" → "Buffer, ArrayBuffer, FormData or Stream". The README and the `es` / `zh` / `fr` translations of the same sentence already have the comma, so this aligns the English page with them.
- `docs/pages/advanced/x-www-form-urlencoded-format.md`: add a missing space after a comma — "browsers,and [Node]" → "browsers, and [Node]".

#### Checklist

- [x] Tests added or updated (or N/A with reason) — N/A, docs-only.
- [x] Docs / types updated if public API changed — N/A, no API change.
- [x] No breaking changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three small typos in the advanced docs for clarity and consistency. Docs-only; no code or behavior changes.

- **Docs**
  - error-handling.md: "get a object" → "get an object".
  - request-config.md: add missing comma in `transformRequest` return types ("Buffer, ArrayBuffer, FormData or Stream").
  - x-www-form-urlencoded-format.md: add missing space after a comma ("browsers, and [Node]").
  - Suggest updating the published docs site after merge; pages in `/docs/pages/advanced/` are updated here.

- **Testing and Versioning**
  - Testing: N/A (docs-only).
  - Semantic version impact: Patch (docs-only; no API changes).

<sup>Written for commit 5c3e78871238879bd91ff813a340a924812ef6cc. Summary will update on new commits. <a href="https://cubic.dev/pr/axios/axios/pull/10905?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

