### PR TITLE
docs: remove outdated badge links from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,10 +315,8 @@
 <div align="center">
 
 [![npm version](https://img.shields.io/npm/v/axios.svg?style=flat-square)](https://www.npmjs.org/package/axios)
-[![CDNJS](https://img.shields.io/cdnjs/v/axios.svg?style=flat-square)](https://cdnjs.com/libraries/axios)
 [![Build status](https://img.shields.io/github/actions/workflow/status/axios/axios/ci.yml?branch=v1.x&label=CI&logo=github&style=flat-square)](https://github.com/axios/axios/actions/workflows/ci.yml)
 [![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod&style=flat-square)](https://gitpod.io/#https://github.com/axios/axios)
-[![code coverage](https://img.shields.io/coveralls/mzabriskie/axios.svg?style=flat-square)](https://coveralls.io/r/mzabriskie/axios)
 [![install size](https://img.shields.io/badge/dynamic/json?url=https://packagephobia.com/v2/api.json?p=axios&query=$.install.pretty&label=install%20size&style=flat-square)](https://packagephobia.now.sh/result?p=axios)
 [![npm bundle size](https://img.shields.io/bundlephobia/minzip/axios?style=flat-square)](https://bundlephobia.com/package/axios@latest)
 [![npm downloads](https://img.shields.io/npm/dm/axios.svg?style=flat-square)](https://npm-stat.com/charts.html?package=axios)


### PR DESCRIPTION
## Summary

Removes out-of-date badge links from the Readme

## Linked issue

N/A

## Changes

See above

#### Checklist

- [ ] Tests added or updated (or N/A with reason)
- [x] Docs / types updated if public API changed (`index.d.ts` and `index.d.cts`)
- [x] No breaking changes (or called out explicitly above)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed two outdated badges from the README to eliminate broken/misleading links. Keeps the `axios` README clean and current.

**Description**
- Removed `cdnjs` and legacy Coveralls badges from README
- Reason: links are outdated; reduces noise and confusion
- No code changes; testing not needed
- If these badges appear in `/docs/`, remove them there too

**Semantic version impact**
- Patch (docs-only; no runtime changes)

<sup>Written for commit 23858c75f8e44acf7fbbaeadab785a566b059bb6. Summary will update on new commits. <a href="https://cubic.dev/pr/axios/axios/pull/10933?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

