### PR TITLE
fix(utils): serialize Set in toJSONObject

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -64,6 +64,7 @@ function isBuffer(val) {
  * @returns {boolean} True if value is an ArrayBuffer, otherwise false
  */
 const isArrayBuffer = kindOfTest('ArrayBuffer');
+const isSet = kindOfTest('Set');
 
 /**
  * Determine if a value is a view on an ArrayBuffer
@@ -800,6 +801,10 @@ const toJSONObject = (obj) => {
       if (!('toJSON' in source)) {
         // add-on descent / delete-on-ascent: preserves path semantics, so DAG nodes serialise at every occurrence (see #7230).
         visited.add(source);
+        if (isSet(source)) {
+          return Array.from(source, visit);
+        }
+
         const target = isArray(source) ? [] : {};
 
         forEach(source, (value, key) => {

--- a/tests/unit/utils.test.js
+++ b/tests/unit/utils.test.js
@@ -68,6 +68,16 @@ describe('utils', () => {
       });
     });
 
+    it('should serialize Set values as arrays', () => {
+      const source = {
+        list: new Set(['a', 'b']),
+      };
+
+      assert.deepStrictEqual(utils.toJSONObject(source), {
+        list: ['a', 'b'],
+      });
+    });
+
     it('should use objects with defined toJSON method without rebuilding', () => {
       const objProp = {};
       const obj = {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Serialize `Set` values in `utils.toJSONObject` by converting them to arrays. This fixes JSON output for objects containing `Set` and prevents incorrect serialization.

- **Bug Fixes**
  - `toJSONObject` now detects `Set` and serializes it as an array via `Array.from(source, visit)`, preserving recursive traversal and visited-node semantics.
  - Tests: added a unit test asserting `Set(['a','b'])` serializes to `['a','b']`.
  - Docs: suggest updating `/docs/utils.md` to note that `Set` values serialize to arrays.
  - Semantic version: patch (bug fix, no breaking changes).

<sup>Written for commit 2ade43325f04254a4e4239df4da13859d2734c96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/axios/axios/pull/10970?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

