### PR TITLE
fix: prevent circular CanceledError serialization

### DIFF
--- a/lib/core/AxiosError.js
+++ b/lib/core/AxiosError.js
@@ -26,13 +26,14 @@ function hasOwnOrPrototypeToJSON(source) {
 // Build a plain-object snapshot of `config` and replace the value of any key
 // (case-insensitive) listed in `redactKeys` with REDACTED. Walks through arrays
 // and AxiosHeaders, and short-circuits on circular references.
-function redactConfig(config, redactKeys) {
+function redactConfig(config, redactKeys, excluded) {
   const lowerKeys = new Set(redactKeys.map((k) => String(k).toLowerCase()));
   const seen = [];
 
   const visit = (source) => {
     if (source === null || typeof source !== 'object') return source;
     if (utils.isBuffer(source)) return source;
+    if (source === excluded) return;
     if (seen.indexOf(source) !== -1) return undefined;
 
     if (source instanceof AxiosHeaders) {
@@ -134,8 +135,8 @@ class AxiosError extends Error {
     const redactKeys = config && utils.hasOwnProp(config, 'redact') ? config.redact : undefined;
     const serializedConfig =
       utils.isArray(redactKeys) && redactKeys.length > 0
-        ? redactConfig(config, redactKeys)
-        : utils.toJSONObject(config);
+        ? redactConfig(config, redactKeys, this)
+        : utils.toJSONObject(config, this);
 
     return {
       // Standard

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -781,13 +781,18 @@ function isSpecCompliantForm(thing) {
  * Recursively converts an object to a JSON-compatible object, handling circular references and Buffers.
  *
  * @param {Object} obj - The object to convert.
+ * @param {Object} [excluded] - Optional object reference to exclude from traversal.
  * @returns {Object} The JSON-compatible object.
  */
-const toJSONObject = (obj) => {
+const toJSONObject = (obj, excluded) => {
   const visited = new WeakSet();
 
   const visit = (source) => {
     if (isObject(source)) {
+      if (source === excluded) {
+        return;
+      }
+
       if (visited.has(source)) {
         return;
       }

--- a/tests/unit/core/AxiosError.test.js
+++ b/tests/unit/core/AxiosError.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { isNativeError } from 'node:util/types';
 import AxiosError from '../../../lib/core/AxiosError.js';
 import AxiosHeaders from '../../../lib/core/AxiosHeaders.js';
+import CancelToken from '../../../lib/cancel/CancelToken.js';
 
 describe('core::AxiosError', () => {
   it('creates an error with message, config, code, request, response, stack and isAxiosError', () => {
@@ -33,6 +34,17 @@ describe('core::AxiosError', () => {
     expect(json.status).toBe(200);
     expect(json.request).toBeUndefined();
     expect(json.response).toBeUndefined();
+  });
+
+  it('does not overflow when serializing a config with a cancelToken cycle', () => {
+    const config = {};
+    config.cancelToken = new CancelToken((cancel) => cancel('timeout', config));
+    const error = config.cancelToken.reason;
+
+    const json = error.toJSON();
+
+    expect(() => JSON.stringify(json)).not.toThrow();
+    expect(json.config.cancelToken.reason).toBeUndefined();
   });
 
   describe('AxiosError.from', () => {


### PR DESCRIPTION
Avoid a circular-reference overflow when serializing a CanceledError tied to a cancelToken. Add exclusion support to toJSONObject and apply it in AxiosError.toJSON/redaction path; include regression test. Validation: npm run test:vitest -- tests/unit/core/AxiosError.test.js tests/unit/utils.test.js; npm run lint -- lib/utils.js lib/core/AxiosError.js

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash when serializing `AxiosError` for canceled requests by avoiding circular references tied to `CancelToken`. Introduces an exclusion in object serialization so `toJSON()` is safe and predictable.

## Description

- Summary of changes
  - Added an optional `excluded` parameter to `utils.toJSONObject(obj, excluded)` to skip a specific object during traversal.
  - Extended `redactConfig(config, redactKeys, excluded)` to also respect the exclusion.
  - Updated `AxiosError.toJSON()` to pass `this` as the excluded object to both paths (redaction and plain serialization).
  - Ensures `config.cancelToken.reason` (which may point back to the error) is omitted in the JSON output.

- Reasoning
  - Prevents overflow/circular-reference issues when a `CancelToken` cancellation links the error back into `config`.

- Additional context
  - Affects only error serialization. Regular request behavior is unchanged.

## Docs

- Update `/docs/` error handling section to note:
  - `AxiosError.toJSON()` now omits self-referential objects for safety.
  - In canceled requests, `config.cancelToken.reason` won’t be included in the serialized JSON.

## Testing

- Added a unit test in `tests/unit/core/AxiosError.test.js` that:
  - Creates a cancel cycle via `CancelToken`.
  - Verifies `JSON.stringify(error.toJSON())` does not throw.
  - Asserts `json.config.cancelToken.reason` is `undefined`.
- No additional tests required.

## Semantic version impact

- Patch: bug fix with no breaking API changes.

<sup>Written for commit fcd25913f761abd7b969e72f76b2a86de62b3006. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/axios/axios/pull/10969?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

