### PR TITLE
feat: add node 26 to matrix

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: 24.x
+          node-version: 26.x
           registry-url: "https://registry.npmjs.org"
           package-manager-cache: false
       - name: Install dependencies

--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x, 18.x, 20.x, 22.x, 24.x]
+        node-version: [12.x, 14.x, 16.x, 18.x, 20.x, 22.x, 24.x, 26.x]
       fail-fast: false
 
     steps:
@@ -59,7 +59,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: 24.x
+          node-version: 26.x
           cache: npm
       - name: Install dependencies
         run: npm ci --ignore-scripts

--- a/.github/workflows/run-ci-v0.yml
+++ b/.github/workflows/run-ci-v0.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x, 18.x, 20.x, 22.x, 24.x]
+        node-version: [12.x, 14.x, 16.x, 18.x, 20.x, 22.x, 24.x, 26.x]
       fail-fast: false
 
     steps:


### PR DESCRIPTION
<!--
Thanks for contributing to axios! A few quick notes:
- For non-trivial changes, please open an issue first so we can discuss the approach.
- Follow Conventional Commits in your commit messages (see CONTRIBUTING.md).
- If you leave the description blank, our AI agent will draft one — feel free to edit afterwards.
-->

## Summary

Backports #10927 to v0.x.

No test changes are needed here (unlike #10927): v0.x has no HTTPS-proxy/CONNECT-tunnel tests that pass an IP literal as the TLS servername, and the full suite build, eslint, mocha, karma, dtslint already passes on Node 26.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Node.js 26 to the v0.x CI and publish/release workflows so v0.x is tested and published on 26.x.

**Description**
- Summary of changes
  - Added 26.x to CI matrices in `.github/workflows/run-ci-v0.yml` and `.github/workflows/release-branch.yml`.
  - Updated `.github/workflows/publish.yml` and `.github/workflows/release-branch.yml` to use `actions/setup-node` with Node 26.x.
- Reasoning
  - Backport Node 26 support to v0.x to keep CI and releases current and aligned with mainline.
- Additional context
  - Full suite (eslint, mocha, karma, dtslint) passes on Node 26.
  - No test changes needed; v0.x has no HTTPS proxy/CONNECT-tunnel cases requiring TLS servername tweaks.

**Docs**
- Update supported Node versions in `/docs/` to include Node 26 for v0.x and note the CI/publish environment.

**Testing**
- No tests added or modified. Existing suites run cleanly on Node 26.

**Semantic version impact**
- No runtime or API changes. Infra-only; if released, treat as a patch.

<sup>Written for commit 3ec270b6ce1f318397a4c1796686cb5e35539e95. Summary will update on new commits. <a href="https://cubic.dev/pr/axios/axios/pull/10937?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

