### PR TITLE
chore: implement bundle size action

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -33,7 +33,7 @@ jobs:
         run: npm run build
 
       - name: Compare bundle size
-        uses: axios/bundle-size@c7ccc7972ff98ae98eaac1f2075be8c31248253a # 0.1.0
+        uses: axios/bundle-size@main # 0.1.0
         with:
           path: '.'
           package-name: axios

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -1,0 +1,47 @@
+name: Bundle Size
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  bundle-size:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24.x
+          registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Build project
+        run: npm run build
+
+      - name: Compare bundle size
+        uses: axios/bundle-size@c7ccc7972ff98ae98eaac1f2075be8c31248253a # 0.1.0
+        with:
+          path: '.'
+          package-name: axios
+          files: |
+            dist/axios.js
+            dist/axios.min.js
+            dist/browser/axios.cjs
+            dist/node/axios.cjs
+          output-file: bundle-size-comparison.json
+          comment-pr: true
+          github-token: ${{ github.token }}

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -33,7 +33,7 @@ jobs:
         run: npm run build
 
       - name: Compare bundle size
-        uses: axios/bundle-size@main # 0.1.0
+        uses: axios/bundle-size@c7ccc7972ff98ae98eaac1f2075be8c31248253a # 0.1.0
         with:
           path: '.'
           package-name: axios

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -43,6 +43,6 @@ jobs:
             dist/browser/axios.cjs
             dist/node/axios.cjs
           output-file: bundle-size-comparison.json
-          comment-pr: true
+          comment-pr: ${{ github.event.pull_request.head.repo.fork == false }}
           github-token: ${{ github.token }}
           release-stream: '1'

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -33,7 +33,7 @@ jobs:
         run: npm run build
 
       - name: Compare bundle size
-        uses: axios/bundle-size@c7ccc7972ff98ae98eaac1f2075be8c31248253a # 0.1.0
+        uses: axios/bundle-size@f15fb81ae6e3de06418f59498989e5aeeca9785d # 0.1.1
         with:
           path: '.'
           package-name: axios
@@ -45,3 +45,4 @@ jobs:
           output-file: bundle-size-comparison.json
           comment-pr: true
           github-token: ${{ github.token }}
+          release-stream: '1'


### PR DESCRIPTION
## Summary

Adds a Bundle Size GitHub Actions workflow that runs on PR open, synchronise, and reopen events, then comments bundle size comparisons for the v1 release stream.

## Linked issue

N/A

## Changes

- Add `.github/workflows/bundle-size.yml` with read-only contents permission and PR comment permission.
- Build axios with Node 24 using `npm ci --ignore-scripts` and `npm run build`.
- Run pinned `axios/bundle-size` against key `dist/` artefacts and publish the comparison as a PR comment.

#### Checklist

- [x] Tests added or updated (or N/A with reason: CI-only workflow change)
- [x] Docs/types updated if public API changed (`index.d.ts` and `index.d.cts`) (N/A: no public API change)
- [x] No breaking changes (or called out explicitly above)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a GitHub Action that builds `axios` and reports bundle size changes on v1 PRs to catch regressions early. Comments only on non-fork PRs and writes a JSON report.

## Description

- Add `.github/workflows/bundle-size.yml` with `contents: read` and `pull-requests: write`; runs on PR open/sync/reopen for the v1 stream.
- Build on Node 24 using `npm ci --ignore-scripts` and `npm run build`.
- Compare via `axios/bundle-size@f15fb81ae6e3de06418f59498989e5aeeca9785d` (`release-stream: '1'`) for: `dist/axios.js`, `dist/axios.min.js`, `dist/browser/axios.cjs`, `dist/node/axios.cjs`.
- Output `bundle-size-comparison.json` and comment only when the PR is from this repo (not forks).

## Docs

- Add a short `/docs/` note about the “Bundle Size” workflow: when it runs, which files are compared, v1 stream scope, and that comments appear only on non-fork PRs.

## Testing

- CI-only change; no source or tests modified. No additional tests needed.

## Semantic version impact

- Patch (CI-only; no runtime or API changes).

<sup>Written for commit c3b5ed6d025c9818d978e78b12ae5577f405b68b. Summary will update on new commits. <a href="https://cubic.dev/pr/axios/axios/pull/10907?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



