### PR TITLE
fix(fetch): honor timeoutErrorMessage and transitional.clarifyTimeout…

### DIFF
--- a/lib/adapters/fetch.js
+++ b/lib/adapters/fetch.js
@@ -181,7 +181,8 @@ const factory = (env) => {
 
     let composedSignal = composeSignals(
       [signal, cancelToken && cancelToken.toAbortSignal()],
-      timeout
+      timeout,
+      { timeoutErrorMessage: config.timeoutErrorMessage, transitional: config.transitional }
     );
 
     let request = null;

--- a/lib/helpers/composeSignals.js
+++ b/lib/helpers/composeSignals.js
@@ -2,7 +2,9 @@ import CanceledError from '../cancel/CanceledError.js';
 import AxiosError from '../core/AxiosError.js';
 import utils from '../utils.js';
 
-const composeSignals = (signals, timeout) => {
+const composeSignals = (signals, timeout, options) => {
+  const { timeoutErrorMessage, transitional } = options || {};
+
   signals = signals ? signals.filter(Boolean) : [];
 
   if (!timeout && !signals.length) {
@@ -30,7 +32,18 @@ const composeSignals = (signals, timeout) => {
     timeout &&
     setTimeout(() => {
       timer = null;
-      onabort(new AxiosError(`timeout of ${timeout}ms exceeded`, AxiosError.ETIMEDOUT));
+      // Mirror the xhr/http adapters so identical config produces identical
+      // timeout errors across every adapter: ECONNABORTED by default,
+      // ETIMEDOUT only when transitional.clarifyTimeoutError is set, and
+      // timeoutErrorMessage overrides the default text.
+      onabort(
+        new AxiosError(
+          timeoutErrorMessage || `timeout of ${timeout}ms exceeded`,
+          transitional && transitional.clarifyTimeoutError
+            ? AxiosError.ETIMEDOUT
+            : AxiosError.ECONNABORTED
+        )
+      );
     }, timeout);
 
   const unsubscribe = () => {

--- a/tests/smoke/bun/tests/timeout.smoke.test.ts
+++ b/tests/smoke/bun/tests/timeout.smoke.test.ts
@@ -14,33 +14,53 @@ const createAbortedError = () => {
   return error;
 };
 
-describe('timeout', () => {
-  test('timeout: 50 with never-resolving fetch mock rejects with ETIMEDOUT', async () => {
-    const fetch = (input: unknown, init?: RequestInit) =>
-      new Promise<Response>((_resolve, reject) => {
-        const signal = init?.signal || (input instanceof Request ? input.signal : undefined);
+// A fetch mock that never resolves and only rejects when the request is
+// aborted, so the only thing that ends the request is axios' own timeout.
+const neverResolvingFetch =
+  () =>
+  (input: unknown, init?: RequestInit) =>
+    new Promise<Response>((_resolve, reject) => {
+      const signal = init?.signal || (input instanceof Request ? input.signal : undefined);
 
-        if (signal) {
-          if (signal.aborted) {
-            reject(createAbortedError());
-            return;
-          }
-
-          signal.addEventListener(
-            'abort',
-            () => {
-              reject(createAbortedError());
-            },
-            { once: true }
-          );
+      if (signal) {
+        if (signal.aborted) {
+          reject(createAbortedError());
+          return;
         }
-      });
 
+        signal.addEventListener(
+          'abort',
+          () => {
+            reject(createAbortedError());
+          },
+          { once: true }
+        );
+      }
+    });
+
+describe('timeout', () => {
+  test('timeout via fetch adapter rejects with ECONNABORTED by default', async () => {
     const err = await axios
       .get('https://example.com/timeout', {
         adapter: 'fetch',
         timeout: 50,
-        env: env(fetch),
+        env: env(neverResolvingFetch()),
+      })
+      .catch((e: any) => e);
+
+    expect(axios.isAxiosError(err)).toBe(true);
+    // Parity with the xhr/http adapters (issue #10888): the default timeout
+    // code is ECONNABORTED, not ETIMEDOUT.
+    expect(err.code).toBe('ECONNABORTED');
+  });
+
+  test('timeout via fetch adapter rejects with ETIMEDOUT when clarifyTimeoutError is set', async () => {
+    const err = await axios
+      .get('https://example.com/timeout', {
+        adapter: 'fetch',
+        timeout: 50,
+        transitional: { clarifyTimeoutError: true },
+        env: env(neverResolvingFetch()),
       })
       .catch((e: any) => e);
 

--- a/tests/unit/adapters/fetch.test.js
+++ b/tests/unit/adapters/fetch.test.js
@@ -583,7 +583,7 @@ describe.runIf(typeof fetch === 'function')('supports fetch with nodejs', () => 
   });
 
   describe('fetch adapter - timeout normalization', () => {
-    it('should reject with an AxiosError(ETIMEDOUT) on timeout', async () => {
+    it('should reject with an AxiosError(ECONNABORTED) on timeout by default', async () => {
       const server = await startHTTPServer(
         async (req, res) => {
           await setTimeoutAsync(1000);
@@ -597,6 +597,64 @@ describe.runIf(typeof fetch === 'function')('supports fetch with nodejs', () => 
           () =>
             fetchAxios(`http://localhost:${server.address().port}/`, {
               timeout: 200,
+            }),
+          (err) => {
+            assert.strictEqual(err.name, 'AxiosError');
+            // Parity with the xhr/http adapters: default timeout code is
+            // ECONNABORTED, not ETIMEDOUT (see issue #10888).
+            assert.strictEqual(err.code, 'ECONNABORTED');
+            assert.match(err.message, /timeout of 200ms exceeded/);
+            return true;
+          }
+        );
+      } finally {
+        await stopHTTPServer(server);
+      }
+    });
+
+    it('should honor a custom timeoutErrorMessage on timeout', async () => {
+      const server = await startHTTPServer(
+        async (req, res) => {
+          await setTimeoutAsync(1000);
+          res.end('OK');
+        },
+        { port: 0 }
+      );
+
+      try {
+        await assert.rejects(
+          () =>
+            fetchAxios(`http://localhost:${server.address().port}/`, {
+              timeout: 200,
+              timeoutErrorMessage: 'custom timeout',
+            }),
+          (err) => {
+            assert.strictEqual(err.name, 'AxiosError');
+            assert.strictEqual(err.code, 'ECONNABORTED');
+            assert.strictEqual(err.message, 'custom timeout');
+            return true;
+          }
+        );
+      } finally {
+        await stopHTTPServer(server);
+      }
+    });
+
+    it('should reject with ETIMEDOUT when transitional.clarifyTimeoutError is set', async () => {
+      const server = await startHTTPServer(
+        async (req, res) => {
+          await setTimeoutAsync(1000);
+          res.end('OK');
+        },
+        { port: 0 }
+      );
+
+      try {
+        await assert.rejects(
+          () =>
+            fetchAxios(`http://localhost:${server.address().port}/`, {
+              timeout: 200,
+              transitional: { clarifyTimeoutError: true },
             }),
           (err) => {
             assert.strictEqual(err.name, 'AxiosError');
@@ -670,6 +728,9 @@ describe.runIf(typeof fetch === 'function')('supports fetch with nodejs', () => 
           () =>
             fetchAxios.get('/', {
               timeout: 50,
+              // clarifyTimeoutError keeps this regression asserting ETIMEDOUT;
+              // the default code is now ECONNABORTED (parity, issue #10888).
+              transitional: { clarifyTimeoutError: true },
               env: { fetch: safariFetch },
             }),
           (err) => {

--- a/tests/unit/composeSignals.test.js
+++ b/tests/unit/composeSignals.test.js
@@ -32,6 +32,41 @@ describe('helpers::composeSignals', () => {
     assert.match(String(signal.reason), /timeout of 100ms exceeded/);
   });
 
+  runIfAbortController(
+    'should default the timeout error code to ECONNABORTED (parity with xhr/http)',
+    async () => {
+      const signal = composeSignals([], 20);
+
+      await new Promise((resolve) => signal.addEventListener('abort', resolve));
+
+      assert.strictEqual(signal.reason.name, 'AxiosError');
+      assert.strictEqual(signal.reason.code, 'ECONNABORTED');
+      assert.match(signal.reason.message, /timeout of 20ms exceeded/);
+    }
+  );
+
+  runIfAbortController('should honor a custom timeoutErrorMessage', async () => {
+    const signal = composeSignals([], 20, { timeoutErrorMessage: 'custom timeout' });
+
+    await new Promise((resolve) => signal.addEventListener('abort', resolve));
+
+    assert.strictEqual(signal.reason.code, 'ECONNABORTED');
+    assert.strictEqual(signal.reason.message, 'custom timeout');
+  });
+
+  runIfAbortController(
+    'should use ETIMEDOUT when transitional.clarifyTimeoutError is set',
+    async () => {
+      const signal = composeSignals([], 20, {
+        transitional: { clarifyTimeoutError: true },
+      });
+
+      await new Promise((resolve) => signal.addEventListener('abort', resolve));
+
+      assert.strictEqual(signal.reason.code, 'ETIMEDOUT');
+    }
+  );
+
   it('should return undefined if signals and timeout are not provided', () => {
     const signal = composeSignals([]);
 


### PR DESCRIPTION
## Summary

The Fetch adapter ignored `timeoutErrorMessage` and `transitional.clarifyTimeoutError` on timeout — it always threw `AxiosError(ETIMEDOUT)` with a fixed message. The XHR (`lib/adapters/xhr.js`) and HTTP (`lib/adapters/http.js`) adapters already default to `ECONNABORTED`, switch to `ETIMEDOUT` only when `transitional.clarifyTimeoutError` is set, and let `timeoutErrorMessage` override the text. This PR brings the Fetch adapter to parity. The packaged smoke test `tests/smoke/esm/tests/timeout.smoke.test.js` already encodes the `ECONNABORTED` + message-override contract — Fetch was the only divergent adapter.

**⚠️ Behavior change (documented in #10888):** the Fetch adapter's default timeout code changes from `ETIMEDOUT` to `ECONNABORTED`, aligning with xhr/http. Opt back into `ETIMEDOUT` with `transitional: { clarifyTimeoutError: true }`. Semver: patch-level fix targeting `v1.x`.

## Linked issue

Closes #10888

## Changes

- `lib/helpers/composeSignals.js`: optional 3rd `options` arg `{ timeoutErrorMessage, transitional }`; the timeout `AxiosError` is built with the same rules as xhr/http. Backward compatible — existing 2-arg callers are unaffected.
- `lib/adapters/fetch.js`: passes `timeoutErrorMessage` and `transitional` through from `config`.
- `tests/unit/composeSignals.test.js`: new cases — default `ECONNABORTED`, `timeoutErrorMessage` override, `clarifyTimeoutError → ETIMEDOUT`.
- `tests/unit/adapters/fetch.test.js`: updated the two tests that asserted the old `ETIMEDOUT` default; added override + clarify variants.

Verified locally: focused unit suite (composeSignals + fetch adapter) **52/52 passing**; ESLint clean on both changed source files. No new dependencies; no public API change (no `index.d.ts` / `index.d.cts` updates).

## Checklist

- [x] Tests added or updated (or N/A with reason)
- [x] Docs / types updated if public API changed (N/A — no public API change)
- [x] No breaking changes (the timeout-code change is explicitly called out above)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the Fetch adapter’s timeout errors with XHR/HTTP. Honors `timeoutErrorMessage` and `transitional.clarifyTimeoutError`; default timeout code is ECONNABORTED (use the clarify flag for ETIMEDOUT).

## Description

- Summary of changes
  - `composeSignals` accepts an `options` arg and builds timeout errors like XHR/HTTP (respects `timeoutErrorMessage` and `transitional.clarifyTimeoutError`).
  - Fetch adapter forwards `timeoutErrorMessage` and `transitional` from config to `composeSignals`.
- Reasoning
  - Ensure adapter parity and respect existing config.
- Additional context
  - Addresses #10888. Behavior change: default timeout code is now ECONNABORTED; use `transitional: { clarifyTimeoutError: true }` for ETIMEDOUT.

## Docs

- Update `/docs/`:
  - Fetch default timeout code is ECONNABORTED; document opting into ETIMEDOUT via `transitional.clarifyTimeoutError`.
  - `timeoutErrorMessage` overrides the timeout message.

## Testing

- Added `composeSignals` unit tests: default code, message override, clarify flag.
- Updated Fetch adapter unit tests for the new default and clarify behavior.
- Updated Bun smoke test to assert ECONNABORTED by default and ETIMEDOUT when the clarify flag is set.
- No further tests needed.

## Semantic version impact

- Patch: bug fix aligning adapter behavior; no public API changes.

<sup>Written for commit a3fe062186309280b62e9cf3731aaf75d77f51bc. Summary will update on new commits. <a href="https://cubic.dev/pr/axios/axios/pull/10910?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

