### PR TITLE
fix: correct isCancel type to narrow to CanceledError<T>

### DIFF
--- a/PRE_RELEASE_CHANGELOG.md
+++ b/PRE_RELEASE_CHANGELOG.md
@@ -11,6 +11,7 @@
 - **AxiosHeaders:** Silently skip empty response header names emitted by some React Native Android responses instead of throwing. (**#6959**, **#10875**)
 - **Config Security:** Ignore inherited `params` and `paramsSerializer` values when resolving request config, preventing prototype-pollution gadgets from changing serialized URLs. (**#10922**)
 - **Types:** Add the missing readonly `name: 'CanceledError'` declaration to CommonJS `CanceledError` typings to match the ESM declarations. (**#10922**)
+- **Types:** Correct the CommonJS `isCancel` type guard to narrow cancellation errors to `CanceledError<T>`, matching the ESM declaration. (**#10952**)
 - **HTTP Adapter - Auth on Redirect:** HTTP Basic credentials supplied via `config.auth` are now restored on same-origin redirects, fixing a regression caused by `follow-redirects` >= 1.15.8 that broke `POST` requests answered with a 303 Location. Cross-origin redirects continue to drop credentials, preserving the existing T-R2 mitigation in `THREATMODEL.md`. (**#6929**)
 - **HTTP Adapter - Socket Path:** Ignore inherited `socketPath` and `allowedSocketPaths` config values when building Node.js requests, preventing prototype-pollution SSRF via Unix sockets. (**#10901**)
 - **React Native FormData:** Clear the default `Content-Type` header for React Native `FormData` requests so Android can build multipart bodies with the correct boundary. (**#10898**)

--- a/index.d.cts
+++ b/index.d.cts
@@ -694,7 +694,7 @@ declare namespace axios {
     CanceledError: typeof CanceledError;
     HttpStatusCode: typeof HttpStatusCode;
     readonly VERSION: string;
-    isCancel(value: any): value is Cancel;
+    isCancel<T = any>(value: any): value is CanceledError<T>;
     all<T>(values: Array<T | Promise<T>>): Promise<T[]>;
     spread<T, R>(callback: (...args: T[]) => R): (array: T[]) => R;
     isAxiosError<T = any, D = any>(payload: any): payload is AxiosError<T, D>;

--- a/tests/module/cjs/tests/helpers/cjs-is-cancel-typing.ts
+++ b/tests/module/cjs/tests/helpers/cjs-is-cancel-typing.ts
@@ -1,0 +1,10 @@
+import axios = require('axios');
+
+declare const thrown: unknown;
+
+if (axios.isCancel<{ ok: true }>(thrown)) {
+  const canceled: InstanceType<typeof axios.CanceledError> = thrown;
+  const data: { ok: true } | undefined = thrown.response?.data;
+
+  console.log(canceled.message, data);
+}

--- a/tests/module/cjs/tests/helpers/cjs-is-cancel-typing.ts
+++ b/tests/module/cjs/tests/helpers/cjs-is-cancel-typing.ts
@@ -5,6 +5,8 @@ declare const thrown: unknown;
 if (axios.isCancel<{ ok: true }>(thrown)) {
   const canceled: InstanceType<typeof axios.CanceledError> = thrown;
   const data: { ok: true } | undefined = thrown.response?.data;
+  // @ts-expect-error -- The generic response data must not be widened to any.
+  const wrongData: { ok: false } | undefined = thrown.response?.data;
 
-  console.log(canceled.message, data);
+  console.log(canceled.message, data, wrongData);
 }

--- a/tests/module/cjs/tests/typings.module.test.cjs
+++ b/tests/module/cjs/tests/typings.module.test.cjs
@@ -25,4 +25,15 @@ describe('module cjs typings compatibility', () => {
       cleanupTempFixture(fixturePath);
     }
   });
+
+  it('narrows isCancel to CanceledError in commonjs typings', () => {
+    const sourcePath = path.join(repoRoot, 'tests/module/cjs/tests/helpers/cjs-is-cancel-typing.ts');
+    const fixturePath = createTempFixture(suiteRoot, 'typings-cjs-is-cancel', sourcePath, tsconfig);
+
+    try {
+      runCommand('node', [tscBin, '--noEmit', '-p', 'tsconfig.json'], { cwd: fixturePath });
+    } finally {
+      cleanupTempFixture(fixturePath);
+    }
+  });
 });


### PR DESCRIPTION
The isCancel type guard in index.d.cts was returning value is Cancel which doesn't match the actual runtime isCancel checks for CanceledError, not Cancel. This updates it to value is CanceledError<T> so TypeScript correctly narrows the type when using the guard.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `axios.isCancel` in CommonJS typings to narrow to `CanceledError<T>`, matching ESM and runtime, and adds CJS typing tests to verify narrowing and that the generic `T` is preserved.

## Description

Use this section for review hints, explanations or discussion points.

- Summary of changes
  - Update `index.d.cts` to `isCancel<T = any>(value: any): value is CanceledError<T>;`
  - Add CJS typing fixture asserting narrowing and generic preservation; run via `tsc --noEmit`
  - Note the change in `PRE_RELEASE_CHANGELOG.md`
- Reasoning
  - Align CJS types with runtime and ESM and preserve generic response data
- Additional context
  - Type-only change; may expose compile-time errors where `Cancel` or widened `any` was assumed

## Docs

Update `/docs/` to show `isCancel` identifies `CanceledError` and keeps generic response types, with a short ESM and CJS example.

## Testing

Added `cjs-is-cancel-typing.ts` and a `typings.module.test.cjs` case that compiles with `tsc --noEmit`, asserting both narrowing to `CanceledError` and generic `T` preservation. No runtime tests needed.

## Semantic version impact

Patch: declaration fix aligning CommonJS types with existing runtime and ESM behavior.

<sup>Written for commit 4b8986964c7fafbbad503ee227f368a539907669. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/axios/axios/pull/10952?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

