### PR TITLE
chore: added dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,17 @@
+{
+  "name": "axios",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:1-24-bookworm",
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+  },
+  "postCreateCommand": "npm ci --ignore-scripts",
+  "customizations": {
+    "vscode": {
+      "extensions": ["dbaeumer.vscode-eslint", "esbenp.prettier-vscode"],
+      "settings": {
+        "eslint.validate": ["javascript"],
+        "editor.formatOnSave": false,
+      },
+    },
+  },
+}


### PR DESCRIPTION
## Summary

Added dev container setup

## Linked issue

N/A

## Changes

- Setups up dev container

#### Checklist

- [ ] Tests added or updated (or N/A with reason)
- [ ] Docs / types updated if public API changed (`index.d.ts` and `index.d.cts`)
- [x] No breaking changes (or called out explicitly above)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a VS Code Dev Container for `axios` to standardize local development and speed up onboarding. Installs `ghcr.io/devcontainers/features/github-cli:1`, runs `npm ci --ignore-scripts`, and configures ESLint/Prettier.

**Description**
- Summary of changes
  - Adds `.devcontainer/devcontainer.json` using `mcr.microsoft.com/devcontainers/javascript-node:1-24-bookworm`.
  - Enables GitHub CLI feature `ghcr.io/devcontainers/features/github-cli:1`.
  - Runs `npm ci --ignore-scripts` on create.
  - Recommends VS Code extensions `dbaeumer.vscode-eslint` and `esbenp.prettier-vscode`; configures ESLint for JavaScript and disables format on save.
- Reasoning
  - Provide a reproducible, ready-to-code environment for contributors and Codespaces.
- Additional context
  - No application code changes.

**Docs**
- Add a /docs/guide for “Using the Dev Container”:
  - Prereqs (Docker, VS Code + Dev Containers, or Codespaces).
  - How to open the repo in a Dev Container/Codespaces.
  - What runs automatically (install via `npm ci --ignore-scripts`) and available tools (GitHub CLI, ESLint/Prettier).

**Testing**
- No tests added; config-only change.
- Manual check: open in Dev Container, verify dependencies install, ESLint activates, and save does not auto-format.

**Semantic version impact**
- No version impact. Tooling-only change; no release required.

<sup>Written for commit 6da970fc44f3feb34ea5ee05da85f03074ae4522. Summary will update on new commits. <a href="https://cubic.dev/pr/axios/axios/pull/10925?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

