### PR TITLE
docs: update threatmodel to include stance on runtime modification

### DIFF
--- a/THREATMODEL.md
+++ b/THREATMODEL.md
@@ -239,6 +239,7 @@ axios will **not**:
 - Warn when TLS validation is disabled via a custom agent.
 - Redact `config` from thrown errors - the caller may legitimately need it for retry logic.
 - Defend against a fully compromised caller process (e.g. attacker-controlled code running inside the caller). Note: for the narrower case of a **polluted `Object.prototype` arriving via a transitive dependency**, axios _does_ defend the reachable config-read gadgets (see T-R4b) — but any new config-read path must continue to use `hasOwnProp` guards to stay on this side of the line.
+- Defend against monkey-patched JavaScript or Node.js runtime APIs (`Object.keys`, `http.request`, `ClientRequest.prototype.setHeader`, `fetch`, etc.). If attacker-controlled code is already running in the same process, it can observe or alter requests below axios and this is outside axios' security boundary.
 
 ---
 


### PR DESCRIPTION
## Summary

Update threat model to include stance on runtime modification

## Linked issue

N/A

## Changes

N/A

#### Checklist

- [ ] Tests added or updated (or N/A with reason)
- [x] Docs/types updated if public API changed (`index.d.ts` and `index.d.cts`)
- [ ] No breaking changes (or called out explicitly above)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the threat model: `axios` does not defend against monkey‑patched JavaScript/Node.js runtime APIs when attacker code runs in the same process. This sets a clear security boundary.

**Description**
- Summary of changes: Add a note to THREATMODEL.md stating `axios` won’t defend against patched runtime APIs like `Object.keys`, `http.request`, `ClientRequest.prototype.setHeader`, or `fetch`.
- Reasoning: If attacker-controlled code runs in the same process, it can observe or alter requests below `axios`; this is outside `axios`’ security boundary.
- Additional context: This does not change existing guidance about guarding config reads against polluted `Object.prototype`.

**Docs**
- Mirror this clarification in `/docs/security/threat-model.md` (or equivalent), and link to it from any security overview page.

**Testing**
- No tests added. Docs-only change; tests not needed.

**Semantic version impact**
- No runtime or API changes. No release needed (docs-only).

<sup>Written for commit 1d206f3d87ff303ed002e77ec6429ea963f0bfd7. Summary will update on new commits. <a href="https://cubic.dev/pr/axios/axios/pull/10945?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

