### PR TITLE
fix: added missing files from the size comparison

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -40,6 +40,8 @@ jobs:
             dist/axios.js
             dist/axios.min.js
             dist/browser/axios.cjs
+            dist/esm/axios.js
+            dist/esm/axios.min.js
             dist/node/axios.cjs
           output-file: bundle-size-comparison.json
           release-stream: '1'


### PR DESCRIPTION
## Summary

Added missing files from the size comparison action.

## Linked issue

N/A

## Changes

N/A

#### Checklist

- [ ] Tests added or updated (or N/A with reason)
- [ ] Docs / types updated if public API changed (`index.d.ts` and `index.d.cts`)
- [ ] No breaking changes (or called out explicitly above)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the ESM builds to the bundle-size workflow so CI tracks size changes for all distributed formats. This improves visibility and prevents ESM bundle size regressions.

**Description**
- Summary of changes
  - Added `dist/esm/axios.js` and `dist/esm/axios.min.js` to the `bundle-size` workflow file list.
- Reasoning
  - ESM artifacts were missing from size comparison, giving an incomplete view of bundle changes.
- Additional context
  - CI-only change; no runtime or public API impact.

**Docs**
- No docs needed for users.
- Suggest adding a brief note in `/docs/contributing.md` (CI section) listing the files tracked by the bundle size check, including the ESM builds.

**Testing**
- No unit tests applicable (workflow-only change).
- CI run will validate that the bundle size report includes the two ESM files.

**Semantic version impact**
- No impact. Tooling/CI change only; no release required.

<sup>Written for commit 6f106166325429adce46349dee738851bb5dffad. Summary will update on new commits. <a href="https://cubic.dev/pr/axios/axios/pull/10916?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

