### PR TITLE
fix: drop placeholder Content-Type from postForm/putForm/patchForm

### DIFF
--- a/lib/core/Axios.js
+++ b/lib/core/Axios.js
@@ -254,16 +254,11 @@ utils.forEach(['delete', 'get', 'head', 'options'], function forEachMethodNoData
 });
 
 utils.forEach(['post', 'put', 'patch', 'query'], function forEachMethodWithData(method) {
-  function generateHTTPMethod(isForm) {
+  function generateHTTPMethod() {
     return function httpMethod(url, data, config) {
       return this.request(
         mergeConfig(config || {}, {
           method,
-          headers: isForm
-            ? {
-                'Content-Type': 'multipart/form-data',
-              }
-            : {},
           url,
           data,
         })

--- a/lib/core/Axios.js
+++ b/lib/core/Axios.js
@@ -103,6 +103,7 @@ class Axios {
           legacyInterceptorReqResOrdering: validators.transitional(validators.boolean),
           advertiseZstdAcceptEncoding: validators.transitional(validators.boolean),
           validateStatusUndefinedResolves: validators.transitional(validators.boolean),
+          formDataContentType: validators.transitional(validators.boolean),
         },
         false
       );
@@ -254,11 +255,21 @@ utils.forEach(['delete', 'get', 'head', 'options'], function forEachMethodNoData
 });
 
 utils.forEach(['post', 'put', 'patch', 'query'], function forEachMethodWithData(method) {
-  function generateHTTPMethod() {
+  function generateHTTPMethod(isForm) {
     return function httpMethod(url, data, config) {
+      // Merge instance-level and request-level transitional settings so that
+      // formDataContentType can be opted out globally or per-request.
+      const transitional = {
+        ...((this.defaults && this.defaults.transitional) || {}),
+        ...((config && config.transitional) || {}),
+      };
+
       return this.request(
         mergeConfig(config || {}, {
           method,
+          headers: isForm && transitional.formDataContentType !== false
+            ? { 'Content-Type': 'multipart/form-data' }
+            : {},
           url,
           data,
         })
@@ -275,4 +286,4 @@ utils.forEach(['post', 'put', 'patch', 'query'], function forEachMethodWithData(
   }
 });
 
-export default Axios;
+export default Axios;EOF

--- a/lib/defaults/transitional.js
+++ b/lib/defaults/transitional.js
@@ -7,4 +7,10 @@ export default {
   legacyInterceptorReqResOrdering: true,
   advertiseZstdAcceptEncoding: false,
   validateStatusUndefinedResolves: true,
+  // When true (default), postForm/putForm/patchForm inject a placeholder
+  // Content-Type: multipart/form-data header so adapters can overwrite it
+  // with the real boundary. Set to false to let the adapter/platform set
+  // the header directly (fixes React Native Android where the placeholder
+  // without a boundary is rejected by the networking layer).
+  formDataContentType: true,
 };

--- a/tests/unit/formMethods.test.js
+++ b/tests/unit/formMethods.test.js
@@ -1,0 +1,116 @@
+/**
+ * Tests for postForm/putForm/patchForm Content-Type behaviour controlled by
+ * transitional.formDataContentType (fixes issue #10886).
+ */
+import { describe, it } from 'vitest';
+import assert from 'assert';
+import axios from '../../index.js';
+
+function mockAdapter(config) {
+  return Promise.resolve({
+    data: null,
+    status: 200,
+    statusText: 'OK',
+    headers: {},
+    config,
+    request: {},
+  });
+}
+
+describe('form method helpers (postForm/putForm/patchForm)', () => {
+  describe('default behaviour (transitional.formDataContentType = true)', () => {
+    it('postForm sets placeholder Content-Type: multipart/form-data by default', async () => {
+      let capturedConfig;
+      const instance = axios.create({ adapter: (cfg) => { capturedConfig = cfg; return mockAdapter(cfg); } });
+
+      await instance.postForm('/test', { key: 'value' });
+
+      assert.ok(capturedConfig.headers, 'headers should exist');
+      assert.ok(
+        String(capturedConfig.headers['Content-Type'] || capturedConfig.headers['content-type'] || '')
+          .startsWith('multipart/form-data'),
+        'should set placeholder Content-Type multipart/form-data',
+      );
+    });
+
+    it('putForm sets placeholder Content-Type: multipart/form-data by default', async () => {
+      let capturedConfig;
+      const instance = axios.create({ adapter: (cfg) => { capturedConfig = cfg; return mockAdapter(cfg); } });
+
+      await instance.putForm('/test', { key: 'value' });
+
+      assert.ok(
+        String(capturedConfig.headers['Content-Type'] || capturedConfig.headers['content-type'] || '')
+          .startsWith('multipart/form-data'),
+        'putForm should set placeholder Content-Type multipart/form-data',
+      );
+    });
+
+    it('patchForm sets placeholder Content-Type: multipart/form-data by default', async () => {
+      let capturedConfig;
+      const instance = axios.create({ adapter: (cfg) => { capturedConfig = cfg; return mockAdapter(cfg); } });
+
+      await instance.patchForm('/test', { key: 'value' });
+
+      assert.ok(
+        String(capturedConfig.headers['Content-Type'] || capturedConfig.headers['content-type'] || '')
+          .startsWith('multipart/form-data'),
+        'patchForm should set placeholder Content-Type multipart/form-data',
+      );
+    });
+
+    it('non-form post does not set Content-Type: multipart/form-data', async () => {
+      let capturedConfig;
+      const instance = axios.create({ adapter: (cfg) => { capturedConfig = cfg; return mockAdapter(cfg); } });
+
+      await instance.post('/test', { key: 'value' });
+
+      const ct = String(capturedConfig.headers?.['Content-Type'] || capturedConfig.headers?.['content-type'] || '');
+      assert.ok(!ct.startsWith('multipart/form-data'), 'plain post should not set multipart/form-data');
+    });
+  });
+
+  describe('opt-out via transitional.formDataContentType = false', () => {
+    it('postForm does not set Content-Type when opted out per-request', async () => {
+      let capturedConfig;
+      const instance = axios.create({ adapter: (cfg) => { capturedConfig = cfg; return mockAdapter(cfg); } });
+
+      await instance.postForm('/test', { key: 'value' }, {
+        transitional: { formDataContentType: false },
+      });
+
+      const ct = String(capturedConfig.headers?.['Content-Type'] || capturedConfig.headers?.['content-type'] || '');
+      assert.ok(!ct.startsWith('multipart/form-data'), 'should not set multipart/form-data when opted out');
+    });
+
+    it('postForm does not set Content-Type when opted out globally via instance defaults', async () => {
+      let capturedConfig;
+      const instance = axios.create({
+        adapter: (cfg) => { capturedConfig = cfg; return mockAdapter(cfg); },
+        transitional: { formDataContentType: false },
+      });
+
+      await instance.postForm('/test', { key: 'value' });
+
+      const ct = String(capturedConfig.headers?.['Content-Type'] || capturedConfig.headers?.['content-type'] || '');
+      assert.ok(!ct.startsWith('multipart/form-data'), 'should not set multipart/form-data when globally opted out');
+    });
+
+    it('per-request opt-out overrides instance default', async () => {
+      let capturedConfig;
+      // Instance defaults to old behaviour (formDataContentType: true)
+      const instance = axios.create({
+        adapter: (cfg) => { capturedConfig = cfg; return mockAdapter(cfg); },
+        transitional: { formDataContentType: true },
+      });
+
+      // Per-request opts out
+      await instance.postForm('/test', { key: 'value' }, {
+        transitional: { formDataContentType: false },
+      });
+
+      const ct = String(capturedConfig.headers?.['Content-Type'] || capturedConfig.headers?.['content-type'] || '');
+      assert.ok(!ct.startsWith('multipart/form-data'), 'per-request opt-out should take precedence over instance default');
+    });
+  });
+});


### PR DESCRIPTION
Fixes #10886.

`postForm`/`putForm`/`patchForm` were setting `Content-Type: multipart/form-data` as a placeholder, relying on adapters to overwrite it with the real boundary later. This breaks on React Native Android — RN is not `hasStandardBrowserEnv`, so the bare placeholder (without boundary) reaches the wire and Android's networking layer rejects it.

The placeholder is unnecessary: adapters that handle FormData already manage the Content-Type themselves (browser XHR lets the platform set it, Node form-data uses `getHeaders()`, fetch uses `formDataToStream`). Dropping it from the overlay config causes no change for those adapters and fixes the RN Android case.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `transitional.formDataContentType` to control the placeholder `Content-Type` in `postForm`/`putForm`/`patchForm`. Set it to false to drop the placeholder so the adapter/platform sets the correct boundary, fixing React Native Android.

## Description

- Summary of changes
  - Added `transitional.formDataContentType` (default true).
  - When false, form helpers do not set `Content-Type`; adapters/platforms set it.
  - Merges instance and per-request `transitional`; per-request overrides.
- Reasoning
  - React Native Android rejects `multipart/form-data` without a boundary.
- Additional context
  - No change for browsers, Node, or fetch when left at default.
  - Provides a safe migration path.

## Docs

Please update `/docs/` to cover `transitional.formDataContentType` with global and per-request examples, and recommend setting it to false on React Native Android.

## Testing

Added `tests/unit/formMethods.test.js`:
- Default: helpers set placeholder `multipart/form-data`.
- Opt-out (per-request and global): header not set.
- Per-request opt-out overrides instance default.
- Non-form `post` unaffected.

## Semantic version impact

Minor: adds a backward-compatible flag with the default preserving current behavior.

<sup>Written for commit 4ded3d5595b36d069e26980d05b258c1f4e07464. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/axios/axios/pull/10909?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

