### PR TITLE
ci(publish): adopt npm staged publishing on v0.x

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,8 @@ jobs:
           node-version: 24.x
           registry-url: "https://registry.npmjs.org"
           package-manager-cache: false
-      # Node 24/26 bundle npm 11.13.0; `npm stage publish` requires npm >= 11.15.0.
+      # `npm stage publish` requires npm >= 11.15.0, newer than the npm bundled with
+      # this workflow's Node. Remove this step once Node bundles npm >= 11.15.0 by default.
       - name: Pin npm with staged-publishing support
         run: npm install -g npm@11.15.0
       - name: Install dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,9 +24,12 @@ jobs:
           node-version: 24.x
           registry-url: "https://registry.npmjs.org"
           package-manager-cache: false
+      # Node 24/26 bundle npm 11.13.0; `npm stage publish` requires npm >= 11.15.0.
+      - name: Pin npm with staged-publishing support
+        run: npm install -g npm@11.15.0
       - name: Install dependencies
         run: npm ci --ignore-scripts
       - name: Build project
         run: npm run build
-      - name: Publish to NPM
-        run: npm publish --provenance --access public --tag v0x
+      - name: Publish to NPM (staged)
+        run: npm stage publish --provenance --access public --tag v0x


### PR DESCRIPTION
<!--
Thanks for contributing to axios! A few quick notes:
- For non-trivial changes, please open an issue first so we can discuss the approach.
- Follow Conventional Commits in your commit messages (see CONTRIBUTING.md).
- If you leave the description blank, our AI agent will draft one — feel free to edit afterwards.
-->

## Summary

Adopts staged publishing for `v0.x` releases. See #10926 and #10935 for reference.

NOTE: This (along with #10926) depends on a one-time, owner-only change to axios' npm Trusted Publisher settings. The publisher predates npm's staged-publishing rollout, so its Allowed actions currently permits only `npm publish`; until `npm stage publish` is enabled there, OIDC publishes will fail with an HTTP 403 error. (Since Trusted Publishing is configured on a project/repository level, not on a branch level, enabling it once covers both branches; if it was enabled with #10926 then this should already be covered :D. See https://docs.npmjs.com/trusted-publishers#for-github-actions for more info.

Once both the v0.x and v1.x release workflows are on npm stage publish, I'd also recommend unselecting `npm publish` from the "Allowed actions" to make staging mandatory for all OIDC publishes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the `v0.x` release workflow to `npm stage publish` so each release is staged and must be approved before going live. Pins `npm` to `11.15.0` in CI until Node ships a compatible version.

**Description**
- Summary of changes
  - Replace `npm publish` with `npm stage publish --provenance --access public --tag v0x`.
  - Add CI step to install `npm@11.15.0` (minimum for staged publishing).
- Reasoning
  - Requires maintainer approval (2FA proof-of-presence) for OIDC publishes.
  - Aligns `v0.x` with the staged model used on `v1.x`.
- Additional context
  - Update npm Trusted Publisher "Allowed actions" to permit `npm stage publish` or publishes will 403.
  - After both branches use staging, consider disabling `npm publish` to make staging mandatory.

**Docs**
- Update `/docs/` with the `v0.x` release flow:
  - How to approve staged releases in the npm UI.
  - Note the temporary `npm@11.15.0` pin and removal criteria.
  - Trusted Publisher settings required for staged publishing.

**Testing**
- No product tests needed; this is a CI workflow change.
- First release run will validate flow; will fail with 403 until Trusted Publisher allows staged publishing.

**Semantic version impact**
- None (tooling-only). If classified, treat as patch.

<sup>Written for commit e966fc9ee41d3d4829a6d07ffcd4724f2a8f28ff. Summary will update on new commits. <a href="https://cubic.dev/pr/axios/axios/pull/10936?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

