### PR TITLE
fix: AxiosHeaders `toJSON()` return types

### DIFF
--- a/README.md
+++ b/README.md
@@ -2161,7 +2161,8 @@ Returns a new `AxiosHeaders` instance.
 ### AxiosHeaders#toJSON(asStrings?)
 
 ```
-toJSON(asStrings?: boolean): RawAxiosHeaders;
+toJSON(asStrings: true): Record<string, string>;
+toJSON(asStrings?: false): Record<string, string | string[]>;
 ```
 
 Resolve all internal header values into a new null prototype object.

--- a/index.d.cts
+++ b/index.d.cts
@@ -66,7 +66,8 @@ declare class AxiosHeaders {
     ...targets: Array<AxiosHeaders | axios.RawAxiosHeaders | string | undefined | null>
   ): AxiosHeaders;
 
-  toJSON(asStrings?: boolean): axios.RawAxiosHeaders;
+  toJSON(asStrings: true): Record<string, string>;
+  toJSON(asStrings?: false): Record<string, string | string[]>;
 
   static from(thing?: AxiosHeaders | axios.RawAxiosHeaders | string): AxiosHeaders;
 

--- a/index.d.cts
+++ b/index.d.cts
@@ -68,6 +68,7 @@ declare class AxiosHeaders {
 
   toJSON(asStrings: true): Record<string, string>;
   toJSON(asStrings?: false): Record<string, string | string[]>;
+  toJSON(asStrings?: boolean): Record<string, string | string[]>;
 
   static from(thing?: AxiosHeaders | axios.RawAxiosHeaders | string): AxiosHeaders;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -47,7 +47,8 @@ export class AxiosHeaders {
     ...targets: Array<AxiosHeaders | RawAxiosHeaders | string | undefined | null>
   ): AxiosHeaders;
 
-  toJSON(asStrings?: boolean): RawAxiosHeaders;
+  toJSON(asStrings: true): Record<string, string>;
+  toJSON(asStrings?: false): Record<string, string | string[]>;
 
   static from(thing?: AxiosHeaders | RawAxiosHeaders | string): AxiosHeaders;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -49,6 +49,7 @@ export class AxiosHeaders {
 
   toJSON(asStrings: true): Record<string, string>;
   toJSON(asStrings?: false): Record<string, string | string[]>;
+  toJSON(asStrings?: boolean): Record<string, string | string[]>;
 
   static from(thing?: AxiosHeaders | RawAxiosHeaders | string): AxiosHeaders;
 


### PR DESCRIPTION
<!--
Thanks for contributing to axios! A few quick notes:
- For non-trivial changes, please open an issue first so we can discuss the approach.
- Follow Conventional Commits in your commit messages (see CONTRIBUTING.md).
- If you leave the description blank, our AI agent will draft one — feel free to edit afterwards.
-->

## Summary

Narrow AxiosHeaders `toJSON()` return types to match the real ones.