### PR TITLE
fix: various runtime crashes and type definition mismatches

### DIFF
--- a/PRE_RELEASE_CHANGELOG.md
+++ b/PRE_RELEASE_CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## Bug Fixes
 
+- **Runtime and types hardening:** Guarded several edge-case crashes in cookie decoding, data URI parsing, form serialization, config merging, option validation, XHR cleanup, and Node HTTP URL serialization error handling. Type declarations now expose missing `CanceledError`, `CancelToken`, `AxiosHeaders`, `SerializerOptions`, and Cloudflare 52x status-code members that already exist at runtime. (**#10959**)
 - **HTTP Adapter - native env proxy:** Avoid double-applying environment proxy handling when Node.js native HTTP proxy support is active for the selected agent. Axios still resolves env proxies itself when the selected agent is not using Node's `proxyEnv` support. (**#10942**, closes **#7299**)
 - **HTTP Adapter - socketPath:** Path-only request URLs (e.g. `'/foo'`) now work again with `config.socketPath`, fixing the `TypeError [ERR_INVALID_URL]` regression introduced in 1.7.4 when `new URL()` was added to the dispatch path. A synthetic `http://localhost` base is supplied only when an own `socketPath` is set, so absolute URLs, non-socket requests, and prototype-polluted `socketPath` values are unaffected. (**#6611**)
 

--- a/PRE_RELEASE_DOCS.md
+++ b/PRE_RELEASE_DOCS.md
@@ -20,6 +20,16 @@ Do not store raw diffs or line-number-only instructions here; prefer stable sect
 
 ## Unreleased
 
+### Runtime and type declaration hardening
+
+- **Change:** Document the runtime edge-case fixes and public type declaration additions.
+- **Source:** `PRE_RELEASE_CHANGELOG.md` Bug Fixes, #10959.
+- **Status:** Pending.
+- **Docs targets:** `README.md` cancellation section; `README.md` `AxiosHeaders` section; `README.md` FormData serializer section; generated docs pages for cancellation, headers, and multipart/urlencoded form serialization; translated docs after English docs are finalized.
+- **Required content:** Note that `CancelToken.subscribe`, `CancelToken.unsubscribe`, `CancelToken.toAbortSignal`, `CanceledError` constructor/`__CANCEL__`, `AxiosHeaders#set(Iterable)`, `AxiosHeaders#toString()`, `SerializerOptions.maxDepth`, `SerializerOptions.Blob`, and `axios.Cancel` typings now match the runtime API. Release notes should also mention the cookie, data URI, form serialization, config validation, XHR cleanup, and Node HTTP adapter error-shape hardening.
+- **Examples:** Consider a short `CancelToken.toAbortSignal()` example and an `AxiosHeaders#set(new Map(...))` example if the docs section is updated.
+- **Notes:** Keep this as release-preparation tracking. Do not imply that `CancelToken` is no longer deprecated.
+
 ### Node native env proxy interaction
 
 - **Change:** Document how the Node.js HTTP adapter interacts with Node native environment proxy handling.

--- a/index.d.cts
+++ b/index.d.cts
@@ -50,6 +50,7 @@ declare class AxiosHeaders {
     rewrite?: boolean | AxiosHeaderMatcher
   ): AxiosHeaders;
   set(headers?: axios.RawAxiosHeaders | AxiosHeaders | string, rewrite?: boolean): AxiosHeaders;
+  set(headers?: Iterable<[string, axios.AxiosHeaderValue]>, rewrite?: boolean): AxiosHeaders;
 
   get(headerName: string, parser: RegExp): RegExpExecArray | null;
   get(headerName: string, matcher?: true | AxiosHeaderParser): axios.AxiosHeaderValue;
@@ -119,6 +120,8 @@ declare class AxiosHeaders {
 
   getSetCookie(): string[];
 
+  toString(): string;
+
   [Symbol.iterator](): IterableIterator<[string, axios.AxiosHeaderValue]>;
 }
 
@@ -165,7 +168,9 @@ declare class AxiosError<T = unknown, D = any> extends Error {
 }
 
 declare class CanceledError<T> extends AxiosError<T> {
+  constructor(message?: string, config?: axios.InternalAxiosRequestConfig, request?: any);
   readonly name: 'CanceledError';
+  __CANCEL__?: boolean;
 }
 
 declare class Axios {
@@ -296,6 +301,12 @@ declare enum HttpStatusCode {
   LoopDetected = 508,
   NotExtended = 510,
   NetworkAuthenticationRequired = 511,
+  WebServerIsDown = 521,
+  ConnectionTimedOut = 522,
+  OriginIsUnreachable = 523,
+  TimeoutOccurred = 524,
+  SslHandshakeFailed = 525,
+  InvalidSslCertificate = 526,
 }
 
 type InternalAxiosError<T = unknown, D = any> = AxiosError<T, D>;
@@ -428,6 +439,8 @@ declare namespace axios {
     dots?: boolean;
     metaTokens?: boolean;
     indexes?: boolean | null;
+    maxDepth?: number;
+    Blob?: { new (...args: any[]): any };
   }
 
   // tslint:disable-next-line
@@ -625,6 +638,9 @@ declare namespace axios {
     promise: Promise<Cancel>;
     reason?: Cancel;
     throwIfRequested(): void;
+    subscribe(listener: (cancel: Cancel | any) => void): void;
+    unsubscribe(listener: (cancel: Cancel | any) => void): void;
+    toAbortSignal(): AbortSignal;
   }
 
   interface CancelTokenSource {
@@ -691,7 +707,7 @@ declare namespace axios {
   }
 
   interface AxiosStatic extends AxiosInstance {
-    Cancel: CancelStatic;
+    Cancel: typeof CanceledError;
     CancelToken: CancelTokenStatic;
     Axios: typeof Axios;
     AxiosError: typeof AxiosError;

--- a/index.d.ts
+++ b/index.d.ts
@@ -31,6 +31,7 @@ export class AxiosHeaders {
     rewrite?: boolean | AxiosHeaderMatcher
   ): AxiosHeaders;
   set(headers?: RawAxiosHeaders | AxiosHeaders | string, rewrite?: boolean): AxiosHeaders;
+  set(headers?: Iterable<[string, AxiosHeaderValue]>, rewrite?: boolean): AxiosHeaders;
 
   get(headerName: string, parser: RegExp): RegExpExecArray | null;
   get(headerName: string, matcher?: true | AxiosHeaderParser): AxiosHeaderValue;
@@ -90,6 +91,8 @@ export class AxiosHeaders {
   hasAuthorization(matcher?: AxiosHeaderMatcher): boolean;
 
   getSetCookie(): string[];
+
+  toString(): string;
 
   [Symbol.iterator](): IterableIterator<[string, AxiosHeaderValue]>;
 }
@@ -233,6 +236,12 @@ export enum HttpStatusCode {
   LoopDetected = 508,
   NotExtended = 510,
   NetworkAuthenticationRequired = 511,
+  WebServerIsDown = 521,
+  ConnectionTimedOut = 522,
+  OriginIsUnreachable = 523,
+  TimeoutOccurred = 524,
+  SslHandshakeFailed = 525,
+  InvalidSslCertificate = 526,
 }
 
 type UppercaseMethod =
@@ -315,6 +324,8 @@ export interface SerializerOptions {
   dots?: boolean;
   metaTokens?: boolean;
   indexes?: boolean | null;
+  maxDepth?: number;
+  Blob?: { new (...args: any[]): any };
 }
 
 // tslint:disable-next-line
@@ -538,7 +549,9 @@ export class AxiosError<T = unknown, D = any> extends Error {
 }
 
 export class CanceledError<T> extends AxiosError<T> {
+  constructor(message?: string, config?: InternalAxiosRequestConfig, request?: any);
   readonly name: 'CanceledError';
+  __CANCEL__?: boolean;
 }
 
 export type AxiosPromise<T = any> = Promise<AxiosResponse<T>>;
@@ -564,6 +577,9 @@ export interface CancelToken {
   promise: Promise<Cancel>;
   reason?: Cancel;
   throwIfRequested(): void;
+  subscribe(listener: (cancel: Cancel | any) => void): void;
+  unsubscribe(listener: (cancel: Cancel | any) => void): void;
+  toAbortSignal(): AbortSignal;
 }
 
 export interface CancelTokenSource {
@@ -716,7 +732,7 @@ export function mergeConfig<D = any>(
 export function create(config?: CreateAxiosDefaults): AxiosInstance;
 
 export interface AxiosStatic extends AxiosInstance {
-  Cancel: CancelStatic;
+  Cancel: typeof CanceledError;
   CancelToken: CancelTokenStatic;
   Axios: typeof Axios;
   AxiosError: typeof AxiosError;

--- a/lib/adapters/adapters.js
+++ b/lib/adapters/adapters.js
@@ -107,7 +107,7 @@ function getAdapter(adapters, config) {
 
     throw new AxiosError(
       `There is no suitable adapter to dispatch the request ` + s,
-      'ERR_NOT_SUPPORT'
+      AxiosError.ERR_NOT_SUPPORT
     );
   }
 

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -874,11 +874,7 @@ export default isHttpAdapterSupported &&
           own('paramsSerializer')
         ).replace(/^\?/, '');
       } catch (err) {
-        const customErr = new Error(err.message);
-        customErr.config = config;
-        customErr.url = own('url');
-        customErr.exists = true;
-        return reject(customErr);
+        return reject(AxiosError.from(err, AxiosError.ERR_BAD_REQUEST, config));
       }
 
       headers.set(

--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -218,6 +218,7 @@ export default isXHRAdapterSupported &&
             config
           )
         );
+        done();
         return;
       }
 

--- a/lib/core/mergeConfig.js
+++ b/lib/core/mergeConfig.js
@@ -16,6 +16,7 @@ const headersToObject = (thing) => (thing instanceof AxiosHeaders ? { ...thing }
  */
 export default function mergeConfig(config1, config2) {
   // eslint-disable-next-line no-param-reassign
+  config1 = config1 || {};
   config2 = config2 || {};
 
   // Use a null-prototype object so that downstream reads such as `config.auth`

--- a/lib/helpers/buildURL.js
+++ b/lib/helpers/buildURL.js
@@ -32,6 +32,7 @@ export default function buildURL(url, params, options) {
   if (!params) {
     return url;
   }
+  url = url || '';
 
   const _options = utils.isFunction(options)
     ? {

--- a/lib/helpers/composeSignals.js
+++ b/lib/helpers/composeSignals.js
@@ -45,7 +45,7 @@ const composeSignals = (signals, timeout) => {
     signals = null;
   };
 
-  signals.forEach((signal) => signal.addEventListener('abort', onabort));
+  signals.forEach((signal) => signal.addEventListener('abort', onabort, { once: true }));
 
   const { signal } = controller;
 

--- a/lib/helpers/cookies.js
+++ b/lib/helpers/cookies.js
@@ -40,7 +40,11 @@ export default platform.hasStandardBrowserEnv
           const cookie = cookies[i].replace(/^\s+/, '');
           const eq = cookie.indexOf('=');
           if (eq !== -1 && cookie.slice(0, eq) === name) {
-            return decodeURIComponent(cookie.slice(eq + 1));
+            try {
+              return decodeURIComponent(cookie.slice(eq + 1));
+            } catch (e) {
+              return cookie.slice(eq + 1);
+            }
           }
         }
         return null;

--- a/lib/helpers/fromDataURI.js
+++ b/lib/helpers/fromDataURI.js
@@ -42,14 +42,16 @@ export default function fromDataURI(uri, asBlob, options) {
 
     // RFC 2397 section 3: default mediatype is text/plain;charset=US-ASCII
     // Bare `data:,` leaves mime undefined; Blob normalises that to "" per spec.
-    let mime;
+    let mime = '';
     if (type) {
       mime = params ? type + params : type;
     } else if (params) {
       mime = 'text/plain' + params;
     }
 
-    const buffer = Buffer.from(decodeURIComponent(body), encoding);
+    const buffer = encoding === 'base64'
+      ? Buffer.from(body, 'base64')
+      : Buffer.from(decodeURIComponent(body), encoding);
 
     if (asBlob) {
       if (!_Blob) {

--- a/lib/helpers/resolveConfig.js
+++ b/lib/helpers/resolveConfig.js
@@ -1,5 +1,6 @@
 import platform from '../platform/index.js';
 import utils from '../utils.js';
+import AxiosError from '../core/AxiosError.js';
 import isURLSameOrigin from './isURLSameOrigin.js';
 import cookies from './cookies.js';
 import buildFullPath from '../core/buildFullPath.js';
@@ -15,7 +16,7 @@ function setFormDataHeaders(headers, formHeaders, policy) {
     return;
   }
 
-  Object.entries(formHeaders).forEach(([key, val]) => {
+  Object.entries(formHeaders || {}).forEach(([key, val]) => {
     if (FORM_DATA_CONTENT_HEADERS.includes(key.toLowerCase())) {
       headers.set(key, val);
     }
@@ -65,10 +66,14 @@ function resolveConfig(config) {
     const username = utils.getSafeProp(auth, 'username') || '';
     const password = utils.getSafeProp(auth, 'password') || '';
 
-    headers.set(
-      'Authorization',
-      'Basic ' + btoa(username + ':' + (password ? encodeUTF8(password) : ''))
-    );
+    try {
+      headers.set(
+        'Authorization',
+        'Basic ' + btoa(username + ':' + (password ? encodeUTF8(password) : ''))
+      );
+    } catch (e) {
+      throw AxiosError.from(e, AxiosError.ERR_BAD_OPTION_VALUE, config);
+    }
   }
 
   if (utils.isFormData(data)) {

--- a/lib/helpers/toFormData.js
+++ b/lib/helpers/toFormData.js
@@ -143,7 +143,13 @@ function toFormData(obj, formData, options) {
     }
 
     if (utils.isArrayBuffer(value) || utils.isTypedArray(value)) {
-      return useBlob && typeof Blob === 'function' ? new Blob([value]) : Buffer.from(value);
+      if (useBlob && typeof _Blob === 'function') {
+        return new _Blob([value]);
+      }
+      if (typeof Buffer !== 'undefined') {
+        return Buffer.from(value);
+      }
+      throw new AxiosError('Blob is not supported. Use a Buffer instead.', AxiosError.ERR_NOT_SUPPORT);
     }
 
     return value;

--- a/lib/helpers/validator.js
+++ b/lib/helpers/validator.js
@@ -79,7 +79,7 @@ validators.spelling = function spelling(correctSpelling) {
  */
 
 function assertOptions(options, schema, allowUnknown) {
-  if (typeof options !== 'object') {
+  if (typeof options !== 'object' || options === null) {
     throw new AxiosError('options must be an object', AxiosError.ERR_BAD_OPTION_VALUE);
   }
   const keys = Object.keys(options);

--- a/tests/browser/cookies.browser.test.js
+++ b/tests/browser/cookies.browser.test.js
@@ -75,6 +75,27 @@ describe('helpers::cookies (vitest browser)', () => {
     expect(document.cookie).toBe('foo=bar%20baz%25');
   });
 
+  it('returns raw cookie value when it is not valid URI encoding', () => {
+    const descriptor = Object.getOwnPropertyDescriptor(document, 'cookie');
+
+    Object.defineProperty(document, 'cookie', {
+      configurable: true,
+      get() {
+        return 'foo=bar%';
+      },
+    });
+
+    try {
+      expect(cookies.read('foo')).toBe('bar%');
+    } finally {
+      if (descriptor) {
+        Object.defineProperty(document, 'cookie', descriptor);
+      } else {
+        delete document.cookie;
+      }
+    }
+  });
+
   it('matches cookie names exactly even when the name contains regex metacharacters', () => {
     // previously cookies.read built a RegExp by interpolating
     // the requested name. Metacharacters could match a different cookie or trigger

--- a/tests/browser/requests.browser.test.js
+++ b/tests/browser/requests.browser.test.js
@@ -533,4 +533,38 @@ describe('requests (vitest browser)', () => {
       message: 'Unsupported protocol ftp:',
     });
   });
+
+  it('should clean up cancellation listeners after unsupported protocol rejection', async () => {
+    const source = axios.CancelToken.source();
+    const controller = new AbortController();
+    let abortListenerCount = 0;
+    const nativeAdd = controller.signal.addEventListener.bind(controller.signal);
+    const nativeRemove = controller.signal.removeEventListener.bind(controller.signal);
+
+    controller.signal.addEventListener = (type, fn, options) => {
+      if (type === 'abort') {
+        abortListenerCount++;
+      }
+      return nativeAdd(type, fn, options);
+    };
+    controller.signal.removeEventListener = (type, fn, options) => {
+      if (type === 'abort') {
+        abortListenerCount--;
+      }
+      return nativeRemove(type, fn, options);
+    };
+
+    await expect(
+      axios.get('ftp:localhost', {
+        adapter: 'xhr',
+        cancelToken: source.token,
+        signal: controller.signal,
+      })
+    ).rejects.toMatchObject({
+      message: 'Unsupported protocol ftp:',
+    });
+
+    expect(source.token._listeners || []).toEqual([]);
+    expect(abortListenerCount).toBe(0);
+  });
 });

--- a/tests/module/cjs/tests/helpers/cjs-added-types.ts
+++ b/tests/module/cjs/tests/helpers/cjs-added-types.ts
@@ -1,0 +1,38 @@
+import axios = require('axios');
+
+const headers = new axios.AxiosHeaders();
+const iterableHeaders: Iterable<[string, axios.AxiosHeaderValue]> = [['x-test', 'ok']];
+headers.set(iterableHeaders);
+const serializedHeaders: string = headers.toString();
+
+const source = axios.CancelToken.source();
+source.token.subscribe((cancel) => {
+  const message: string | undefined = cancel && cancel.message;
+  console.log(message);
+});
+source.token.unsubscribe(() => {});
+const signal: AbortSignal = source.token.toAbortSignal();
+
+const cancel = new axios.CanceledError<{ ok: true }>(
+  'stop',
+  {} as axios.InternalAxiosRequestConfig,
+  {}
+);
+const cancelFlag: boolean | undefined = cancel.__CANCEL__;
+const cancelCtor: typeof axios.CanceledError = axios.Cancel;
+const cancelFromAlias = new cancelCtor('from alias');
+
+const status = axios.HttpStatusCode.WebServerIsDown;
+
+class CustomBlob {
+  constructor(_parts?: any[]) {}
+}
+
+const serializerOptions: axios.FormSerializerOptions = {
+  maxDepth: 2,
+  Blob: CustomBlob,
+};
+
+axios.toFormData({ file: new Uint8Array([1]) }, undefined, serializerOptions);
+
+console.log(serializedHeaders, signal.aborted, cancelFlag, cancelFromAlias.message, status);

--- a/tests/module/cjs/tests/typings.module.test.cjs
+++ b/tests/module/cjs/tests/typings.module.test.cjs
@@ -36,4 +36,15 @@ describe('module cjs typings compatibility', () => {
       cleanupTempFixture(fixturePath);
     }
   });
+
+  it('type-checks additive commonjs public typings', () => {
+    const sourcePath = path.join(repoRoot, 'tests/module/cjs/tests/helpers/cjs-added-types.ts');
+    const fixturePath = createTempFixture(suiteRoot, 'typings-cjs-added', sourcePath, tsconfig);
+
+    try {
+      runCommand('node', [tscBin, '--noEmit', '-p', 'tsconfig.json'], { cwd: fixturePath });
+    } finally {
+      cleanupTempFixture(fixturePath);
+    }
+  });
 });

--- a/tests/module/esm/tests/helpers/esm-added-types.ts
+++ b/tests/module/esm/tests/helpers/esm-added-types.ts
@@ -1,0 +1,46 @@
+import axios, {
+  AxiosHeaders,
+  CanceledError,
+  HttpStatusCode,
+  toFormData,
+  type AxiosHeaderValue,
+  type FormSerializerOptions,
+  type InternalAxiosRequestConfig,
+} from 'axios';
+
+const headers = new AxiosHeaders();
+const iterableHeaders: Iterable<[string, AxiosHeaderValue]> = [['x-test', 'ok']];
+headers.set(iterableHeaders);
+const serializedHeaders: string = headers.toString();
+
+const source = axios.CancelToken.source();
+source.token.subscribe((cancel) => {
+  const message: string | undefined = cancel && cancel.message;
+  console.log(message);
+});
+source.token.unsubscribe(() => {});
+const signal: AbortSignal = source.token.toAbortSignal();
+
+const cancel = new CanceledError<{ ok: true }>(
+  'stop',
+  {} as InternalAxiosRequestConfig,
+  {}
+);
+const cancelFlag: boolean | undefined = cancel.__CANCEL__;
+const cancelCtor: typeof CanceledError = axios.Cancel;
+const cancelFromAlias = new cancelCtor('from alias');
+
+const status: HttpStatusCode = HttpStatusCode.WebServerIsDown;
+
+class CustomBlob {
+  constructor(_parts?: any[]) {}
+}
+
+const serializerOptions: FormSerializerOptions = {
+  maxDepth: 2,
+  Blob: CustomBlob,
+};
+
+toFormData({ file: new Uint8Array([1]) }, undefined, serializerOptions);
+
+console.log(serializedHeaders, signal.aborted, cancelFlag, cancelFromAlias.message, status);

--- a/tests/module/esm/tests/typings.module.test.js
+++ b/tests/module/esm/tests/typings.module.test.js
@@ -28,4 +28,17 @@ describe('module esm typings compatibility', () => {
       cleanupTempFixture(fixturePath);
     }
   });
+
+  it('type-checks additive esm public typings', () => {
+    const sourcePath = path.join(repoRoot, 'tests/module/esm/tests/helpers/esm-added-types.ts');
+    const fixturePath = createTempFixture(suiteRoot, 'typings-esm-added', sourcePath, tsconfig, {
+      type: 'module',
+    });
+
+    try {
+      runCommand('node', [tscBin, '--noEmit', '-p', 'tsconfig.json'], { cwd: fixturePath });
+    } finally {
+      cleanupTempFixture(fixturePath);
+    }
+  });
 });

--- a/tests/unit/adapters/adapters.test.js
+++ b/tests/unit/adapters/adapters.test.js
@@ -1,6 +1,7 @@
 import { beforeEach, describe, it } from 'vitest';
 import assert from 'assert';
 import adapters from '../../../lib/adapters/adapters.js';
+import AxiosError from '../../../lib/core/AxiosError.js';
 
 describe('adapters', () => {
   const store = { ...adapters.adapters };
@@ -31,7 +32,15 @@ describe('adapters', () => {
 
   it('should detect adapter unsupported status', () => {
     adapters.adapters.testadapter = false;
-    assert.throws(() => adapters.getAdapter('testAdapter'), /is not supported by the environment/);
+    assert.throws(
+      () => adapters.getAdapter('testAdapter'),
+      (err) => {
+        assert.ok(err instanceof AxiosError);
+        assert.strictEqual(err.code, AxiosError.ERR_NOT_SUPPORT);
+        assert.match(err.message, /is not supported by the environment/);
+        return true;
+      }
+    );
   });
 
   it('should pick suitable adapter from the list', () => {

--- a/tests/unit/adapters/http.test.js
+++ b/tests/unit/adapters/http.test.js
@@ -1902,7 +1902,8 @@ describe('supports http with nodejs', () => {
           },
         }),
         (error) => {
-          assert.deepStrictEqual(error.exists, true);
+          assert.ok(error instanceof AxiosError, 'error should be an AxiosError');
+          assert.strictEqual(error.code, AxiosError.ERR_BAD_REQUEST);
           return true;
         }
       );

--- a/tests/unit/core/mergeConfig.test.js
+++ b/tests/unit/core/mergeConfig.test.js
@@ -4,6 +4,10 @@ import mergeConfig from '../../../lib/core/mergeConfig.js';
 import { AxiosHeaders } from '../../../index.js';
 
 describe('core::mergeConfig', () => {
+  it('accepts null for first argument', () => {
+    expect(mergeConfig(null, { url: '/foo' })).toEqual({ url: '/foo' });
+  });
+
   it('accepts undefined for second argument', () => {
     expect(mergeConfig(defaults, undefined)).toEqual(defaults);
   });

--- a/tests/unit/fromDataURI.test.js
+++ b/tests/unit/fromDataURI.test.js
@@ -11,6 +11,22 @@ describe('helpers::fromDataURI', () => {
     assert.deepStrictEqual(fromDataURI(dataURI, false), buffer);
   });
 
+  it('should not call decodeURIComponent for base64 data', () => {
+    const buffer = Buffer.from('123');
+    const originalDecodeURIComponent = globalThis.decodeURIComponent;
+    globalThis.decodeURIComponent = () => {
+      throw new Error('base64 body should not be URL decoded');
+    };
+
+    try {
+      const dataURI = 'data:application/octet-stream;base64,' + buffer.toString('base64');
+
+      assert.deepStrictEqual(fromDataURI(dataURI, false), buffer);
+    } finally {
+      globalThis.decodeURIComponent = originalDecodeURIComponent;
+    }
+  });
+
   it('should parse data URI with no mediatype and base64', () => {
     const buffer = Buffer.from('123');
     const dataURI = 'data:;base64,' + buffer.toString('base64');

--- a/tests/unit/helpers/buildURL.test.js
+++ b/tests/unit/helpers/buildURL.test.js
@@ -16,6 +16,10 @@ describe('helpers::buildURL', () => {
     ).toEqual('/foo?foo=bar');
   });
 
+  it('should support params with undefined url', () => {
+    expect(buildURL(undefined, { foo: 'bar' })).toEqual('?foo=bar');
+  });
+
   it('should support sending raw params to custom serializer func', () => {
     const serializer = vi.fn().mockReturnValue('foo=bar');
     const params = { foo: 'bar' };

--- a/tests/unit/helpers/composeSignals.test.js
+++ b/tests/unit/helpers/composeSignals.test.js
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import composeSignals from '../../../lib/helpers/composeSignals.js';
+
+describe('helpers::composeSignals', () => {
+  it('registers abort listeners as once-only listeners', () => {
+    const controller = new AbortController();
+    const calls = [];
+    const nativeAdd = controller.signal.addEventListener.bind(controller.signal);
+
+    controller.signal.addEventListener = (type, fn, options) => {
+      calls.push({ type, options });
+      return nativeAdd(type, fn, options);
+    };
+
+    const signal = composeSignals([controller.signal]);
+
+    try {
+      expect(calls).toHaveLength(1);
+      expect(calls[0]).toEqual({ type: 'abort', options: { once: true } });
+    } finally {
+      signal.unsubscribe();
+    }
+  });
+});

--- a/tests/unit/helpers/resolveConfig.test.js
+++ b/tests/unit/helpers/resolveConfig.test.js
@@ -1,6 +1,8 @@
 import { describe, it } from 'vitest';
 import assert from 'assert';
+import FormData from 'form-data';
 import resolveConfig from '../../../lib/helpers/resolveConfig.js';
+import AxiosError from '../../../lib/core/AxiosError.js';
 
 class ReactNativeFormData {
   append() {}
@@ -54,6 +56,40 @@ describe('helpers::resolveConfig', () => {
       delete Object.prototype.username;
       delete Object.prototype.password;
     }
+  });
+
+  it('should wrap invalid auth encoding as AxiosError', () => {
+    assert.throws(
+      () =>
+        resolveConfig({
+          url: '/foo',
+          auth: {
+            username: 'user',
+            password: '\uD800',
+          },
+        }),
+      (err) => {
+        assert.ok(err instanceof AxiosError);
+        assert.strictEqual(err.code, AxiosError.ERR_BAD_OPTION_VALUE);
+        return true;
+      }
+    );
+  });
+
+  it('should ignore null form-data headers with content-only policy', () => {
+    const data = new FormData();
+    data.getHeaders = () => null;
+
+    const config = resolveConfig({
+      url: '/upload',
+      data,
+      formDataHeaderPolicy: 'content-only',
+      headers: {
+        'X-Test': 'ok',
+      },
+    });
+
+    assert.strictEqual(config.headers.get('X-Test'), 'ok');
   });
 
   it('should ignore inherited nested serializer fields', () => {

--- a/tests/unit/helpers/validator.test.js
+++ b/tests/unit/helpers/validator.test.js
@@ -64,4 +64,17 @@ describe('validator::assertOptions', () => {
       );
     }).not.toThrow();
   });
+
+  it('should reject null options', () => {
+    let error;
+    try {
+      validator.assertOptions(null, {});
+    } catch (err) {
+      error = err;
+    }
+
+    expect(error).toBeInstanceOf(AxiosError);
+    expect(error.message).toBe('options must be an object');
+    expect(error.code).toBe(AxiosError.ERR_BAD_OPTION_VALUE);
+  });
 });

--- a/tests/unit/toFormData.test.js
+++ b/tests/unit/toFormData.test.js
@@ -66,6 +66,53 @@ describe('helpers::toFormData', () => {
     assert.ok(formData instanceof FormData);
   });
 
+  it('should use custom Blob constructor for typed array values', () => {
+    class CustomBlob {
+      constructor(parts) {
+        this.parts = parts;
+      }
+    }
+
+    const formData = {
+      calls: [],
+      append(key, value) {
+        this.calls.push([key, value]);
+      },
+      get [Symbol.toStringTag]() {
+        return 'FormData';
+      },
+      *[Symbol.iterator]() {}
+    };
+
+    const value = new Uint8Array([1, 2, 3]);
+    toFormData({ file: value }, formData, { Blob: CustomBlob });
+
+    assert.strictEqual(formData.calls.length, 1);
+    assert.strictEqual(formData.calls[0][0], 'file');
+    assert.ok(formData.calls[0][1] instanceof CustomBlob);
+    assert.deepStrictEqual(formData.calls[0][1].parts, [value]);
+  });
+
+  it('should throw AxiosError when typed array values require Buffer and Buffer is unavailable', () => {
+    const originalBuffer = globalThis.Buffer;
+    const formData = createRNFormDataSpy();
+
+    try {
+      globalThis.Buffer = undefined;
+
+      assert.throws(
+        () => toFormData({ file: new Uint8Array([1]) }, formData),
+        (err) => {
+          assert.ok(err instanceof AxiosError);
+          assert.strictEqual(err.code, AxiosError.ERR_NOT_SUPPORT);
+          return true;
+        }
+      );
+    } finally {
+      globalThis.Buffer = originalBuffer;
+    }
+  });
+
   it('should append root-level React Native blob without recursion', () => {
     const formData = createRNFormDataSpy();
 


### PR DESCRIPTION
This PR fixes 14 issues found while auditing the codebase for inconsistencies between the source and type declarations, null-safety gaps, and a couple of edge cases that crash requests.


Runtime fixes
- cookies.js: decodeURIComponent throws on plain cookie values (not everyone URL-encodes them). Wrapped in try/catch.

- fromDataURI.js: Was running decodeURIComponent on base64 data URIs, which corrupts the payload. Only decode when it's not base64.

- toFormData.js: Custom Blob constructor passed via options was being used for the capability check but ignored when actually creating the Blob, always fell back to the global one. Also guards Buffer.from against missing global in non-Node environments.

- composeSignals.js: Abort listeners were never auto-removed after firing. Added { once: true } so long-lived signals don't accumulate dead listeners.

- buildURL.js: Crashes with TypeError when called with params but an undefined URL. Added a guard.

- resolveConfig.js: encodeURIComponent explodes on lone surrogates in auth passwords. Also guards Object.entries against null from getHeaders().

- mergeConfig.js: mergeConfig(null, config) throws because hasOwnProperty.call(null, ...) isn't valid. Added the same null guard config2 already had.

- validator.js: typeof null === 'object' is a JS footgun transitional: null bypassed the type check and hit Object.keys(null).

- adapters.js: Hardcoded 'ERR_NOT_SUPPORT' string instead of the constant.

- xhr.js: Protocol rejection path returned early without calling done(), leaking cancel listeners.

- http.js: Raw Error was being thrown from the buildURL catch block instead of AxiosError.
Type fixes (index.d.ts + index.d.cts)

- Added 6 missing HTTP status codes (521-526) that exist in the source

- CanceledError had no explicit constructor signature and was missing __CANCEL__

- CancelToken was missing subscribe, unsubscribe, and toAbortSignal

- AxiosHeaders.set() was missing the iterable overload

- AxiosHeaders.toString() wasn't declared

- SerializerOptions was missing maxDepth and Blob

- axios.Cancel was typed as CancelStatic but at runtime it's just CanceledError

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes several runtime edge-case crashes and cleans up cancellation listeners, while updating TypeScript types to match runtime APIs. Improves stability across adapters and makes `axios` typings accurate, including new `CancelToken` methods, `AxiosHeaders` updates, and Cloudflare 52x status codes.

**Description**
- Summary of changes
  - Runtime hardening: safe cookie decoding; correct base64 handling in data URIs (and default empty mime to ""); respect custom `Blob` and guard `Buffer` in `toFormData`; once-only abort listeners in composed signals; ensure XHR protocol rejection calls `done()`; use `AxiosError.ERR_NOT_SUPPORT`; wrap URL build errors as `AxiosError`; guard undefined `url`; add null guards in `mergeConfig`/config validator; handle bad auth password encoding.
  - Types alignment: add HTTP 521–526; add `CanceledError` constructor and `__CANCEL__`; expose `axios.Cancel` as `typeof CanceledError`; add `CancelToken.subscribe/unsubscribe/toAbortSignal`; add iterable overload and `toString` on `AxiosHeaders`; extend `SerializerOptions` with `maxDepth` and `Blob`.
- Reasoning
  - Prevent crashes and listener leaks; make public typings reflect the runtime.
- Additional context
  - Changelog and pre-release docs updated to track these fixes and type additions.

**Docs**
- Update `/docs/` to note: new HTTP status codes; `CanceledError` details and `axios.Cancel` mapping; `CancelToken.subscribe/unsubscribe/toAbortSignal`; `AxiosHeaders` iterable `set` and `toString`; `SerializerOptions.maxDepth` and `Blob`; and the runtime hardening notes for cookies, data URIs, form serialization, config validation, XHR cleanup, and Node HTTP adapter error wrapping.

**Testing**
- Added: unit tests for cookies (raw values), data URI base64 handling and empty mime, composed signals `{ once: true }`, undefined `url` in `buildURL`, `mergeConfig` with null, validator rejecting null options, XHR cleanup on unsupported protocols, and `toFormData` with custom `Blob` and missing `Buffer`.
- Modified: Node HTTP adapter tests to expect `AxiosError` with `ERR_BAD_REQUEST` on URL build failures; adapter selection tests to assert `ERR_NOT_SUPPORT`.
- Added: ESM and CJS type-check fixtures covering `CanceledError`, `axios.Cancel`, `CancelToken` methods, `AxiosHeaders#set(Iterable)`/`toString`, `SerializerOptions.maxDepth`/`Blob`, and new 52x status codes.

**Semantic version impact**
- Patch: bug fixes and additive typing updates. Type corrections may surface compile-time issues where projects relied on previous inaccuracies, but no runtime breaking changes.

<sup>Written for commit 3fab3fa227ad6c30c548b69a31de8335161fd9a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/axios/axios/pull/10959?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

