### PR TITLE
fix(http): guard socket.setKeepAlive in proxy socket path

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -1118,7 +1118,9 @@ export default isHttpAdapterSupported &&
 
       req.on('socket', function handleRequestSocket(socket) {
         // default interval of sending ack packet is 1 minute
-        socket.setKeepAlive(true, 1000 * 60);
+        if (typeof socket.setKeepAlive === 'function') {
+          socket.setKeepAlive(true, 1000 * 60);
+        }
 
         // Install a single 'error' listener per socket (not per request) to avoid
         // accumulating listeners on pooled keep-alive sockets that get reassigned

--- a/tests/unit/adapters/http.test.js
+++ b/tests/unit/adapters/http.test.js
@@ -5317,6 +5317,56 @@ describe('supports http with nodejs', () => {
     assert.strictEqual(error.message, 'write EPIPE');
   });
 
+  it('should ignore socket keep-alive setup when socket.setKeepAlive is unavailable', async () => {
+    const socket = new EventEmitter();
+    socket.on('error', () => {});
+
+    const transport = {
+      request(_, cb) {
+        return new (class MockRequest extends EventEmitter {
+          constructor() {
+            super();
+            this.destroyed = false;
+          }
+
+          setTimeout() {}
+
+          write() {}
+
+          end() {
+            this.emit('socket', socket);
+
+            setImmediate(() => {
+              const response = stream.Readable.from(['ok']);
+              response.statusCode = 200;
+              response.headers = {};
+              cb(response);
+              this.emit('close');
+            });
+          }
+
+          destroy(err) {
+            if (this.destroyed) {
+              return;
+            }
+
+            this.destroyed = true;
+            err && this.emit('error', err);
+            this.emit('close');
+          }
+        })();
+      },
+    };
+
+    const response = await axios.get('http://example.com/', {
+      transport,
+      maxRedirects: 0,
+    });
+
+    assert.strictEqual(response.status, 200);
+    assert.strictEqual(response.data, 'ok');
+  });
+
   describe('keep-alive', () => {
     it('should not emit MaxListenersExceededWarning under concurrent requests through a pooled keep-alive agent (regression #10780)', async () => {
       const server = await startHTTPServer(


### PR DESCRIPTION
## What this fixes
- Prevents a TypeError when a proxy socket implementation does not expose setKeepAlive (issue #10908), which can happen with certain proxy agents.
- Keeps the existing socket error handling behavior intact while making keep-alive setup conditional.

## Validation
- npm run test:vitest:unit -- tests/unit/adapters/http.test.js

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guard the call to socket.setKeepAlive in the HTTP adapter to avoid a TypeError when using proxy transports that don’t implement it. This keeps existing socket error handling unchanged and maintains keep-alive where supported.

- **Description**
  - Call `socket.setKeepAlive` only when it exists in the proxy socket path of the HTTP adapter.
  - Fixes #10908 where some proxy agents don’t expose `setKeepAlive`.
  - Docs: If we document proxy agent compatibility, add a brief note in `/docs/` that keep-alive configuration is now conditional for proxy sockets.
  - Testing: Added a unit test that simulates a transport without `setKeepAlive` and verifies a 200 response via `axios`.
  - Semantic version impact: Patch. Bug fix with no breaking changes.

<sup>Written for commit 1115e4d1c08e068bc990534ee9b12d6975e7ce85. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/axios/axios/pull/10963?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

