### PR TITLE
ci: stop caching npm (#10943)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,13 +24,11 @@ jobs:
           node-version: 26.x
           registry-url: "https://registry.npmjs.org"
           package-manager-cache: false
-      - name: Install SFW
-        run: npm install -g sfw
       - name: Pin npm with staged-publishing support
-        run: sfw npm install -g npm@11.15.0
+        run: npm install -g npm@11.15.0
       - name: Install dependencies
-        run: sfw npm ci --ignore-scripts
+        run: npm ci --ignore-scripts
       - name: Build project
-        run: sfw npm run build
+        run: npm run build
       - name: Publish to NPM (staged)
-        run: sfw npm stage publish --provenance --access public --tag v0x
+        run: npm stage publish --provenance --access public --tag v0x

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,13 +24,13 @@ jobs:
           node-version: 26.x
           registry-url: "https://registry.npmjs.org"
           package-manager-cache: false
-      # `npm stage publish` requires npm >= 11.15.0, newer than the npm bundled with
-      # this workflow's Node. Remove this step once Node bundles npm >= 11.15.0 by default.
+      - name: Install SFW
+        run: npm install -g sfw
       - name: Pin npm with staged-publishing support
-        run: npm install -g npm@11.15.0
+        run: sfw npm install -g npm@11.15.0
       - name: Install dependencies
-        run: npm ci --ignore-scripts
+        run: sfw npm ci --ignore-scripts
       - name: Build project
-        run: npm run build
+        run: sfw npm run build
       - name: Publish to NPM (staged)
-        run: npm stage publish --provenance --access public --tag v0x
+        run: sfw npm stage publish --provenance --access public --tag v0x

--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -36,14 +36,12 @@ jobs:
           node-version: ${{ matrix.node-version }}
           registry-url: "https://registry.npmjs.org"
           package-manager-cache: false
-      - name: Install SFW
-        run: npm install -g sfw
       - name: Install dependencies
-        run: sfw npm ci --ignore-scripts
+        run: npm ci --ignore-scripts
       - name: Build project
-        run: sfw npm run build
+        run: npm run build
       - name: Run tests
-        run: sfw npm run test
+        run: npm run test
 
   bump-version-and-create-pr:
     name: Bump version and create PR v0.x
@@ -65,10 +63,8 @@ jobs:
           node-version: 26.x
           registry-url: "https://registry.npmjs.org"
           package-manager-cache: false
-      - name: Install SFW
-        run: npm install -g sfw
       - name: Install dependencies
-        run: sfw npm ci --ignore-scripts
+        run: npm ci --ignore-scripts
       - name: NPM bump version
         id: bump
         run: |
@@ -77,9 +73,9 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "branch=release-v0x/version-$VERSION" >> "$GITHUB_OUTPUT"
       - name: Grunt version
-        run: sfw npm run preversion
+        run: npm run preversion
       - name: Build project
-        run: sfw npm run build
+        run: npm run build
       - name: Create pull request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:

--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -34,13 +34,16 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: ${{ matrix.node-version }}
-          cache: npm
+          registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
+      - name: Install SFW
+        run: npm install -g sfw
       - name: Install dependencies
-        run: npm ci --ignore-scripts
+        run: sfw npm ci --ignore-scripts
       - name: Build project
-        run: npm run build
+        run: sfw npm run build
       - name: Run tests
-        run: npm run test
+        run: sfw npm run test
 
   bump-version-and-create-pr:
     name: Bump version and create PR v0.x
@@ -60,9 +63,12 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 26.x
-          cache: npm
+          registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
+      - name: Install SFW
+        run: npm install -g sfw
       - name: Install dependencies
-        run: npm ci --ignore-scripts
+        run: sfw npm ci --ignore-scripts
       - name: NPM bump version
         id: bump
         run: |
@@ -71,9 +77,9 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "branch=release-v0x/version-$VERSION" >> "$GITHUB_OUTPUT"
       - name: Grunt version
-        run: npm run preversion
+        run: sfw npm run preversion
       - name: Build project
-        run: npm run build
+        run: sfw npm run build
       - name: Create pull request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:

--- a/.github/workflows/run-ci-v0.yml
+++ b/.github/workflows/run-ci-v0.yml
@@ -30,13 +30,16 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: ${{ matrix.node-version }}
-          cache: npm
+          registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
+      - name: Install SFW
+        run: npm install -g sfw
       - name: Install dependencies
-        run: npm ci --ignore-scripts
+        run: swf npm ci --ignore-scripts
       - name: Build project
-        run: npm run build
+        run: sfw npm run build
       - name: Run tests
-        run: npm run test
+        run: sfw npm run test
       - name: Dependency Review
         uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
-        if: matrix.node-version == '24.x'
+        if: matrix.node-version == '26.x'

--- a/.github/workflows/run-ci-v0.yml
+++ b/.github/workflows/run-ci-v0.yml
@@ -32,14 +32,12 @@ jobs:
           node-version: ${{ matrix.node-version }}
           registry-url: "https://registry.npmjs.org"
           package-manager-cache: false
-      - name: Install SFW
-        run: npm install -g sfw
       - name: Install dependencies
-        run: swf npm ci --ignore-scripts
+        run: npm ci --ignore-scripts
       - name: Build project
-        run: sfw npm run build
+        run: npm run build
       - name: Run tests
-        run: sfw npm run test
+        run: npm run test
       - name: Dependency Review
         uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
         if: matrix.node-version == '26.x'


### PR DESCRIPTION
## Summary

Use sfw on all workflows, also stop caching npm

## Linked issue

N/A

## Changes

N/A

#### Checklist

- [x] Tests added or updated (or N/A with reason)
- [ ] Docs / types updated if public API changed (`index.d.ts` and `index.d.cts`)
- [x] No breaking changes (or called out explicitly above)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable `npm` caching and standardize Node setup across CI to make builds deterministic. Pin `npm@11.15.0` for staged publish, run Dependency Review on Node `26.x`, and revert the earlier `sfw` changes.

## Description

- Summary of changes
  - Set `actions/setup-node` `registry-url` and `package-manager-cache: false` in `release-branch.yml` and `run-ci-v0.yml`.
  - Keep `npm@11.15.0` pin in `publish.yml` for `npm stage publish`.
  - Run Dependency Review only on Node `26.x`.
  - Clean up comments and revert `sfw` adoption (workflows use plain `npm`).

- Reasoning
  - Avoid stale caches and ensure fresh installs for reliable builds and publish.
  - Use a consistent, modern Node version for dependency scanning.
  - Revert `sfw` pending follow-up to reduce CI risk.

- Additional context
  - CI-only changes; no source or public API changes.

## Docs

- Update `/docs/` CI guidance:
  - Note that `npm` cache is disabled in CI and `registry-url` is set.
  - Document that staged publish pins `npm@11.15.0`.
  - Remove/adjust any mention of using `sfw` in CI for now.

## Testing

- No tests added or changed.
- Validate CI:
  - `publish.yml` staged publish still succeeds with pinned `npm`.
  - `release-branch.yml` build/test flow works with cache disabled.
  - `run-ci-v0.yml` matrix runs and Dependency Review triggers only on Node `26.x`.

## Semantic version impact

- No semantic version impact (CI-only). If a release is cut, classify as patch.

<sup>Written for commit a5baa80d039d914cbbcaafe2f7316607e68eb77c. Summary will update on new commits. <a href="https://cubic.dev/pr/axios/axios/pull/10943?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

