### PR TITLE
feat: improve fetchOptions type definition

### DIFF
--- a/index.d.cts
+++ b/index.d.cts
@@ -551,8 +551,7 @@ declare namespace axios {
     withXSRFToken?: boolean | ((config: InternalAxiosRequestConfig) => boolean | undefined);
     parseReviver?: (this: any, key: string, value: any, context?: { source?: string }) => any;
     fetchOptions?:
-      | Omit<RequestInit, 'body' | 'headers' | 'method' | 'signal'>
-      | Record<string, any>;
+      | Omit<RequestInit, 'body' | 'headers' | 'method' | 'signal'>;
     httpVersion?: 1 | 2;
     http2Options?: Record<string, any> & {
       sessionTimeout?: number;


### PR DESCRIPTION
This PR addresses issue #6869.

The current fetchOptions type definition includes Record<string, any>, which reduces TypeScript type safety and IDE autocomplete support. This change updates the type definition to rely on RequestInit, which aligns with the Fetch API standard and improves developer experience.

Changes:

* Removed Record<string, any> from the fetchOptions type definition.
* Kept the existing RequestInit-based typing.

Related Issue:
#6869


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tighten `fetchOptions` typing to only allow `RequestInit` fields, removing `Record<string, any>`. This improves type safety and IDE autocomplete, and may surface invalid option usage at compile time.

## Description

- Summary of changes
  - Removed `Record<string, any>` from `fetchOptions`.
  - Kept `fetchOptions` as `Omit<RequestInit, 'body' | 'headers' | 'method' | 'signal'>`.
- Reasoning
  - Aligns with the Fetch API.
  - Improves DX via stricter types and better autocomplete.
- Additional context
  - Addresses #6869.

## Docs

Update `/docs/` to state that `fetchOptions` accepts only `RequestInit` fields (excluding `body`, `headers`, `method`, `signal`). Remove any mention of arbitrary custom keys.

## Testing

- No runtime behavior changes.
- Add or update a small TypeScript type test to ensure only valid `RequestInit` keys are accepted and invalid keys fail type-check.

## Semantic version impact

Breaking (types-only): narrows the public type and can cause new TypeScript errors for consumers passing non-`RequestInit` fields.

<sup>Written for commit 0573372aff6221ea8999380ad7aacf36d526f163. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/axios/axios/pull/10961?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

