### PR TITLE
fix(headers): tolerate whitespace-only string from getAllResponseHeaders()

### DIFF
--- a/lib/core/AxiosHeaders.js
+++ b/lib/core/AxiosHeaders.js
@@ -109,8 +109,22 @@ class AxiosHeaders {
 
     if (utils.isPlainObject(header) || header instanceof this.constructor) {
       setHeaders(header, valueOrRewrite);
-    } else if (utils.isString(header) && (header = header.trim()) && !isValidHeaderName(header)) {
-      setHeaders(parseHeaders(header), valueOrRewrite);
+    } else if (utils.isString(header)) {
+      const trimmed = header.trim();
+      // Whitespace-only strings (e.g. '\n', '\r\n', ' ') can come from some
+      // XMLHttpRequest polyfills' getAllResponseHeaders() and are treated
+      // as a no-op, matching how AxiosHeaders.from(null) and from('')
+      // already behave via the constructor short-circuit. An originally
+      // empty '' still falls through to setHeader() so it throws, keeping
+      // .set('', value) consistent with .set({ '': value }).
+      if (header && !trimmed) {
+        return this;
+      }
+      if (trimmed && !isValidHeaderName(trimmed)) {
+        setHeaders(parseHeaders(trimmed), valueOrRewrite);
+      } else {
+        setHeader(valueOrRewrite, trimmed, rewrite);
+      }
     } else if (utils.isObject(header) && utils.isIterable(header)) {
       let obj = {},
         dest,
@@ -129,7 +143,7 @@ class AxiosHeaders {
 
       setHeaders(obj, valueOrRewrite);
     } else {
-      header != null && header !== '' && setHeader(valueOrRewrite, header, rewrite);
+      header != null && setHeader(valueOrRewrite, header, rewrite);
     }
 
     return this;

--- a/lib/core/AxiosHeaders.js
+++ b/lib/core/AxiosHeaders.js
@@ -129,7 +129,7 @@ class AxiosHeaders {
 
       setHeaders(obj, valueOrRewrite);
     } else {
-      header != null && setHeader(valueOrRewrite, header, rewrite);
+      header != null && header !== '' && setHeader(valueOrRewrite, header, rewrite);
     }
 
     return this;

--- a/tests/unit/core/AxiosHeaders.test.js
+++ b/tests/unit/core/AxiosHeaders.test.js
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import AxiosHeaders from '../../../lib/core/AxiosHeaders.js';
 
 describe('core::AxiosHeaders', () => {
-  describe('whitespace-only input', () => {
+  describe('whitespace-only input (no-op)', () => {
     // Some XMLHttpRequest polyfills (notably React Native on HarmonyOS for
     // large multipart responses) can return '\n', '\r\n' or ' ' from
     // getAllResponseHeaders() instead of either a proper header block or ''.
@@ -32,6 +32,27 @@ describe('core::AxiosHeaders', () => {
       const h = AxiosHeaders.from('\r\n');
       expect(Object.keys(h)).toHaveLength(0);
     });
+
+    it('headers.set("\\n", "value") is a no-op (does not throw, does not write)', () => {
+      const h = new AxiosHeaders();
+      expect(() => h.set('\n', 'whatever')).not.toThrow();
+      expect(Object.keys(h)).toHaveLength(0);
+    });
+  });
+
+  describe('explicit empty / invalid header name still throws', () => {
+    // Distinct from whitespace-only input above: the user explicitly asked
+    // to set '' as a header name. This should remain an error, and stay
+    // consistent across overloads.
+    it('throws on set("", value)', () => {
+      const h = new AxiosHeaders();
+      expect(() => h.set('', 'bar')).toThrow(/header name must be a non-empty string/);
+    });
+
+    it('throws on set({ "": value }) (overload consistency)', () => {
+      const h = new AxiosHeaders();
+      expect(() => h.set({ '': 'bar' })).toThrow(/header name must be a non-empty string/);
+    });
   });
 
   describe('regression', () => {
@@ -46,12 +67,18 @@ describe('core::AxiosHeaders', () => {
       expect(h.get('x-foo')).toBe('bar');
     });
 
+    it('still trims surrounding whitespace from a single header name', () => {
+      const h = new AxiosHeaders();
+      h.set('  X-Foo  ', 'bar');
+      expect(h.get('x-foo')).toBe('bar');
+    });
+
     it('still treats null/undefined input as empty headers', () => {
       expect(Object.keys(new AxiosHeaders(null))).toHaveLength(0);
       expect(Object.keys(new AxiosHeaders(undefined))).toHaveLength(0);
     });
 
-    it('still treats "" as empty headers', () => {
+    it('still treats "" as empty headers (constructor short-circuit)', () => {
       expect(Object.keys(new AxiosHeaders(''))).toHaveLength(0);
     });
   });

--- a/tests/unit/core/AxiosHeaders.test.js
+++ b/tests/unit/core/AxiosHeaders.test.js
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import AxiosHeaders from '../../../lib/core/AxiosHeaders.js';
+
+describe('core::AxiosHeaders', () => {
+  describe('whitespace-only input', () => {
+    // Some XMLHttpRequest polyfills (notably React Native on HarmonyOS for
+    // large multipart responses) can return '\n', '\r\n' or ' ' from
+    // getAllResponseHeaders() instead of either a proper header block or ''.
+    // The xhr adapter feeds that value straight into AxiosHeaders.from(),
+    // which used to throw "header name must be a non-empty string" from
+    // inside onloadend, leaving the request promise unsettled.
+    it('treats "\\n" as an empty headers no-op', () => {
+      expect(() => new AxiosHeaders('\n')).not.toThrow();
+      const h = new AxiosHeaders('\n');
+      expect(Object.keys(h)).toHaveLength(0);
+    });
+
+    it('treats "\\r\\n" as an empty headers no-op', () => {
+      expect(() => new AxiosHeaders('\r\n')).not.toThrow();
+      const h = new AxiosHeaders('\r\n');
+      expect(Object.keys(h)).toHaveLength(0);
+    });
+
+    it('treats " " (single space) as an empty headers no-op', () => {
+      expect(() => new AxiosHeaders(' ')).not.toThrow();
+      const h = new AxiosHeaders(' ');
+      expect(Object.keys(h)).toHaveLength(0);
+    });
+
+    it('AxiosHeaders.from() with whitespace-only string returns empty headers', () => {
+      expect(() => AxiosHeaders.from('\n')).not.toThrow();
+      const h = AxiosHeaders.from('\r\n');
+      expect(Object.keys(h)).toHaveLength(0);
+    });
+  });
+
+  describe('regression', () => {
+    it('still parses a valid raw header block', () => {
+      const h = new AxiosHeaders('Content-Type: application/json\n');
+      expect(h.get('content-type')).toBe('application/json');
+    });
+
+    it('still supports set(name, value) for a single header name', () => {
+      const h = new AxiosHeaders();
+      h.set('X-Foo', 'bar');
+      expect(h.get('x-foo')).toBe('bar');
+    });
+
+    it('still treats null/undefined input as empty headers', () => {
+      expect(Object.keys(new AxiosHeaders(null))).toHaveLength(0);
+      expect(Object.keys(new AxiosHeaders(undefined))).toHaveLength(0);
+    });
+
+    it('still treats "" as empty headers', () => {
+      expect(Object.keys(new AxiosHeaders(''))).toHaveLength(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

The `xhr` adapter calls `AxiosHeaders.from(request.getAllResponseHeaders())` in `onloadend`. Some `XMLHttpRequest` polyfills — observed in production on React Native + RNOH on HarmonyOS 6.1 for large multipart upload responses — return `'\n'`, `'\r\n'` or `' '` instead of either a proper header block or `''`. Such whitespace-only strings bleed through `AxiosHeaders.set`'s string branch (the inline `(header = header.trim())` reassigns `header` to `''`), then fall into the final `setHeader(undefined, '', undefined)` call, which throws `header name must be a non-empty string` from inside `onloadend`. The request promise is then **never settled** — interceptors cannot catch it — even though the HTTP request itself succeeded.

`AxiosHeaders.from(null)` and `AxiosHeaders.from('')` already behave as "empty headers" no-ops thanks to the constructor short-circuit (`headers && this.set(headers)`). This PR makes whitespace-only strings behave the same way by adding one extra `&& header !== ''` guard in the final fallthrough of `set()`.

### Minimal repro

```js
import AxiosHeaders from 'axios/unsafe/core/AxiosHeaders.js';

new AxiosHeaders('\n');
// before: throws "header name must be a non-empty string"
// after:  empty AxiosHeaders instance
```

In the wild it surfaces as:

```
Error: header name must be a non-empty string
    at AxiosHeaders.set (axios/lib/core/AxiosHeaders.js:...)
    at parseHeaders (axios/lib/helpers/parseHeaders.js:...)
    at AxiosHeaders.from (axios/lib/core/AxiosHeaders.js:...)
    at xhrAdapter.onloadend (axios/lib/adapters/xhr.js:97)
```

## Linked issue

N/A — happy to open one if maintainers prefer. The bug was observed in production on RNOH (HarmonyOS).

## Changes

- `lib/core/AxiosHeaders.js`: skip the final `setHeader` call when the string branch left `header` empty after `trim()`, instead of throwing `header name must be a non-empty string`.
- `tests/unit/core/AxiosHeaders.test.js` (new): 8 cases covering `new AxiosHeaders('\n' | '\r\n' | ' ')`, `AxiosHeaders.from('\n')`, plus regression tests for valid header blocks, `set(name, value)`, and `null` / `undefined` / `''` inputs.

#### Checklist

- [x] Tests added (`tests/unit/core/AxiosHeaders.test.js`, 8 cases, all green locally)
- [x] No public API change beyond accepting whitespace-only input that previously threw
- [x] No `index.d.ts` / `index.d.cts` change needed
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat whitespace-only strings from `XMLHttpRequest.getAllResponseHeaders()` as empty in `AxiosHeaders` to prevent the `xhr` adapter from throwing and leaving requests unsettled. Keep `set('', value)` validation unchanged while no-op’ing whitespace that trims to empty.

## Description

- Summary of changes
  - Refactored the string branch in `AxiosHeaders.set()` to no-op when an originally non-empty header trims to `''` (e.g., `'\n'`, `'\r\n'`, `' '`), but still throw on an originally empty `''`. Valid raw header blocks still parse as before.
- Reasoning
  - Some XHR polyfills return whitespace-only header blocks, which previously threw inside `onloadend` and hung the request. This fixes that without weakening header-name validation.
- Additional context
  - Matches `AxiosHeaders.from(null)` and `AxiosHeaders.from('')` behavior. Seen on React Native + RNOH on HarmonyOS.

## Docs

- Add a short troubleshooting note in `/docs/` for the `xhr` adapter that whitespace-only header blocks from polyfills are tolerated. No API changes.

## Testing

- Added `tests/unit/core/AxiosHeaders.test.js` with 12 cases:
  - Whitespace-only inputs are no-ops.
  - `set('', value)` and `set({ '': value })` still throw.
  - Regression coverage for valid parsing, `set(name, value)`, trimming, and `null`/`undefined`/`''` constructor inputs.

## Semantic version impact

- Patch: bug fix with no public API change.

<sup>Written for commit 52998e22ed8aeb3f4d809dc73393dff22840ba0b. Summary will update on new commits. <a href="https://cubic.dev/pr/axios/axios/pull/10932?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

