### PR TITLE
fix(http): guard socket.setKeepAlive for proxy agent streams (fixes #10908)

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -1110,7 +1110,11 @@ export default isHttpAdapterSupported &&
 
       req.on('socket', function handleRequestSocket(socket) {
         // default interval of sending ack packet is 1 minute
-        socket.setKeepAlive(true, 1000 * 60);
+        // Guard against proxy agents that provide a generic stream without
+        // a TCP `setKeepAlive` method (see issue #10908).
+        if (socket && typeof socket.setKeepAlive === 'function') {
+          socket.setKeepAlive(true, 1000 * 60);
+        }
 
         // Install a single 'error' listener per socket (not per request) to avoid
         // accumulating listeners on pooled keep-alive sockets that get reassigned


### PR DESCRIPTION
# fix(http): guard socket.setKeepAlive for proxy agent streams (fixes #10908)

Closes #10908

## Problem
Some proxy agents return generic Duplex streams (not `net.Socket`) which do not implement `setKeepAlive`. Calling `socket.setKeepAlive(...)` unguarded in the HTTP adapter causes a runtime `TypeError`.

## What I changed
- Added a defensive guard in http.js so `setKeepAlive` is called only when present:

```diff
-    socket.setKeepAlive(true, 1000 * 60);
+    if (socket && typeof socket.setKeepAlive === 'function') {
+      socket.setKeepAlive(true, 1000 * 60);
+    }
```

## Why
- Minimal, non-breaking defensive fix that prevents exceptions when using proxy agents that provide non-TCP streams.
- Keeps behavior unchanged for normal `net.Socket` sockets.

## Tests
Ran unit tests locally:

```bash
npm ci
npm run test:vitest:unit
# All unit tests passed (801 tests)
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guarded `socket.setKeepAlive` in the HTTP adapter to handle proxy agents that return generic streams, preventing a runtime TypeError. This keeps normal `net.Socket` behavior unchanged.

**Description**
- Summary of changes: Call `setKeepAlive` only if the socket has the method.
- Reasoning: Some proxy agents provide Duplex streams without `setKeepAlive`, causing crashes.
- Additional context: Fixes #10908; minimal, defensive change.

**Docs**
- Suggest adding a note in `/docs/` for the HTTP adapter explaining keep-alive is applied only when supported by the underlying socket (common with proxy agents).

**Testing**
- No new tests added.
- All existing unit tests pass locally.
- Recommend a small unit test that mocks a Duplex without `setKeepAlive` to ensure no error is thrown.

**Semantic version impact**
- Patch (bug fix, no breaking changes).

<sup>Written for commit eb0b2006ed099bd44480b682e534deb5e212d067. Summary will update on new commits. <a href="https://cubic.dev/pr/axios/axios/pull/10949?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

