### PR TITLE
fix(ci): pin npm to 11.15.0 so `npm stage publish` works

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,8 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           package-manager-cache: false
 
-      # Node 26 bundles npm 11.13.0; `npm stage publish` requires npm >= 11.15.0.
+      # `npm stage publish` requires npm >= 11.15.0, newer than the npm bundled with
+      # this workflow's Node. Remove this step once Node bundles npm >= 11.15.0 by default.
       - name: Pin npm with staged-publishing support
         run: npm install -g npm@11.15.0
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,6 +26,10 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           package-manager-cache: false
 
+      # Node 26 bundles npm 11.13.0; `npm stage publish` requires npm >= 11.15.0.
+      - name: Pin npm with staged-publishing support
+        run: npm install -g npm@11.15.0
+
       - name: Install dependencies
         run: npm ci --ignore-scripts
 


### PR DESCRIPTION
## Summary

Currently, attempted publishes will fail due to the staged publishing change merged in #10926; staged publishing [requires](https://docs.npmjs.com/staged-publishing) an npm version of `11.15.0` (latest at the time of writing) or higher, but the default `npm` version shipped on Node 26.2.0 is currently `11.13.0`.

This PR upgrades and pins the `npm` version used during published to `11.15.0`; this is intended to be a short-lived shim until the default `npm` version shipped via `actions/setup-node` is bumped.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins `npm` to 11.15.0 in the publish workflow to enable staged publishing and unblock releases on Node 26.2. Temporary until `actions/setup-node` ships `npm` >= 11.15.0.

**Description**
- Summary of changes: Add a step in `.github/workflows/publish.yml` to install `npm@11.15.0` before install/publish.
- Reasoning: `npm stage publish` requires `npm` >= 11.15.0; Node 26.2 defaults to 11.13.0, causing publish failures.
- Additional context: Remove the pin once `actions/setup-node` bundles `npm` >= 11.15.0.

**Docs**
- Add a note in `/docs/` (release process) that CI pins `npm@11.15.0` for staged publishing and that this is temporary.

**Testing**
- No tests added. CI-only change; not needed. Validate by running the publish workflow on a pre-release tag.

**Semantic version impact**
- Patch: infrastructure-only; no public API or behavior changes to published packages.

<sup>Written for commit 13bd1e760b0ad1dbc40583190e9165b9e491519b. Summary will update on new commits. <a href="https://cubic.dev/pr/axios/axios/pull/10935?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

