### PR TITLE
chore: remove sponsor

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,27 +29,10 @@
         </td>
         <td align="center" width="50%">
             <a
-                href="https://hopper.security/?utm_source&#x3D;axios&amp;utm_medium&#x3D;readme_sponsorlist&amp;utm_campaign&#x3D;sponsorship"
-                style="padding: 10px; display: inline-block"
+                href="https://opencollective.com/axios/contribute"
                 target="_blank"
+                >💜 Become a sponsor</a
             >
-                <img
-                    width="90px"
-                    height="90px"
-                    src="https://images.opencollective.com/hopper-security/c4f7de2/avatar.png"
-                    alt="Hopper Security"
-                />
-            </a>
-            <p align="center">
-                Hopper provides a secure, open-source registry where every component is verified against malware and continuously remediated for vulnerabilities across all versions. In simple terms, Hopper removes the need to manage software supply chain risk altogether.
-            </p>
-            <p align="center">
-                <a
-                    href="https://hopper.security/?utm_source&#x3D;axios&amp;utm_medium&#x3D;readme_sponsorlist&amp;utm_campaign&#x3D;sponsorship"
-                    target="_blank"
-                    ><b>hopper.security</b></a
-                >
-            </p>
         </td>
     </tr>
 </table>


### PR DESCRIPTION
<!--
Thanks for contributing to axios! A few quick notes:
- For non-trivial changes, please open an issue first so we can discuss the approach.
- Follow Conventional Commits in your commit messages (see CONTRIBUTING.md).
- If you leave the description blank, our AI agent will draft one — feel free to edit afterwards.
-->

## Summary

<!-- What does this PR do, and why? -->

## Linked issue

<!-- e.g. Closes #1234 -->

## Changes

<!-- Bullet list of the notable changes. Keep it short. -->

-

#### Checklist

- [ ] Tests added or updated (or N/A with reason)
- [ ] Docs / types updated if public API changed (`index.d.ts` and `index.d.cts`)
- [ ] No breaking changes (or called out explicitly above)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the Hopper Security sponsor block from the README and replaced it with a single “💜 Become a sponsor” link to Open Collective to simplify and neutralize the sponsor section.

## Description

- Summary of changes
  - Removed vendor-specific sponsor content and image.
  - Added one link to https://opencollective.com/axios/contribute.
- Reasoning
  - Sponsor relationship ended and we want an evergreen sponsor CTA.
- Additional context
  - README-only change; no code or build impact.

## Docs

If the docs mention specific sponsors, update the sponsorship/support page in `/docs/` to point to the Open Collective link and remove vendor-specific references.

## Testing

No tests changed. None needed for a README-only update.

## Semantic version impact

No impact on runtime or API. No release required; if included in a release, classify as a patch (docs-only).

<sup>Written for commit 89e831db5842de573339021fbe6451b084aeee27. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/axios/axios/pull/10955?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

