### PR TITLE
fix(xhr): avoid document.cookie sync read via cookieStore

### DIFF
--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -7,15 +7,21 @@ import parseProtocol from '../helpers/parseProtocol.js';
 import platform from '../platform/index.js';
 import AxiosHeaders from '../core/AxiosHeaders.js';
 import { progressEventReducer } from '../helpers/progressEventReducer.js';
-import resolveConfig from '../helpers/resolveConfig.js';
+import resolveConfig, { resolveConfigAsync } from '../helpers/resolveConfig.js';
 import { toByteStringHeaderObject } from '../helpers/sanitizeHeaderValue.js';
 
 const isXHRAdapterSupported = typeof XMLHttpRequest !== 'undefined';
 
 export default isXHRAdapterSupported &&
-  function (config) {
+  async function (config) {
+    const useAsyncConfig =
+      platform.hasStandardBrowserEnv &&
+      typeof window !== 'undefined' &&
+      window.cookieStore &&
+      typeof window.cookieStore.get === 'function';
+    const _config = useAsyncConfig ? await resolveConfigAsync(config) : resolveConfig(config);
+
     return new Promise(function dispatchXhrRequest(resolve, reject) {
-      const _config = resolveConfig(config);
       let requestData = _config.data;
       const requestHeaders = AxiosHeaders.from(_config.headers).normalize();
       let { responseType, onUploadProgress, onDownloadProgress } = _config;

--- a/lib/helpers/cookies.js
+++ b/lib/helpers/cookies.js
@@ -1,6 +1,33 @@
 import utils from '../utils.js';
 import platform from '../platform/index.js';
 
+function getCookieFromDocument(name) {
+  if (typeof document === 'undefined') return null;
+
+  const cookieString = document.cookie.split(';');
+
+  for (let i = 0; i < cookieString.length; i++) {
+    const cookie = cookieString[i].replace(/^\s+/, '');
+    const eq = cookie.indexOf('=');
+    if (eq !== -1 && cookie.slice(0, eq) === name) {
+      return decodeURIComponent(cookie.slice(eq + 1));
+    }
+  }
+
+  return null;
+}
+
+const readFromCookieStore = (name) => {
+  if (typeof cookieStore === 'undefined' || !utils.isFunction(cookieStore.get)) {
+    return null;
+  }
+
+  return cookieStore.get(name).then(
+    (cookie) => (cookie ? cookie.value : null),
+    () => null
+  );
+};
+
 export default platform.hasStandardBrowserEnv
   ? // Standard browser envs support document.cookie
     {
@@ -29,21 +56,16 @@ export default platform.hasStandardBrowserEnv
       },
 
       read(name) {
-        if (typeof document === 'undefined') return null;
-        // Match name=value by splitting on the semicolon separator instead of building a
-        // RegExp from `name` — interpolating an unescaped string into a RegExp would let
-        // metacharacters (e.g. `.+?` in an attacker-influenced cookie name) cause ReDoS or
-        // match the wrong cookie. Browsers may serialize cookie pairs as either ";" or
-        // "; ", so ignore optional whitespace before each cookie name.
-        const cookies = document.cookie.split(';');
-        for (let i = 0; i < cookies.length; i++) {
-          const cookie = cookies[i].replace(/^\s+/, '');
-          const eq = cookie.indexOf('=');
-          if (eq !== -1 && cookie.slice(0, eq) === name) {
-            return decodeURIComponent(cookie.slice(eq + 1));
-          }
+        return getCookieFromDocument(name);
+      },
+
+      async readAsync(name) {
+        const cookieStoreValue = await readFromCookieStore(name);
+        if (cookieStoreValue != null) {
+          return cookieStoreValue;
         }
-        return null;
+
+        return getCookieFromDocument(name);
       },
 
       remove(name) {
@@ -54,6 +76,9 @@ export default platform.hasStandardBrowserEnv
     {
       write() {},
       read() {
+        return null;
+      },
+      async readAsync() {
         return null;
       },
       remove() {},

--- a/lib/helpers/resolveConfig.js
+++ b/lib/helpers/resolveConfig.js
@@ -109,4 +109,79 @@ function resolveConfig(config) {
   return newConfig;
 }
 
+async function resolveConfigAsync(config) {
+  const newConfig = mergeConfig({}, config);
+
+  // Read only own properties to prevent prototype pollution gadgets
+  // (e.g. Object.prototype.baseURL = 'https://evil.com').
+  const own = (key) => (utils.hasOwnProp(newConfig, key) ? newConfig[key] : undefined);
+
+  const data = own('data');
+  let withXSRFToken = own('withXSRFToken');
+  const xsrfHeaderName = own('xsrfHeaderName');
+  const xsrfCookieName = own('xsrfCookieName');
+  let headers = own('headers');
+  const auth = own('auth');
+  const baseURL = own('baseURL');
+  const allowAbsoluteUrls = own('allowAbsoluteUrls');
+  const url = own('url');
+
+  newConfig.headers = headers = AxiosHeaders.from(headers);
+
+  newConfig.url = buildURL(
+    buildFullPath(baseURL, url, allowAbsoluteUrls),
+    own('params'),
+    own('paramsSerializer')
+  );
+
+  // HTTP basic authentication
+  if (auth) {
+    headers.set(
+      'Authorization',
+      'Basic ' +
+        btoa((auth.username || '') + ':' + (auth.password ? encodeUTF8(auth.password) : ''))
+    );
+  }
+
+  if (utils.isFormData(data)) {
+    if (
+      platform.hasStandardBrowserEnv ||
+      platform.hasStandardBrowserWebWorkerEnv ||
+      utils.isReactNative(data)
+    ) {
+      headers.setContentType(undefined); // browser/web worker/RN handles it
+    } else if (utils.isFunction(data.getHeaders)) {
+      // Node.js FormData (like form-data package)
+      setFormDataHeaders(headers, data.getHeaders(), own('formDataHeaderPolicy'));
+    }
+  }
+
+  // Add xsrf header
+  // This is only done if running in a standard browser environment.
+  // Specifically not if we're in a web worker, or react-native.
+
+  if (platform.hasStandardBrowserEnv) {
+    if (utils.isFunction(withXSRFToken)) {
+      withXSRFToken = withXSRFToken(newConfig);
+    }
+
+    // Strict boolean check â€” prevents proto-pollution gadgets (e.g. Object.prototype.withXSRFToken = 1)
+    // and misconfigurations (e.g. "false") from short-circuiting the same-origin check and leaking
+    // the XSRF token cross-origin.
+    const shouldSendXSRF =
+      withXSRFToken === true || (withXSRFToken == null && isURLSameOrigin(newConfig.url));
+
+    if (shouldSendXSRF) {
+      const xsrfValue = xsrfHeaderName && xsrfCookieName && (await cookies.readAsync(xsrfCookieName));
+
+      if (xsrfValue) {
+        headers.set(xsrfHeaderName, xsrfValue);
+      }
+    }
+  }
+
+  return newConfig;
+}
+
 export default resolveConfig;
+export { resolveConfigAsync };

--- a/tests/browser/xsrf.browser.test.js
+++ b/tests/browser/xsrf.browser.test.js
@@ -66,9 +66,24 @@ const clearXsrfCookie = () => {
   ).toUTCString()}; path=/`;
 };
 
+const waitForRequest = async () => {
+  const start = Date.now();
+
+  while (Date.now() - start < 1000) {
+    const request = requests.at(-1);
+    if (request) {
+      return request;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+
+  throw new Error('Expected an XHR request to be sent');
+};
+
 const sendRequest = async (url, config) => {
   const responsePromise = axios(url, config);
-  const request = requests.at(-1);
+  const request = await waitForRequest();
 
   expect(request).toBeDefined();
   await responsePromise;
@@ -130,6 +145,22 @@ describe('xsrf (vitest browser)', () => {
 
     expect(request.requestHeaders[axios.defaults.xsrfHeaderName]).toBeUndefined();
   });
+
+  it.skipIf(() => !(window.cookieStore && window.cookieStore.get), 'cookieStore is not supported')(
+    'should use cookieStore.get for xsrf reads when available',
+    async () => {
+      const readSpy = vi.spyOn(cookies, 'read');
+      const getSpy = vi
+        .spyOn(window.cookieStore, 'get')
+        .mockResolvedValueOnce({ value: 'cookie-store-token' });
+
+      const request = await sendRequest('/foo');
+
+      expect(getSpy).toHaveBeenCalledWith(axios.defaults.xsrfCookieName);
+      expect(readSpy).not.toHaveBeenCalled();
+      expect(request.requestHeaders[axios.defaults.xsrfHeaderName]).toBe('cookie-store-token');
+    }
+  );
 
   it('should not set xsrf header for cross origin when using withCredentials', async () => {
     setXsrfCookie('12345');


### PR DESCRIPTION
## Summary

This introduces async XSRF cookie resolution for the XHR adapter when Cookie Store API is available, avoiding synchronous `document.cookie` reads in supported browsers.

### Changes

- Add `readAsync` to `lib/helpers/cookies.js` and use `cookieStore.get` when available.
- Add `resolveConfigAsync` in `lib/helpers/resolveConfig.js` with async XSRF token lookup.
- Use async config path in XHR adapter only when `window.cookieStore.get` exists.
- Add browser regression coverage in `tests/browser/xsrf.browser.test.js`.

### Validation

- `npm run test:vitest:unit -- tests/unit/helpers/resolveConfig.test.js`
- `npm run test:vitest:unit -- tests/unit/helpers/resolveConfig.test.js tests/unit/core/dispatchRequest.test.js`
- `npm run test:vitest:browser -- tests/browser/xsrf.browser.test.js`
- `npx eslint lib/helpers/cookies.js lib/helpers/resolveConfig.js lib/adapters/xhr.js tests/browser/xsrf.browser.test.js tests/unit/helpers/resolveConfig.test.js`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Avoid synchronous `document.cookie` reads by using async XSRF token lookup via `cookieStore.get` in the XHR adapter when supported. Falls back to the existing sync path in unsupported environments.

**Description**
- Summary of changes
  - Added `readAsync` in `lib/helpers/cookies.js` to read via `cookieStore.get` with a `document.cookie` fallback.
  - Added `resolveConfigAsync` in `lib/helpers/resolveConfig.js` for async XSRF header resolution.
  - Updated the `XHR` adapter to await `resolveConfigAsync` only when `window.cookieStore.get` exists.
  - Added browser regression coverage in `tests/browser/xsrf.browser.test.js`.
- Reasoning
  - Avoids blocking the main thread with sync cookie access.
  - Uses modern APIs where available without changing behavior elsewhere.
- Additional context
  - Runs only in standard browser envs.
  - No API changes; adapter still returns a Promise.

**Docs**
- Update the XSRF docs in `/docs/` to note async token retrieval via `cookieStore.get` when available, with transparent fallback to `document.cookie`. No configuration changes needed.

**Testing**
- Added a browser test in `tests/browser/xsrf.browser.test.js` to confirm `cookieStore.get` is used and the XSRF header is set.
- No additional tests are required for this change.

**Semantic version impact**
- Patch: internal improvement with no breaking API changes.

<sup>Written for commit 00d61a68cdc7bad07308f0bba237c9d9306e510f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/axios/axios/pull/10967?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

