### PR TITLE
chore: implement bundle size action

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -33,7 +33,7 @@ jobs:
         run: npm run build
 
       - name: Compare bundle size
-        uses: axios/bundle-size@c7ccc7972ff98ae98eaac1f2075be8c31248253a # 0.1.0
+        uses: axios/bundle-size@main # 0.1.0
         with:
           path: '.'
           package-name: axios

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -1,0 +1,47 @@
+name: Bundle Size
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  bundle-size:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24.x
+          registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Build project
+        run: npm run build
+
+      - name: Compare bundle size
+        uses: axios/bundle-size@c7ccc7972ff98ae98eaac1f2075be8c31248253a # 0.1.0
+        with:
+          path: '.'
+          package-name: axios
+          files: |
+            dist/axios.js
+            dist/axios.min.js
+            dist/browser/axios.cjs
+            dist/node/axios.cjs
+          output-file: bundle-size-comparison.json
+          comment-pr: true
+          github-token: ${{ github.token }}

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -33,7 +33,7 @@ jobs:
         run: npm run build
 
       - name: Compare bundle size
-        uses: axios/bundle-size@main # 0.1.0
+        uses: axios/bundle-size@c7ccc7972ff98ae98eaac1f2075be8c31248253a # 0.1.0
         with:
           path: '.'
           package-name: axios

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -33,7 +33,7 @@ jobs:
         run: npm run build
 
       - name: Compare bundle size
-        uses: axios/bundle-size@c7ccc7972ff98ae98eaac1f2075be8c31248253a # 0.1.0
+        uses: axios/bundle-size@f15fb81ae6e3de06418f59498989e5aeeca9785d # 0.1.1
         with:
           path: '.'
           package-name: axios
@@ -45,3 +45,4 @@ jobs:
           output-file: bundle-size-comparison.json
           comment-pr: true
           github-token: ${{ github.token }}
+          release-stream: '1'


### PR DESCRIPTION
## Summary

Adds a Bundle Size GitHub Actions workflow that runs on PR open, synchronize, and reopen events, then comments bundle size comparisons for the v1 release stream.

## Linked issue

N/A

## Changes

- Add `.github/workflows/bundle-size.yml` with read-only contents permission and PR comment permission.
- Build axios with Node 24 using `npm ci --ignore-scripts` and `npm run build`.
- Run pinned `axios/bundle-size` against key `dist/` artifacts and publish the comparison as a PR comment.

#### Checklist

- [x] Tests added or updated (or N/A with reason: CI-only workflow change)
- [x] Docs / types updated if public API changed (`index.d.ts` and `index.d.cts`) (N/A: no public API change)
- [x] No breaking changes (or called out explicitly above)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a GitHub Action that builds `axios` and comments bundle size deltas on PRs for the v1 stream to catch regressions early. Runs on PR open, sync, and reopen, and compares key `dist/` bundles.

**Description**
- Adds `.github/workflows/bundle-size.yml` with `contents: read` and `pull-requests: write`.
- Builds on Node 24 using `npm ci --ignore-scripts` and `npm run build`.
- Compares `dist/axios.js`, `dist/axios.min.js`, `dist/browser/axios.cjs`, `dist/node/axios.cjs` via pinned `axios/bundle-size` and posts a PR comment; also writes `bundle-size-comparison.json`.
- Testing: CI-only; no source or tests changed. No additional tests needed.
- Docs: Suggest adding a short `/docs/` note explaining the bundle size workflow and where PR comments appear.

**Semantic version impact**
- Patch (CI-only; no runtime or API changes).

<sup>Written for commit 148e387d36f87488e9e75bcbbb5ff49399f22f91. Summary will update on new commits. <a href="https://cubic.dev/pr/axios/axios/pull/10906?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

