### PR TITLE
fix(http): preserve basic auth on same-origin redirects (#6929)

### DIFF
--- a/PRE_RELEASE_CHANGELOG.md
+++ b/PRE_RELEASE_CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## Unreleased
 
-## Bug Fixes
-
-- **HTTP Adapter - Auth on Redirect:** HTTP Basic credentials supplied via `config.auth` are now restored on same-origin redirects, fixing a regression caused by `follow-redirects` >= 1.15.8 that broke `POST` requests answered with a 303 Location. Cross-origin redirects continue to drop credentials, preserving the existing T-R2 mitigation in `THREATMODEL.md`. (**#6929**)
-
 ## New Features
 
 - **HTTP Adapter - Zstandard:** Added automatic zstd decompression on Node.js versions that support it. `zstd` is only advertised in the default `Accept-Encoding` header when `transitional.advertiseZstdAcceptEncoding: true` is set. (**#6792**)
@@ -13,6 +9,7 @@
 ## Bug Fixes
 
 - **AxiosHeaders:** Silently skip empty response header names emitted by some React Native Android responses instead of throwing. (**#6959**, **#10875**)
+- **HTTP Adapter - Auth on Redirect:** HTTP Basic credentials supplied via `config.auth` are now restored on same-origin redirects, fixing a regression caused by `follow-redirects` >= 1.15.8 that broke `POST` requests answered with a 303 Location. Cross-origin redirects continue to drop credentials, preserving the existing T-R2 mitigation in `THREATMODEL.md`. (**#6929**)
 - **HTTP Adapter - Socket Path:** Ignore inherited `socketPath` and `allowedSocketPaths` config values when building Node.js requests, preventing prototype-pollution SSRF via Unix sockets. (**#10901**)
 - **React Native FormData:** Clear the default `Content-Type` header for React Native `FormData` requests so Android can build multipart bodies with the correct boundary. (**#10898**)
 - **Request Data:** Preserve enumerable symbol keys when merging plain request data before `transformRequest`. (**#6392**)

--- a/PRE_RELEASE_CHANGELOG.md
+++ b/PRE_RELEASE_CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## Bug Fixes
+
+- **HTTP Adapter - Auth on Redirect:** HTTP Basic credentials supplied via `config.auth` are now restored on same-origin redirects, fixing a regression caused by `follow-redirects` >= 1.15.8 that broke `POST` requests answered with a 303 Location. Cross-origin redirects continue to drop credentials, preserving the existing T-R2 mitigation in `THREATMODEL.md`. (**#6929**)
+
 ## New Features
 
 - **HTTP Adapter - Zstandard:** Added automatic zstd decompression on Node.js versions that support it. `zstd` is only advertised in the default `Accept-Encoding` header when `transitional.advertiseZstdAcceptEncoding: true` is set. (**#6792**)

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -157,6 +157,9 @@ function dispatchBeforeRedirect(options, responseDetails, requestDetails) {
   if (options.beforeRedirects.proxy) {
     options.beforeRedirects.proxy(options);
   }
+  if (options.beforeRedirects.auth) {
+    options.beforeRedirects.auth(options);
+  }
   if (options.beforeRedirects.config) {
     options.beforeRedirects.config(options, responseDetails, requestDetails);
   }
@@ -859,6 +862,23 @@ export default isHttpAdapterSupported &&
           const configBeforeRedirect = own('beforeRedirect');
           if (configBeforeRedirect) {
             options.beforeRedirects.config = configBeforeRedirect;
+          }
+          if (auth) {
+            // Restore HTTP Basic credentials on same-origin redirects only.
+            // follow-redirects >= 1.15.8 strips Authorization on every redirect (see #6929);
+            // cross-origin stripping is the documented mitigation for T-R2 in THREATMODEL.md
+            // and is preserved by deliberately not restoring on origin change.
+            const requestOrigin = parsed.origin;
+            const authToRestore = auth;
+            options.beforeRedirects.auth = function beforeRedirectAuth(redirectOptions) {
+              try {
+                if (new URL(redirectOptions.href).origin === requestOrigin) {
+                  redirectOptions.auth = authToRestore;
+                }
+              } catch (e) {
+                // ignore malformed URL: leaving auth stripped is fail-safe
+              }
+            };
           }
           transport = isHttpsRequest ? httpsFollow : httpFollow;
         }

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -146,8 +146,8 @@ const flushOnFinish = (stream, [throttled, flush]) => {
 const http2Sessions = new Http2Sessions();
 
 /**
- * If the proxy or config beforeRedirects functions are defined, call them with the options
- * object.
+ * If the proxy, auth, or config beforeRedirects functions are defined, call them
+ * with the options object.
  *
  * @param {Object<string, any>} options - The options object that was passed to the request.
  *

--- a/tests/unit/adapters/http.test.js
+++ b/tests/unit/adapters/http.test.js
@@ -1165,6 +1165,98 @@ describe('supports http with nodejs', () => {
     }
   });
 
+  it('should preserve basic auth across same-origin 303 POST -> GET redirect', async () => {
+    const server = await startHTTPServer(
+      (req, res) => {
+        if (req.url === '/login') {
+          res.setHeader('Location', '/profile');
+          res.statusCode = 303;
+          res.end();
+          return;
+        }
+        res.end(req.headers.authorization || '');
+      },
+      { port: SERVER_PORT }
+    );
+
+    try {
+      const auth = { username: 'foo', password: 'bar' };
+      const response = await axios.post(
+        `http://localhost:${server.address().port}/login`,
+        { hello: 'world' },
+        { auth, maxRedirects: 1 }
+      );
+      const base64 = Buffer.from('foo:bar', 'utf8').toString('base64');
+      assert.strictEqual(response.data, `Basic ${base64}`);
+      assert.strictEqual(response.request.path, '/profile');
+    } finally {
+      await stopHTTPServer(server);
+    }
+  });
+
+  it('should strip basic auth on cross-origin redirect', async () => {
+    const targetServer = await startHTTPServer(
+      (req, res) => {
+        res.end(req.headers.authorization || 'no-auth');
+      },
+      { port: ALTERNATE_SERVER_PORT }
+    );
+    const redirectServer = await startHTTPServer(
+      (req, res) => {
+        res.setHeader('Location', `http://127.0.0.1:${targetServer.address().port}/`);
+        res.statusCode = 302;
+        res.end();
+      },
+      { port: SERVER_PORT }
+    );
+
+    try {
+      const auth = { username: 'foo', password: 'bar' };
+      const response = await axios.get(`http://localhost:${redirectServer.address().port}/start`, {
+        auth,
+        maxRedirects: 1,
+      });
+      assert.strictEqual(response.data, 'no-auth');
+    } finally {
+      await stopHTTPServer(redirectServer);
+      await stopHTTPServer(targetServer);
+    }
+  });
+
+  it('should preserve basic auth across multi-hop same-origin redirects', async () => {
+    const server = await startHTTPServer(
+      (req, res) => {
+        if (req.url === '/a') {
+          res.setHeader('Location', '/b');
+          res.statusCode = 302;
+          res.end();
+          return;
+        }
+        if (req.url === '/b') {
+          res.setHeader('Location', '/c');
+          res.statusCode = 302;
+          res.end();
+          return;
+        }
+        res.end(req.headers.authorization || '');
+      },
+      { port: SERVER_PORT }
+    );
+
+    try {
+      const auth = { username: 'foo', password: 'bar' };
+      const response = await axios.get(`http://localhost:${server.address().port}/a`, {
+        auth,
+        maxRedirects: 5,
+      });
+      const base64 = Buffer.from('foo:bar', 'utf8').toString('base64');
+      assert.strictEqual(response.data, `Basic ${base64}`);
+      assert.strictEqual(response.request.path, '/c');
+    } finally {
+      await stopHTTPServer(server);
+    }
+  });
+
   it('should provides a default User-Agent header', async () => {
     const server = await startHTTPServer(
       (req, res) => {


### PR DESCRIPTION
## Summary

`config.auth` (HTTP Basic credentials) was being lost on every redirect after `follow-redirects` 1.15.8 — including same-origin POST → 303 → GET, which is the most common Basic-auth redirect pattern and what users in #6929 hit (401 Unauthorized).

This restores `auth` on the redirected request **only when the redirect target shares the original request's origin**. Cross-origin redirects continue to drop credentials, so the T-R2 cross-host credential-leak mitigation documented in `THREATMODEL.md` is preserved.

Implementation mirrors the existing `beforeRedirects.proxy` pattern (a hook registered alongside `beforeRedirects.config` and invoked from `dispatchBeforeRedirect`).

## Linked issue

Closes #6929

## Changes

- `lib/adapters/http.js`: add `beforeRedirects.auth` hook that re-applies `options.auth` when the redirect URL's origin matches the original request origin; wire it into `dispatchBeforeRedirect`. Malformed redirect URLs fall through with auth left stripped (fail-safe).
- `tests/unit/adapters/http.test.js`: three new regression tests
  - same-origin 303 POST → GET preserves Basic auth (the exact #6929 scenario)
  - cross-origin 302 strips Basic auth (regression guard for T-R2)
  - multi-hop same-origin redirect chain preserves Basic auth
- `PRE_RELEASE_CHANGELOG.md`: bug-fix entry under Unreleased.

## Security notes

- Same-origin = exact match on `URL(redirectOptions.href).origin` vs the parsed request URL's `origin` (protocol + hostname + port). This is the same notion of origin PR #10892 uses for cross-origin sensitive-header stripping.
- HTTPS → HTTP downgrade to the same hostname/port is *not* same-origin (different protocol), so credentials are still dropped on downgrade.
- No new public API surface; the hook is internal-only (analogous to `beforeRedirects.proxy`).

#### Checklist

- [x] Tests added or updated (or N/A with reason)
- [x] Docs / types updated if public API changed (`index.d.ts` and `index.d.cts`) — N/A, no public API change
- [x] No breaking changes (or called out explicitly above)

<sub>AI-assisted (Claude Opus 4.7); commit subject is one line per author preference, disclosed here. Happy to amend in an `Assisted-by:` trailer if reviewers prefer.</sub>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores HTTP Basic auth on same-origin redirects in the Node HTTP adapter to prevent 401s introduced by `follow-redirects` >= 1.15.8. Cross-origin redirects and malformed targets still strip credentials.

- **Description**
  - Added `beforeRedirects.auth` to re-apply `options.auth` when the redirect URL’s origin matches the original; invoked from `dispatchBeforeRedirect`.
  - Keeps security behavior: no restore on origin change or HTTPS→HTTP downgrade.
  - Added changelog entry under Bug Fixes.
  - Docs: update `/docs/` to clarify Basic auth is restored only on same-origin redirects and not on HTTPS→HTTP.
  - SemVer: patch (bug fix, no public API change).

- **Testing**
  - Added unit tests:
    - same-origin 303 POST→GET preserves auth
    - cross-origin 302 strips auth
    - multi-hop same-origin chain preserves auth

<sup>Written for commit 62ca77a64364ac43331d6d195714f07d47727074. Summary will update on new commits. <a href="https://cubic.dev/pr/axios/axios/pull/10929?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

