### PR TITLE
docs: update contributor policy docs

### DIFF
--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -39,7 +39,7 @@ At least one maintainer must review and approve the PR before it can be merged. 
 If changes are requested, address them in a timely manner. If you are unable to make the changes, communicate that clearly so someone else can pick it up.
 
 > [!IMPORTANT]  
-> We will wait a maximum of 21 days for a response to requested changes before closing the PR. If the PR is closed due to inactivity, it can be reopened if the requested changes are made.
+> We will wait a maximum of 28 days for a response to requested changes before closing the PR as stale. Once closed as stale, we will either address the issue in a maintainer-led PR or open an issue for other contributors to pick up. If the author wants to continue the work, they should re-create the PR from the latest version of the correct target branch, address all feedback provided, and request review from a maintainer.
 
 ## Security Disclosures
 

--- a/README.md
+++ b/README.md
@@ -325,6 +325,7 @@
 [![gitter chat](https://img.shields.io/gitter/room/mzabriskie/axios.svg?style=flat-square)](https://gitter.im/mzabriskie/axios)
 [![code helpers](https://www.codetriage.com/axios/axios/badges/users.svg)](https://www.codetriage.com/axios/axios)
 [![Contributors](https://img.shields.io/github/contributors/axios/axios.svg?style=flat-square)](CONTRIBUTORS.md)
+[![Agent Friendly](https://agentfriendlycode.com/api/badge/github/axios/axios.svg)](https://agentfriendlycode.com/repo/32)
 
 </div>
 


### PR DESCRIPTION
## Summary

Updates contributor-facing documentation for stale PR handling and project metadata.

## Linked issue


## Changes

- Extend the stale PR response window from 21 to 28 days.
- Clarify what happens after a PR is closed as stale and how authors should restart the work.
- Add the Agent Friendly badge to the README badge list.

#### Checklist

- [ ] Tests added or updated (or N/A with reason)
- [ ] Docs / types updated if public API changed (`index.d.ts` and `index.d.cts`)
- [ ] No breaking changes (or called out explicitly above)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates contributor policy docs to extend the stale PR window to 28 days and clarify next steps after closure. Adds an Agent Friendly badge to the README.

## Description

- Summary of changes
  - Stale PR response window: 21 → 28 days in COLLABORATOR_GUIDE.md.
  - Clarified what happens after a stale close and how authors can continue.
  - Added “Agent Friendly” badge to README.
- Reasoning
  - Give contributors more time, reduce churn, and make follow-up steps explicit.
- Additional context
  - Maintainers may pick up the work or open an issue after stale closure.

## Docs

Update any mirrored contributor docs in /docs/ to reflect the 28-day window and post-close process. If the docs site shows repo badges, add the Agent Friendly badge there too.

## Testing

No tests added; this is a docs-only change. No tests needed.

## Semantic version impact

Patch (docs-only; no API or runtime changes).

<sup>Written for commit e45c7eace417e7bd6c18b1dc8a4c6cdbb40a0a80. Summary will update on new commits. <a href="https://cubic.dev/pr/axios/axios/pull/10921?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

