### PR TITLE
fix(types): constrain AxiosHeaders custom fields

### DIFF
--- a/index.d.cts
+++ b/index.d.cts
@@ -10,6 +10,7 @@ type AxiosHeaderMatcher =
   | ((this: AxiosHeaders, value: string, name: string) => boolean);
 
 type AxiosHeaderParser = (this: AxiosHeaders, value: axios.AxiosHeaderValue, header: string) => any;
+type AxiosHeaderValueOrMethod = axios.AxiosHeaderValue | ((...args: any[]) => any);
 
 type CommonRequestHeadersList =
   | 'Accept'
@@ -42,7 +43,7 @@ type BrowserProgressEvent = any;
 declare class AxiosHeaders {
   constructor(headers?: axios.RawAxiosHeaders | AxiosHeaders | string);
 
-  [key: string]: any;
+  [key: string]: AxiosHeaderValueOrMethod;
 
   set(
     headerName?: string,
@@ -503,7 +504,7 @@ declare namespace axios {
     beforeRedirect?: (
       options: Record<string, any>,
       responseDetails: { headers: Record<string, string>; statusCode: HttpStatusCode },
-      requestDetails: { headers: Record<string, string>; url: string; method: string },
+      requestDetails: { headers: Record<string, string>; url: string; method: string }
     ) => void;
     socketPath?: string | null;
     allowedSocketPaths?: string | string[] | null;

--- a/index.d.cts
+++ b/index.d.cts
@@ -10,7 +10,70 @@ type AxiosHeaderMatcher =
   | ((this: AxiosHeaders, value: string, name: string) => boolean);
 
 type AxiosHeaderParser = (this: AxiosHeaders, value: axios.AxiosHeaderValue, header: string) => any;
-type AxiosHeaderValueOrMethod = axios.AxiosHeaderValue | ((...args: any[]) => any);
+declare const AxiosHeaderMethodSymbol: unique symbol;
+
+type AxiosHeaderMethodBrand = {
+  readonly [AxiosHeaderMethodSymbol]: true;
+};
+
+type AxiosHeaderSetter = AxiosHeaderMethodBrand & {
+  (
+    headerName?: string,
+    value?: axios.AxiosHeaderValue,
+    rewrite?: boolean | AxiosHeaderMatcher
+  ): AxiosHeaders;
+  (headers?: axios.RawAxiosHeaders | AxiosHeaders | string, rewrite?: boolean): AxiosHeaders;
+};
+
+type AxiosHeaderGetter = AxiosHeaderMethodBrand & {
+  (headerName: string, parser: RegExp): RegExpExecArray | null;
+  (headerName: string, matcher?: true | AxiosHeaderParser): axios.AxiosHeaderValue;
+};
+
+type AxiosHeaderTester = AxiosHeaderMethodBrand &
+  ((header: string, matcher?: AxiosHeaderMatcher) => boolean);
+
+type AxiosHeaderDeleter = AxiosHeaderMethodBrand &
+  ((header: string | string[], matcher?: AxiosHeaderMatcher) => boolean);
+
+type AxiosHeaderClearer = AxiosHeaderMethodBrand & ((matcher?: AxiosHeaderMatcher) => boolean);
+
+type AxiosHeaderNormalizer = AxiosHeaderMethodBrand & ((format: boolean) => AxiosHeaders);
+
+type AxiosHeaderConcatenator = AxiosHeaderMethodBrand &
+  ((
+    ...targets: Array<AxiosHeaders | axios.RawAxiosHeaders | string | undefined | null>
+  ) => AxiosHeaders);
+
+type AxiosHeaderToJSON = AxiosHeaderMethodBrand & ((asStrings?: boolean) => axios.RawAxiosHeaders);
+
+type AxiosHeaderAccessorSetter<Value = axios.AxiosHeaderValue> = AxiosHeaderMethodBrand &
+  ((value: Value, rewrite?: boolean | AxiosHeaderMatcher) => AxiosHeaders);
+
+type AxiosHeaderAccessorGetter = AxiosHeaderMethodBrand & {
+  (parser?: RegExp): RegExpExecArray | null;
+  (matcher?: AxiosHeaderMatcher): axios.AxiosHeaderValue;
+};
+
+type AxiosHeaderAccessorTester = AxiosHeaderMethodBrand &
+  ((matcher?: AxiosHeaderMatcher) => boolean);
+
+type AxiosHeaderSetCookieGetter = AxiosHeaderMethodBrand & (() => string[]);
+
+type AxiosHeaderValueOrMethod =
+  | axios.AxiosHeaderValue
+  | AxiosHeaderSetter
+  | AxiosHeaderGetter
+  | AxiosHeaderTester
+  | AxiosHeaderDeleter
+  | AxiosHeaderClearer
+  | AxiosHeaderNormalizer
+  | AxiosHeaderConcatenator
+  | AxiosHeaderToJSON
+  | AxiosHeaderAccessorSetter
+  | AxiosHeaderAccessorGetter
+  | AxiosHeaderAccessorTester
+  | AxiosHeaderSetCookieGetter;
 
 type CommonRequestHeadersList =
   | 'Accept'
@@ -45,29 +108,21 @@ declare class AxiosHeaders {
 
   [key: string]: AxiosHeaderValueOrMethod;
 
-  set(
-    headerName?: string,
-    value?: axios.AxiosHeaderValue,
-    rewrite?: boolean | AxiosHeaderMatcher
-  ): AxiosHeaders;
-  set(headers?: axios.RawAxiosHeaders | AxiosHeaders | string, rewrite?: boolean): AxiosHeaders;
+  set: AxiosHeaderSetter;
 
-  get(headerName: string, parser: RegExp): RegExpExecArray | null;
-  get(headerName: string, matcher?: true | AxiosHeaderParser): axios.AxiosHeaderValue;
+  get: AxiosHeaderGetter;
 
-  has(header: string, matcher?: AxiosHeaderMatcher): boolean;
+  has: AxiosHeaderTester;
 
-  delete(header: string | string[], matcher?: AxiosHeaderMatcher): boolean;
+  delete: AxiosHeaderDeleter;
 
-  clear(matcher?: AxiosHeaderMatcher): boolean;
+  clear: AxiosHeaderClearer;
 
-  normalize(format: boolean): AxiosHeaders;
+  normalize: AxiosHeaderNormalizer;
 
-  concat(
-    ...targets: Array<AxiosHeaders | axios.RawAxiosHeaders | string | undefined | null>
-  ): AxiosHeaders;
+  concat: AxiosHeaderConcatenator;
 
-  toJSON(asStrings?: boolean): axios.RawAxiosHeaders;
+  toJSON: AxiosHeaderToJSON;
 
   static from(thing?: AxiosHeaders | axios.RawAxiosHeaders | string): AxiosHeaders;
 
@@ -77,46 +132,31 @@ declare class AxiosHeaders {
     ...targets: Array<AxiosHeaders | axios.RawAxiosHeaders | string | undefined | null>
   ): AxiosHeaders;
 
-  setContentType(value: ContentType, rewrite?: boolean | AxiosHeaderMatcher): AxiosHeaders;
-  getContentType(parser?: RegExp): RegExpExecArray | null;
-  getContentType(matcher?: AxiosHeaderMatcher): axios.AxiosHeaderValue;
-  hasContentType(matcher?: AxiosHeaderMatcher): boolean;
+  setContentType: AxiosHeaderAccessorSetter<ContentType>;
+  getContentType: AxiosHeaderAccessorGetter;
+  hasContentType: AxiosHeaderAccessorTester;
 
-  setContentLength(
-    value: axios.AxiosHeaderValue,
-    rewrite?: boolean | AxiosHeaderMatcher
-  ): AxiosHeaders;
-  getContentLength(parser?: RegExp): RegExpExecArray | null;
-  getContentLength(matcher?: AxiosHeaderMatcher): axios.AxiosHeaderValue;
-  hasContentLength(matcher?: AxiosHeaderMatcher): boolean;
+  setContentLength: AxiosHeaderAccessorSetter;
+  getContentLength: AxiosHeaderAccessorGetter;
+  hasContentLength: AxiosHeaderAccessorTester;
 
-  setAccept(value: axios.AxiosHeaderValue, rewrite?: boolean | AxiosHeaderMatcher): AxiosHeaders;
-  getAccept(parser?: RegExp): RegExpExecArray | null;
-  getAccept(matcher?: AxiosHeaderMatcher): axios.AxiosHeaderValue;
-  hasAccept(matcher?: AxiosHeaderMatcher): boolean;
+  setAccept: AxiosHeaderAccessorSetter;
+  getAccept: AxiosHeaderAccessorGetter;
+  hasAccept: AxiosHeaderAccessorTester;
 
-  setUserAgent(value: axios.AxiosHeaderValue, rewrite?: boolean | AxiosHeaderMatcher): AxiosHeaders;
-  getUserAgent(parser?: RegExp): RegExpExecArray | null;
-  getUserAgent(matcher?: AxiosHeaderMatcher): axios.AxiosHeaderValue;
-  hasUserAgent(matcher?: AxiosHeaderMatcher): boolean;
+  setUserAgent: AxiosHeaderAccessorSetter;
+  getUserAgent: AxiosHeaderAccessorGetter;
+  hasUserAgent: AxiosHeaderAccessorTester;
 
-  setContentEncoding(
-    value: axios.AxiosHeaderValue,
-    rewrite?: boolean | AxiosHeaderMatcher
-  ): AxiosHeaders;
-  getContentEncoding(parser?: RegExp): RegExpExecArray | null;
-  getContentEncoding(matcher?: AxiosHeaderMatcher): axios.AxiosHeaderValue;
-  hasContentEncoding(matcher?: AxiosHeaderMatcher): boolean;
+  setContentEncoding: AxiosHeaderAccessorSetter;
+  getContentEncoding: AxiosHeaderAccessorGetter;
+  hasContentEncoding: AxiosHeaderAccessorTester;
 
-  setAuthorization(
-    value: axios.AxiosHeaderValue,
-    rewrite?: boolean | AxiosHeaderMatcher
-  ): AxiosHeaders;
-  getAuthorization(parser?: RegExp): RegExpExecArray | null;
-  getAuthorization(matcher?: AxiosHeaderMatcher): axios.AxiosHeaderValue;
-  hasAuthorization(matcher?: AxiosHeaderMatcher): boolean;
+  setAuthorization: AxiosHeaderAccessorSetter;
+  getAuthorization: AxiosHeaderAccessorGetter;
+  hasAuthorization: AxiosHeaderAccessorTester;
 
-  getSetCookie(): string[];
+  getSetCookie: AxiosHeaderSetCookieGetter;
 
   [Symbol.iterator](): IterableIterator<[string, axios.AxiosHeaderValue]>;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -19,36 +19,89 @@ type AxiosHeaderMatcher =
   | ((this: AxiosHeaders, value: string, name: string) => boolean);
 
 type AxiosHeaderParser = (this: AxiosHeaders, value: AxiosHeaderValue, header: string) => any;
-type AxiosHeaderValueOrMethod = AxiosHeaderValue | ((...args: any[]) => any);
+declare const AxiosHeaderMethodSymbol: unique symbol;
+
+type AxiosHeaderMethodBrand = {
+  readonly [AxiosHeaderMethodSymbol]: true;
+};
+
+type AxiosHeaderSetter = AxiosHeaderMethodBrand & {
+  (
+    headerName?: string,
+    value?: AxiosHeaderValue,
+    rewrite?: boolean | AxiosHeaderMatcher
+  ): AxiosHeaders;
+  (headers?: RawAxiosHeaders | AxiosHeaders | string, rewrite?: boolean): AxiosHeaders;
+};
+
+type AxiosHeaderGetter = AxiosHeaderMethodBrand & {
+  (headerName: string, parser: RegExp): RegExpExecArray | null;
+  (headerName: string, matcher?: true | AxiosHeaderParser): AxiosHeaderValue;
+};
+
+type AxiosHeaderTester = AxiosHeaderMethodBrand &
+  ((header: string, matcher?: AxiosHeaderMatcher) => boolean);
+
+type AxiosHeaderDeleter = AxiosHeaderMethodBrand &
+  ((header: string | string[], matcher?: AxiosHeaderMatcher) => boolean);
+
+type AxiosHeaderClearer = AxiosHeaderMethodBrand & ((matcher?: AxiosHeaderMatcher) => boolean);
+
+type AxiosHeaderNormalizer = AxiosHeaderMethodBrand & ((format: boolean) => AxiosHeaders);
+
+type AxiosHeaderConcatenator = AxiosHeaderMethodBrand &
+  ((...targets: Array<AxiosHeaders | RawAxiosHeaders | string | undefined | null>) => AxiosHeaders);
+
+type AxiosHeaderToJSON = AxiosHeaderMethodBrand & ((asStrings?: boolean) => RawAxiosHeaders);
+
+type AxiosHeaderAccessorSetter<Value = AxiosHeaderValue> = AxiosHeaderMethodBrand &
+  ((value: Value, rewrite?: boolean | AxiosHeaderMatcher) => AxiosHeaders);
+
+type AxiosHeaderAccessorGetter = AxiosHeaderMethodBrand & {
+  (parser?: RegExp): RegExpExecArray | null;
+  (matcher?: AxiosHeaderMatcher): AxiosHeaderValue;
+};
+
+type AxiosHeaderAccessorTester = AxiosHeaderMethodBrand &
+  ((matcher?: AxiosHeaderMatcher) => boolean);
+
+type AxiosHeaderSetCookieGetter = AxiosHeaderMethodBrand & (() => string[]);
+
+type AxiosHeaderValueOrMethod =
+  | AxiosHeaderValue
+  | AxiosHeaderSetter
+  | AxiosHeaderGetter
+  | AxiosHeaderTester
+  | AxiosHeaderDeleter
+  | AxiosHeaderClearer
+  | AxiosHeaderNormalizer
+  | AxiosHeaderConcatenator
+  | AxiosHeaderToJSON
+  | AxiosHeaderAccessorSetter
+  | AxiosHeaderAccessorGetter
+  | AxiosHeaderAccessorTester
+  | AxiosHeaderSetCookieGetter;
 
 export class AxiosHeaders {
   constructor(headers?: RawAxiosHeaders | AxiosHeaders | string);
 
   [key: string]: AxiosHeaderValueOrMethod;
 
-  set(
-    headerName?: string,
-    value?: AxiosHeaderValue,
-    rewrite?: boolean | AxiosHeaderMatcher
-  ): AxiosHeaders;
-  set(headers?: RawAxiosHeaders | AxiosHeaders | string, rewrite?: boolean): AxiosHeaders;
+  set: AxiosHeaderSetter;
 
-  get(headerName: string, parser: RegExp): RegExpExecArray | null;
-  get(headerName: string, matcher?: true | AxiosHeaderParser): AxiosHeaderValue;
+  get: AxiosHeaderGetter;
 
-  has(header: string, matcher?: AxiosHeaderMatcher): boolean;
+  has: AxiosHeaderTester;
 
-  delete(header: string | string[], matcher?: AxiosHeaderMatcher): boolean;
+  delete: AxiosHeaderDeleter;
 
-  clear(matcher?: AxiosHeaderMatcher): boolean;
+  clear: AxiosHeaderClearer;
 
-  normalize(format: boolean): AxiosHeaders;
+  normalize: AxiosHeaderNormalizer;
 
-  concat(
-    ...targets: Array<AxiosHeaders | RawAxiosHeaders | string | undefined | null>
-  ): AxiosHeaders;
+  concat: AxiosHeaderConcatenator;
 
-  toJSON(asStrings?: boolean): RawAxiosHeaders;
+  toJSON: AxiosHeaderToJSON;
 
   static from(thing?: AxiosHeaders | RawAxiosHeaders | string): AxiosHeaders;
 
@@ -58,37 +111,31 @@ export class AxiosHeaders {
     ...targets: Array<AxiosHeaders | RawAxiosHeaders | string | undefined | null>
   ): AxiosHeaders;
 
-  setContentType(value: ContentType, rewrite?: boolean | AxiosHeaderMatcher): AxiosHeaders;
-  getContentType(parser?: RegExp): RegExpExecArray | null;
-  getContentType(matcher?: AxiosHeaderMatcher): AxiosHeaderValue;
-  hasContentType(matcher?: AxiosHeaderMatcher): boolean;
+  setContentType: AxiosHeaderAccessorSetter<ContentType>;
+  getContentType: AxiosHeaderAccessorGetter;
+  hasContentType: AxiosHeaderAccessorTester;
 
-  setContentLength(value: AxiosHeaderValue, rewrite?: boolean | AxiosHeaderMatcher): AxiosHeaders;
-  getContentLength(parser?: RegExp): RegExpExecArray | null;
-  getContentLength(matcher?: AxiosHeaderMatcher): AxiosHeaderValue;
-  hasContentLength(matcher?: AxiosHeaderMatcher): boolean;
+  setContentLength: AxiosHeaderAccessorSetter;
+  getContentLength: AxiosHeaderAccessorGetter;
+  hasContentLength: AxiosHeaderAccessorTester;
 
-  setAccept(value: AxiosHeaderValue, rewrite?: boolean | AxiosHeaderMatcher): AxiosHeaders;
-  getAccept(parser?: RegExp): RegExpExecArray | null;
-  getAccept(matcher?: AxiosHeaderMatcher): AxiosHeaderValue;
-  hasAccept(matcher?: AxiosHeaderMatcher): boolean;
+  setAccept: AxiosHeaderAccessorSetter;
+  getAccept: AxiosHeaderAccessorGetter;
+  hasAccept: AxiosHeaderAccessorTester;
 
-  setUserAgent(value: AxiosHeaderValue, rewrite?: boolean | AxiosHeaderMatcher): AxiosHeaders;
-  getUserAgent(parser?: RegExp): RegExpExecArray | null;
-  getUserAgent(matcher?: AxiosHeaderMatcher): AxiosHeaderValue;
-  hasUserAgent(matcher?: AxiosHeaderMatcher): boolean;
+  setUserAgent: AxiosHeaderAccessorSetter;
+  getUserAgent: AxiosHeaderAccessorGetter;
+  hasUserAgent: AxiosHeaderAccessorTester;
 
-  setContentEncoding(value: AxiosHeaderValue, rewrite?: boolean | AxiosHeaderMatcher): AxiosHeaders;
-  getContentEncoding(parser?: RegExp): RegExpExecArray | null;
-  getContentEncoding(matcher?: AxiosHeaderMatcher): AxiosHeaderValue;
-  hasContentEncoding(matcher?: AxiosHeaderMatcher): boolean;
+  setContentEncoding: AxiosHeaderAccessorSetter;
+  getContentEncoding: AxiosHeaderAccessorGetter;
+  hasContentEncoding: AxiosHeaderAccessorTester;
 
-  setAuthorization(value: AxiosHeaderValue, rewrite?: boolean | AxiosHeaderMatcher): AxiosHeaders;
-  getAuthorization(parser?: RegExp): RegExpExecArray | null;
-  getAuthorization(matcher?: AxiosHeaderMatcher): AxiosHeaderValue;
-  hasAuthorization(matcher?: AxiosHeaderMatcher): boolean;
+  setAuthorization: AxiosHeaderAccessorSetter;
+  getAuthorization: AxiosHeaderAccessorGetter;
+  hasAuthorization: AxiosHeaderAccessorTester;
 
-  getSetCookie(): string[];
+  getSetCookie: AxiosHeaderSetCookieGetter;
 
   [Symbol.iterator](): IterableIterator<[string, AxiosHeaderValue]>;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -19,11 +19,12 @@ type AxiosHeaderMatcher =
   | ((this: AxiosHeaders, value: string, name: string) => boolean);
 
 type AxiosHeaderParser = (this: AxiosHeaders, value: AxiosHeaderValue, header: string) => any;
+type AxiosHeaderValueOrMethod = AxiosHeaderValue | ((...args: any[]) => any);
 
 export class AxiosHeaders {
   constructor(headers?: RawAxiosHeaders | AxiosHeaders | string);
 
-  [key: string]: any;
+  [key: string]: AxiosHeaderValueOrMethod;
 
   set(
     headerName?: string,
@@ -401,7 +402,7 @@ export interface AxiosRequestConfig<D = any> {
       headers: Record<string, string>;
       url: string;
       method: string;
-    },
+    }
   ) => void;
   socketPath?: string | null;
   allowedSocketPaths?: string | string[] | null;

--- a/tests/module/cjs/tests/helpers/headers-types.ts
+++ b/tests/module/cjs/tests/helpers/headers-types.ts
@@ -8,3 +8,6 @@ headers.anotherCustomHeader = ['foo', 'bar'];
 
 // @ts-expect-error -- Header values must be assignable to AxiosHeaderValue.
 headers.invalidHeader = Promise.resolve('foo');
+
+// @ts-expect-error -- Custom header fields cannot be functions.
+headers.invalidFunction = () => 'foo';

--- a/tests/module/cjs/tests/helpers/headers-types.ts
+++ b/tests/module/cjs/tests/helpers/headers-types.ts
@@ -1,0 +1,10 @@
+import axios = require('axios');
+
+const headers = new axios.AxiosHeaders({ x: 1 });
+
+headers.y = 2;
+headers.someCustomHeader = 'foo';
+headers.anotherCustomHeader = ['foo', 'bar'];
+
+// @ts-expect-error -- Header values must be assignable to AxiosHeaderValue.
+headers.invalidHeader = Promise.resolve('foo');

--- a/tests/module/cjs/tests/typings.module.test.cjs
+++ b/tests/module/cjs/tests/typings.module.test.cjs
@@ -25,4 +25,23 @@ describe('module cjs typings compatibility', () => {
       cleanupTempFixture(fixturePath);
     }
   });
+
+  it('type-checks AxiosHeaders custom fields', () => {
+    const sourcePath = path.join(repoRoot, 'tests/module/cjs/tests/helpers/headers-types.ts');
+    const fixturePath = createTempFixture(suiteRoot, 'headers-types-cjs', sourcePath, {
+      compilerOptions: {
+        ...tsconfig.compilerOptions,
+        baseUrl: '.',
+        paths: {
+          axios: ['../../../../index.d.cts'],
+        },
+      },
+    });
+
+    try {
+      runCommand('node', [tscBin, '--noEmit', '-p', 'tsconfig.json'], { cwd: fixturePath });
+    } finally {
+      cleanupTempFixture(fixturePath);
+    }
+  });
 });

--- a/tests/module/esm/tests/helpers/headers-types.ts
+++ b/tests/module/esm/tests/helpers/headers-types.ts
@@ -1,0 +1,10 @@
+import { AxiosHeaders } from '../../../../index.js';
+
+const headers = new AxiosHeaders({ x: 1 });
+
+headers.y = 2;
+headers.someCustomHeader = 'foo';
+headers.anotherCustomHeader = ['foo', 'bar'];
+
+// @ts-expect-error -- Header values must be assignable to AxiosHeaderValue.
+headers.invalidHeader = Promise.resolve('foo');

--- a/tests/module/esm/tests/helpers/headers-types.ts
+++ b/tests/module/esm/tests/helpers/headers-types.ts
@@ -8,3 +8,6 @@ headers.anotherCustomHeader = ['foo', 'bar'];
 
 // @ts-expect-error -- Header values must be assignable to AxiosHeaderValue.
 headers.invalidHeader = Promise.resolve('foo');
+
+// @ts-expect-error -- Custom header fields cannot be functions.
+headers.invalidFunction = () => 'foo';

--- a/tests/module/esm/tests/typings.module.test.js
+++ b/tests/module/esm/tests/typings.module.test.js
@@ -28,4 +28,17 @@ describe('module esm typings compatibility', () => {
       cleanupTempFixture(fixturePath);
     }
   });
+
+  it('type-checks AxiosHeaders custom fields', () => {
+    const sourcePath = path.join(repoRoot, 'tests/module/esm/tests/helpers/headers-types.ts');
+    const fixturePath = createTempFixture(suiteRoot, 'headers-types-esm', sourcePath, tsconfig, {
+      type: 'module',
+    });
+
+    try {
+      runCommand('node', [tscBin, '--noEmit', '-p', 'tsconfig.json'], { cwd: fixturePath });
+    } finally {
+      cleanupTempFixture(fixturePath);
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- Tighten the AxiosHeaders string index signature to accepted header values or declared methods in both ESM and CJS typings.
- Add module typing coverage for valid custom header fields and a rejected Promise assignment.
- Runtime behavior remains unchanged.

Fixes #7487

## Tests
- .\\node_modules\\.bin\\mocha --timeout 10000 tests\\typings.module.test.cjs (from tests/module/cjs)
- npx vitest run --config vitest.config.js --project module tests/typings.module.test.js (from tests/module/esm)
- npx prettier --check index.d.ts index.d.cts tests/module/esm/tests/typings.module.test.js tests/module/cjs/tests/typings.module.test.cjs tests/module/esm/tests/helpers/headers-types.ts tests/module/cjs/tests/helpers/headers-types.ts
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Constrain `AxiosHeaders` string index to valid header values while preserving declared method calls across ESM and CJS. Branded class methods so custom function fields are rejected; type-only change, no runtime impact.

**Description**
- Branded declared `AxiosHeaders` methods and typed them as properties to distinguish them from arbitrary functions.
- Narrowed `[key: string]` to `AxiosHeaderValueOrMethod` in `index.d.ts` and `index.d.cts` so custom fields accept only header values; methods remain callable.
- Added ESM/CJS type tests for custom fields: allow string/number/array; reject `Promise` and custom function assignments.
- Docs: update `/docs/` to list allowed custom header value types and note that promises/functions are not allowed.
- Fixes #7487.

**Semantic version impact**
- Patch: Type tightening only; may surface invalid TypeScript usages at compile time.

<sup>Written for commit d31a7a0d3c6f12ce46d6bc345e03313a45cb1011. Summary will update on new commits. <a href="https://cubic.dev/pr/axios/axios/pull/10941?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

