### PR TITLE
feat(http): add zstd decompression support

### DIFF
--- a/PRE_RELEASE_CHANGELOG.md
+++ b/PRE_RELEASE_CHANGELOG.md
@@ -4,10 +4,10 @@
 
 ## New Features
 
-- **HTTP Adapter - Zstandard:** Added automatic zstd decompression on Node.js versions that support it. `zstd` is only advertised in the default `Accept-Encoding` header when `advertiseZstd: true` is set. (**#6792**)
+- **HTTP Adapter - Zstandard:** Added automatic zstd decompression on Node.js versions that support it. `zstd` is only advertised in the default `Accept-Encoding` header when `transitional.advertiseZstdAcceptEncoding: true` is set. (**#6792**)
 
 ## Release Documentation TODO
 
-- Update `README.md` request config docs for `advertiseZstd` and zstd decompression support.
-- Update `docs/pages/advanced/request-config.md` for `advertiseZstd` and zstd decompression support.
+- Update `README.md` request config docs for `transitional.advertiseZstdAcceptEncoding` and zstd decompression support.
+- Update `docs/pages/advanced/request-config.md` for `transitional.advertiseZstdAcceptEncoding` and zstd decompression support.
 - Update decompression-bomb security guidance in `README.md` and `docs/pages/misc/security.md` to mention zstd.

--- a/index.d.cts
+++ b/index.d.cts
@@ -392,6 +392,7 @@ declare namespace axios {
     forcedJSONParsing?: boolean;
     clarifyTimeoutError?: boolean;
     legacyInterceptorReqResOrdering?: boolean;
+    advertiseZstdAcceptEncoding?: boolean;
   }
 
   interface GenericAbortSignal {
@@ -512,7 +513,6 @@ declare namespace axios {
     proxy?: AxiosProxyConfig | false;
     cancelToken?: CancelToken | undefined;
     decompress?: boolean;
-    advertiseZstd?: boolean;
     transitional?: TransitionalOptions;
     signal?: GenericAbortSignal;
     insecureHTTPParser?: boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -281,6 +281,7 @@ export interface TransitionalOptions {
   forcedJSONParsing?: boolean;
   clarifyTimeoutError?: boolean;
   legacyInterceptorReqResOrdering?: boolean;
+  advertiseZstdAcceptEncoding?: boolean;
 }
 
 export interface GenericAbortSignal {
@@ -410,7 +411,6 @@ export interface AxiosRequestConfig<D = any> {
   proxy?: AxiosProxyConfig | false;
   cancelToken?: CancelToken | undefined;
   decompress?: boolean;
-  advertiseZstd?: boolean;
   transitional?: TransitionalOptions;
   signal?: GenericAbortSignal;
   insecureHTTPParser?: boolean;

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -869,6 +869,7 @@ export default isHttpAdapterSupported &&
 
       headers.set(
         'Accept-Encoding',
+        utils.hasOwnProp(transitional, 'advertiseZstdAcceptEncoding') &&
         transitional.advertiseZstdAcceptEncoding === true ? ACCEPT_ENCODING_WITH_ZSTD : ACCEPT_ENCODING,
         false
       );

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -526,6 +526,7 @@ export default isHttpAdapterSupported &&
   function httpAdapter(config) {
     return wrapAsync(async function dispatchHttpRequest(resolve, reject, onDone) {
       const own = (key) => (utils.hasOwnProp(config, key) ? config[key] : undefined);
+      const transitional = own('transitional') || transitionalDefaults;
       let data = own('data');
       let lookup = own('lookup');
       let family = own('family');
@@ -594,7 +595,6 @@ export default isHttpAdapterSupported &&
         let timeoutErrorMessage = config.timeout
           ? 'timeout of ' + config.timeout + 'ms exceeded'
           : 'timeout exceeded';
-        const transitional = config.transitional || transitionalDefaults;
         if (config.timeoutErrorMessage) {
           timeoutErrorMessage = config.timeoutErrorMessage;
         }
@@ -869,7 +869,7 @@ export default isHttpAdapterSupported &&
 
       headers.set(
         'Accept-Encoding',
-        own('advertiseZstd') === true ? ACCEPT_ENCODING_WITH_ZSTD : ACCEPT_ENCODING,
+        transitional.advertiseZstdAcceptEncoding === true ? ACCEPT_ENCODING_WITH_ZSTD : ACCEPT_ENCODING,
         false
       );
 

--- a/lib/core/Axios.js
+++ b/lib/core/Axios.js
@@ -101,6 +101,7 @@ class Axios {
           forcedJSONParsing: validators.transitional(validators.boolean),
           clarifyTimeoutError: validators.transitional(validators.boolean),
           legacyInterceptorReqResOrdering: validators.transitional(validators.boolean),
+          advertiseZstdAcceptEncoding: validators.transitional(validators.boolean),
         },
         false
       );

--- a/lib/core/mergeConfig.js
+++ b/lib/core/mergeConfig.js
@@ -96,7 +96,6 @@ export default function mergeConfig(config1, config2) {
     onUploadProgress: defaultToConfig2,
     onDownloadProgress: defaultToConfig2,
     decompress: defaultToConfig2,
-    advertiseZstd: defaultToConfig2,
     maxContentLength: defaultToConfig2,
     maxBodyLength: defaultToConfig2,
     beforeRedirect: defaultToConfig2,

--- a/lib/defaults/transitional.js
+++ b/lib/defaults/transitional.js
@@ -5,4 +5,5 @@ export default {
   forcedJSONParsing: true,
   clarifyTimeoutError: false,
   legacyInterceptorReqResOrdering: true,
+  advertiseZstdAcceptEncoding: false,
 };

--- a/tests/unit/adapters/http.test.js
+++ b/tests/unit/adapters/http.test.js
@@ -850,7 +850,7 @@ describe('supports http with nodejs', () => {
       }
     });
 
-    it('should advertise zstd when enabled and supported', async () => {
+    it('should advertise zstd when enabled through transitional config and supported', async () => {
       if (!isZstdSupported) {
         return;
       }
@@ -867,7 +867,9 @@ describe('supports http with nodejs', () => {
 
       try {
         await axios.get(`http://localhost:${server.address().port}/`, {
-          advertiseZstd: true,
+          transitional: {
+            advertiseZstdAcceptEncoding: true,
+          },
         });
         assert.strictEqual(acceptEncoding.includes('zstd'), true);
       } finally {


### PR DESCRIPTION
## Summary

Adds Node HTTP adapter support for zstd-compressed responses while keeping `zstd` out of the default `Accept-Encoding` header unless explicitly enabled through transitional config.

## Linked issue

<!-- e.g. Closes #1234 -->

## Changes

- Add capability-checked zstd decompression in the Node HTTP adapter.
- Add `transitional.advertiseZstdAcceptEncoding` to opt into advertising zstd support.
- Update TypeScript declarations, validation, unit coverage, and pre-release notes for the new transitional option.
- Add OpenSpec agent workflow files and repo guidance for future spec-driven changes.

#### Checklist

- [x] Tests added or updated (or N/A with reason)
- [x] Docs / types updated if public API changed (`index.d.ts` and `index.d.cts`)
- [x] No breaking changes (or called out explicitly above)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds zstd (Zstandard) decompression to the Node HTTP adapter and gates `zstd` advertising behind a new transitional flag. Defaults unchanged; we only include `zstd` in `Accept-Encoding` when `transitional.advertiseZstdAcceptEncoding` is true.

## Description

- Summary of changes
  - Add capability-checked zstd decompression in the Node HTTP adapter.
  - Introduce `transitional.advertiseZstdAcceptEncoding`; remove the old `advertiseZstd` request option.
  - Validate the new flag in `Axios`; default to `false` in `defaults/transitional.js`.
  - Use own-property check on `transitional` before reading the flag for security hardening.
  - Update types (`index.d.ts`/`index.d.cts`), merge rules, and pre-release notes.

- Reasoning
  - Keep behavior opt-in and predictable; ensure secure handling of transitional flags.

- Additional context
  - Applies to `axios` Node adapter; browsers are unaffected.

## Docs

- Update `/docs/` and `README.md` to document `transitional.advertiseZstdAcceptEncoding`, Node-only support, and decompression-bomb guidance.
- Update advanced request config examples to use the new transitional flag.

## Testing

- Updated unit test to enable `transitional.advertiseZstdAcceptEncoding` and assert `zstd` is included in `Accept-Encoding` when supported.
- Optional: add an integration test to verify end-to-end zstd decompression.

## Semantic version impact

- Minor: new opt-in feature with no default behavior changes; the removed `advertiseZstd` option was not part of a released API.

<sup>Written for commit ecc59c76c34e4bd093d75716ebd28eb41206c720. Summary will update on new commits. <a href="https://cubic.dev/pr/axios/axios/pull/10920?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

