### PR TITLE
fix(fetch): align timeout errors with other adapters

### DIFF
--- a/PRE_RELEASE_CHANGELOG.md
+++ b/PRE_RELEASE_CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## Bug Fixes
+
+- **Fetch Adapter:** Honored `timeoutErrorMessage` and `transitional.clarifyTimeoutError` when fetch requests time out. (**#10888**)
+
 ## New Features
 
 - **HTTP Adapter - Zstandard:** Added automatic zstd decompression on Node.js versions that support it. `zstd` is only advertised in the default `Accept-Encoding` header when `transitional.advertiseZstdAcceptEncoding: true` is set. (**#6792**)

--- a/lib/adapters/fetch.js
+++ b/lib/adapters/fetch.js
@@ -29,9 +29,7 @@ const test = (fn, ...args) => {
 
 const factory = (env) => {
   const globalObject =
-    utils.global !== undefined && utils.global !== null
-      ? utils.global
-      : globalThis;
+    utils.global !== undefined && utils.global !== null ? utils.global : globalThis;
   const { ReadableStream, TextEncoder } = globalObject;
 
   env = utils.merge.call(
@@ -162,10 +160,12 @@ const factory = (env) => {
       signal,
       cancelToken,
       timeout,
+      timeoutErrorMessage,
       onDownloadProgress,
       onUploadProgress,
       responseType,
       headers,
+      transitional,
       withCredentials = 'same-origin',
       fetchOptions,
       maxContentLength,
@@ -181,7 +181,8 @@ const factory = (env) => {
 
     let composedSignal = composeSignals(
       [signal, cancelToken && cancelToken.toAbortSignal()],
-      timeout
+      timeout,
+      { timeoutErrorMessage, transitional }
     );
 
     let request = null;

--- a/lib/helpers/composeSignals.js
+++ b/lib/helpers/composeSignals.js
@@ -2,7 +2,7 @@ import CanceledError from '../cancel/CanceledError.js';
 import AxiosError from '../core/AxiosError.js';
 import utils from '../utils.js';
 
-const composeSignals = (signals, timeout) => {
+const composeSignals = (signals, timeout, options = {}) => {
   signals = signals ? signals.filter(Boolean) : [];
 
   if (!timeout && !signals.length) {
@@ -30,11 +30,21 @@ const composeSignals = (signals, timeout) => {
     timeout &&
     setTimeout(() => {
       timer = null;
-      onabort(new AxiosError(`timeout of ${timeout}ms exceeded`, AxiosError.ETIMEDOUT));
+      const { timeoutErrorMessage, transitional } = options;
+      onabort(
+        new AxiosError(
+          timeoutErrorMessage || `timeout of ${timeout}ms exceeded`,
+          transitional && transitional.clarifyTimeoutError
+            ? AxiosError.ETIMEDOUT
+            : AxiosError.ECONNABORTED
+        )
+      );
     }, timeout);
 
   const unsubscribe = () => {
-    if (!signals) { return; }
+    if (!signals) {
+      return;
+    }
     timer && clearTimeout(timer);
     timer = null;
     signals.forEach((signal) => {

--- a/tests/unit/adapters/fetch.test.js
+++ b/tests/unit/adapters/fetch.test.js
@@ -583,7 +583,7 @@ describe.runIf(typeof fetch === 'function')('supports fetch with nodejs', () => 
   });
 
   describe('fetch adapter - timeout normalization', () => {
-    it('should reject with an AxiosError(ETIMEDOUT) on timeout', async () => {
+    it('should reject with an AxiosError(ECONNABORTED) on timeout by default', async () => {
       const server = await startHTTPServer(
         async (req, res) => {
           await setTimeoutAsync(1000);
@@ -597,6 +597,64 @@ describe.runIf(typeof fetch === 'function')('supports fetch with nodejs', () => 
           () =>
             fetchAxios(`http://localhost:${server.address().port}/`, {
               timeout: 200,
+            }),
+          (err) => {
+            assert.strictEqual(err.name, 'AxiosError');
+            assert.strictEqual(err.code, 'ECONNABORTED');
+            assert.match(err.message, /timeout of 200ms exceeded/);
+            return true;
+          }
+        );
+      } finally {
+        await stopHTTPServer(server);
+      }
+    });
+
+    it('should respect the timeoutErrorMessage property', async () => {
+      const server = await startHTTPServer(
+        async (req, res) => {
+          await setTimeoutAsync(1000);
+          res.end('OK');
+        },
+        { port: 0 }
+      );
+
+      try {
+        await assert.rejects(
+          () =>
+            fetchAxios(`http://localhost:${server.address().port}/`, {
+              timeout: 200,
+              timeoutErrorMessage: 'oops, timeout',
+            }),
+          (err) => {
+            assert.strictEqual(err.name, 'AxiosError');
+            assert.strictEqual(err.code, 'ECONNABORTED');
+            assert.strictEqual(err.message, 'oops, timeout');
+            return true;
+          }
+        );
+      } finally {
+        await stopHTTPServer(server);
+      }
+    });
+
+    it('should clarify timeout errors when requested', async () => {
+      const server = await startHTTPServer(
+        async (req, res) => {
+          await setTimeoutAsync(1000);
+          res.end('OK');
+        },
+        { port: 0 }
+      );
+
+      try {
+        await assert.rejects(
+          () =>
+            fetchAxios(`http://localhost:${server.address().port}/`, {
+              timeout: 200,
+              transitional: {
+                clarifyTimeoutError: true,
+              },
             }),
           (err) => {
             assert.strictEqual(err.name, 'AxiosError');
@@ -649,7 +707,7 @@ describe.runIf(typeof fetch === 'function')('supports fetch with nodejs', () => 
     // under CI runner load even though the production code is fine. Retry as
     // a backstop.
     it(
-      'should surface ETIMEDOUT when fetch rejects with a broken DOMException on abort (Safari)',
+      'should surface ECONNABORTED when fetch rejects with a broken DOMException on timeout (Safari)',
       { retry: 2 },
       async () => {
         const safariFetch = (url, init) => {
@@ -674,7 +732,7 @@ describe.runIf(typeof fetch === 'function')('supports fetch with nodejs', () => 
             }),
           (err) => {
             assert.strictEqual(err.name, 'AxiosError');
-            assert.strictEqual(err.code, 'ETIMEDOUT');
+            assert.strictEqual(err.code, 'ECONNABORTED');
             assert.match(err.message, /timeout of 50ms exceeded/);
             return true;
           }

--- a/tests/unit/composeSignals.test.js
+++ b/tests/unit/composeSignals.test.js
@@ -4,6 +4,14 @@ import composeSignals from '../../lib/helpers/composeSignals.js';
 
 describe('helpers::composeSignals', () => {
   const runIfAbortController = typeof AbortController === 'function' ? it : it.skip;
+  const waitForAbort = (signal) =>
+    new Promise((resolve) => {
+      if (signal.aborted) {
+        resolve();
+        return;
+      }
+      signal.addEventListener('abort', resolve, { once: true });
+    });
 
   runIfAbortController('should abort when any of the signals abort', () => {
     let called;
@@ -25,11 +33,32 @@ describe('helpers::composeSignals', () => {
   runIfAbortController('should abort on timeout', async () => {
     const signal = composeSignals([], 100);
 
-    await new Promise((resolve) => {
-      signal.addEventListener('abort', resolve);
-    });
+    await waitForAbort(signal);
 
     assert.match(String(signal.reason), /timeout of 100ms exceeded/);
+    assert.strictEqual(signal.reason.code, 'ECONNABORTED');
+  });
+
+  runIfAbortController('should use a custom timeout message', async () => {
+    const signal = composeSignals([], 100, { timeoutErrorMessage: 'custom timeout' });
+
+    await waitForAbort(signal);
+
+    assert.strictEqual(signal.reason.message, 'custom timeout');
+    assert.strictEqual(signal.reason.code, 'ECONNABORTED');
+  });
+
+  runIfAbortController('should clarify timeout errors when requested', async () => {
+    const signal = composeSignals([], 100, {
+      transitional: {
+        clarifyTimeoutError: true,
+      },
+    });
+
+    await waitForAbort(signal);
+
+    assert.match(String(signal.reason), /timeout of 100ms exceeded/);
+    assert.strictEqual(signal.reason.code, 'ETIMEDOUT');
   });
 
   it('should return undefined if signals and timeout are not provided', () => {


### PR DESCRIPTION
## Summary
- pass `timeoutErrorMessage` and `transitional` timeout settings into the fetch adapter's composed signal
- default fetch timeout errors to `ECONNABORTED`, matching HTTP/XHR behavior
- preserve `ETIMEDOUT` when `transitional.clarifyTimeoutError` is enabled

Fixes #10888

## Tests
- `npm run test:vitest:unit -- tests/unit/composeSignals.test.js tests/unit/adapters/fetch.test.js`
- `npx eslint lib/helpers/composeSignals.js lib/adapters/fetch.js tests/unit/composeSignals.test.js tests/unit/adapters/fetch.test.js`
- `npx prettier --check lib/helpers/composeSignals.js lib/adapters/fetch.js tests/unit/composeSignals.test.js tests/unit/adapters/fetch.test.js PRE_RELEASE_CHANGELOG.md`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the `fetch` adapter’s timeout errors with other adapters. Defaults to `ECONNABORTED`, honors `timeoutErrorMessage`, and uses `ETIMEDOUT` when `transitional.clarifyTimeoutError` is enabled.

## Description
- Passes `timeoutErrorMessage` and `transitional` from the `fetch` adapter into `composeSignals`.
- `composeSignals` builds an `AxiosError` with the custom message; default code `ECONNABORTED`, switches to `ETIMEDOUT` when `clarifyTimeoutError` is true.
- Normalizes Safari timeout handling to `ECONNABORTED` by default and ensures `AbortSignal.reason` carries the `AxiosError`. Adds PRE_RELEASE_CHANGELOG entry. Fixes #10888.

## Docs
Suggest updating `/docs/` to clarify `fetch` timeout behavior, `timeoutErrorMessage`, and `transitional.clarifyTimeoutError`.

## Testing
Unit tests updated/added in `tests/unit/adapters/fetch.test.js` and `tests/unit/composeSignals.test.js` to cover default `ECONNABORTED`, custom timeout messages, clarified `ETIMEDOUT`, Safari timeout behavior, and `AbortSignal.reason`.

## Semantic version impact
Patch.

<sup>Written for commit d7a6229ae5e69c155cdc292563e83a8371ff642e. Summary will update on new commits. <a href="https://cubic.dev/pr/axios/axios/pull/10928?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

