### PR TITLE
fix: UTF-8 encode auth username for Basic header

### DIFF
--- a/lib/helpers/resolveConfig.js
+++ b/lib/helpers/resolveConfig.js
@@ -62,10 +62,12 @@ function resolveConfig(config) {
 
   // HTTP basic authentication
   if (auth) {
+    const username = auth.username ? encodeUTF8(auth.username) : '';
+    const password = auth.password ? encodeUTF8(auth.password) : '';
+
     headers.set(
       'Authorization',
-      'Basic ' +
-        btoa((auth.username || '') + ':' + (auth.password ? encodeUTF8(auth.password) : ''))
+      'Basic ' + btoa(username + ':' + password)
     );
   }
 

--- a/tests/unit/helpers/resolveConfig.test.js
+++ b/tests/unit/helpers/resolveConfig.test.js
@@ -14,6 +14,11 @@ class ReactNativeFormData {
   }
 }
 
+const encodeUTF8 = (str) =>
+  encodeURIComponent(str).replace(/%([0-9A-F]{2})/gi, (_, hex) =>
+    String.fromCharCode(parseInt(hex, 16))
+  );
+
 describe('helpers::resolveConfig', () => {
   it('clears Content-Type for React Native FormData', () => {
     const data = new ReactNativeFormData();
@@ -31,5 +36,20 @@ describe('helpers::resolveConfig', () => {
       Object.prototype.hasOwnProperty.call(config.headers.toJSON(), 'Content-Type'),
       false
     );
+  });
+
+  it('should encode basic auth credentials with UTF-8', () => {
+    const config = resolveConfig({
+      url: '/resource',
+      auth: {
+        username: '用户',
+        password: 'pässwörd',
+      },
+      headers: {},
+    });
+
+    const expected = 'Basic ' + btoa(`${encodeUTF8('用户')}:${encodeUTF8('pässwörd')}`);
+
+    assert.strictEqual(config.headers.get('Authorization'), expected);
   });
 });


### PR DESCRIPTION
## Summary
- encode both \'auth.username\' and \'auth.password\' using existing UTF-8 helper before composing the HTTP Basic Authorization header in esolveConfig
- add regression coverage for Unicode credentials in 	ests/unit/helpers/resolveConfig.test.js

## Validation
- npm run test:vitest:unit -- tests/unit/helpers/resolveConfig.test.js

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
UTF-8 encodes both `auth.username` and `auth.password` when building the HTTP Basic Authorization header in `resolveConfig`, fixing non-ASCII credential handling. Adds a unit test to prevent regressions.

## Description
- Summary of changes
  - Encode `auth.username` and `auth.password` with existing UTF-8 helper before `btoa`.
  - Build the header as `Basic btoa(username + ':' + password)`.
- Reasoning
  - Non-ASCII usernames produced invalid/mismatched headers; this aligns handling for both fields.
- Additional context
  - Change is limited to Basic auth header construction in `resolveConfig`.

## Docs
Please add a note in `/docs/` explaining that Basic auth credentials are UTF-8 encoded for the Authorization header, including examples with Unicode usernames/passwords.

## Testing
- Added a unit test in `tests/unit/helpers/resolveConfig.test.js` asserting the Authorization header encodes Unicode credentials with UTF-8.
- No additional tests needed.

## Semantic version impact
Patch: bug fix with no API changes.

<sup>Written for commit f8d35a459886f42591c630a96630b1e8750e529e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/axios/axios/pull/10968?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

