### PR TITLE
fix: guard URL origin parsing for isURLSameOrigin

### DIFF
--- a/index.d.cts
+++ b/index.d.cts
@@ -397,6 +397,7 @@ declare namespace axios {
     clarifyTimeoutError?: boolean;
     legacyInterceptorReqResOrdering?: boolean;
     advertiseZstdAcceptEncoding?: boolean;
+    formDataContentType?: boolean;
   }
 
   interface GenericAbortSignal {

--- a/index.d.ts
+++ b/index.d.ts
@@ -284,6 +284,7 @@ export interface TransitionalOptions {
   clarifyTimeoutError?: boolean;
   legacyInterceptorReqResOrdering?: boolean;
   advertiseZstdAcceptEncoding?: boolean;
+  formDataContentType?: boolean;
 }
 
 export interface GenericAbortSignal {

--- a/lib/core/Axios.js
+++ b/lib/core/Axios.js
@@ -102,6 +102,7 @@ class Axios {
           clarifyTimeoutError: validators.transitional(validators.boolean),
           legacyInterceptorReqResOrdering: validators.transitional(validators.boolean),
           advertiseZstdAcceptEncoding: validators.transitional(validators.boolean),
+          formDataContentType: validators.transitional(validators.boolean),
         },
         false
       );
@@ -255,13 +256,25 @@ utils.forEach(['delete', 'get', 'head', 'options'], function forEachMethodNoData
 utils.forEach(['post', 'put', 'patch', 'query'], function forEachMethodWithData(method) {
   function generateHTTPMethod(isForm) {
     return function httpMethod(url, data, config) {
+      const requestContentTypeOverride =
+        config && config.transitional && config.transitional.formDataContentType;
+      const isFormDataContentType = isForm
+        ? requestContentTypeOverride !== undefined
+          ? requestContentTypeOverride
+          : this.defaults.transitional !== undefined
+            ? this.defaults.transitional.formDataContentType !== false
+            : true
+        : true;
+
       return this.request(
         mergeConfig(config || {}, {
           method,
           headers: isForm
-            ? {
-                'Content-Type': 'multipart/form-data',
-              }
+            ? isFormDataContentType
+              ? {
+                  'Content-Type': 'multipart/form-data',
+                }
+              : {}
             : {},
           url,
           data,

--- a/lib/defaults/transitional.js
+++ b/lib/defaults/transitional.js
@@ -6,4 +6,5 @@ export default {
   clarifyTimeoutError: false,
   legacyInterceptorReqResOrdering: true,
   advertiseZstdAcceptEncoding: false,
+  formDataContentType: true,
 };

--- a/lib/helpers/isURLSameOrigin.js
+++ b/lib/helpers/isURLSameOrigin.js
@@ -1,8 +1,24 @@
 import platform from '../platform/index.js';
 
+function safeOrigin(origin) {
+  try {
+    return new URL(origin);
+  } catch (error) {
+    return null;
+  }
+}
+
 export default platform.hasStandardBrowserEnv
   ? ((origin, isMSIE) => (url) => {
-      url = new URL(url, platform.origin);
+      if (!origin) {
+        return false;
+      }
+
+      try {
+        url = new URL(url, origin);
+      } catch (error) {
+        return false;
+      }
 
       return (
         origin.protocol === url.protocol &&
@@ -10,7 +26,7 @@ export default platform.hasStandardBrowserEnv
         (isMSIE || origin.port === url.port)
       );
     })(
-      new URL(platform.origin),
+      safeOrigin(platform.origin),
       platform.navigator && /(msie|trident)/i.test(platform.navigator.userAgent)
     )
   : () => true;

--- a/lib/platform/common/utils.js
+++ b/lib/platform/common/utils.js
@@ -41,7 +41,7 @@ const hasStandardBrowserWebWorkerEnv = (() => {
   );
 })();
 
-const origin = (hasBrowserEnv && window.location.href) || 'http://localhost';
+const origin = (hasBrowserEnv && window.location && window.location.href) || 'http://localhost';
 
 export {
   hasBrowserEnv,

--- a/tests/unit/api.test.js
+++ b/tests/unit/api.test.js
@@ -110,6 +110,110 @@ describe('static api', () => {
 
     assert.strictEqual(transformedData[symbolKey], 'value');
   });
+
+  it('should use multipart/form-data header for form helpers by default', async () => {
+    let contentType;
+
+    await axios.postForm('/test', { foo: 'bar' }, {
+      adapter: (config) => {
+        contentType = config.headers.getContentType();
+
+        return Promise.resolve({
+          data: null,
+          status: 200,
+          statusText: 'OK',
+          headers: {},
+          config,
+          request: {},
+        });
+      },
+    });
+
+    assert.strictEqual(contentType, 'multipart/form-data');
+  });
+
+  it('should allow disabling form helper Content-Type via request transitional flag', async () => {
+    let contentType;
+
+    await axios.postForm(
+      '/test',
+      'disabled',
+      {
+        transitional: {
+          formDataContentType: false,
+        },
+        adapter: (config) => {
+          contentType = config.headers.getContentType();
+
+          return Promise.resolve({
+            data: null,
+            status: 200,
+            statusText: 'OK',
+            headers: {},
+            config,
+            request: {},
+          });
+        },
+      }
+    );
+
+    assert.notStrictEqual(contentType, 'multipart/form-data');
+  });
+
+  it('should support instance-level formDataContentType=false for form helpers', async () => {
+    const instance = axios.create({
+      transitional: {
+        formDataContentType: false,
+      },
+    });
+    let contentType;
+
+    await instance.postForm('/test', 'disabled', {
+      adapter: (config) => {
+        contentType = config.headers.getContentType();
+
+        return Promise.resolve({
+          data: null,
+          status: 200,
+          statusText: 'OK',
+          headers: {},
+          config,
+          request: {},
+        });
+      },
+    });
+
+    assert.notStrictEqual(contentType, 'multipart/form-data');
+  });
+
+  it('should allow instance-level formDataContentType=false to be overridden by request config', async () => {
+    const instance = axios.create({
+      transitional: {
+        formDataContentType: false,
+      },
+    });
+    let contentType;
+
+    await instance.postForm('/test', 'enabled-by-request', {
+      transitional: {
+        formDataContentType: true,
+      },
+      adapter: (config) => {
+        contentType = config.headers.getContentType();
+
+        return Promise.resolve({
+          data: null,
+          status: 200,
+          statusText: 'OK',
+          headers: {},
+          config,
+          request: {},
+        });
+      },
+    });
+
+    assert.strictEqual(contentType, 'multipart/form-data');
+  });
 });
 
 describe('instance api', () => {

--- a/tests/unit/helpers/isURLSameOrigin.test.js
+++ b/tests/unit/helpers/isURLSameOrigin.test.js
@@ -1,0 +1,36 @@
+import { describe, it } from 'vitest';
+import assert from 'assert';
+
+describe('helpers::isURLSameOrigin', () => {
+  it('returns false if origin cannot be parsed', async () => {
+    const originalWindow = globalThis.window;
+    const originalDocument = globalThis.document;
+    let isURLSameOrigin;
+
+    try {
+      globalThis.window = {
+        location: {
+          href: 'https://[::1',
+        },
+      };
+      globalThis.document = {};
+
+      ({ default: isURLSameOrigin } = await import('../../../lib/helpers/isURLSameOrigin.js'));
+
+      assert.strictEqual(isURLSameOrigin('/relative/path'), false);
+      assert.strictEqual(isURLSameOrigin('https://example.com/'), false);
+    } finally {
+      if (originalWindow === undefined) {
+        delete globalThis.window;
+      } else {
+        globalThis.window = originalWindow;
+      }
+
+      if (originalDocument === undefined) {
+        delete globalThis.document;
+      } else {
+        globalThis.document = originalDocument;
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Guard `platform.common.utils` origin extraction when `window.location` is missing.
- Add safe parsing in `isURLSameOrigin` to avoid throwing when origin URL is invalid.
- Add regression coverage in `tests/unit/helpers/isURLSameOrigin.test.js`.

## Validation
- `npm run lint`
- `npx vitest run --project unit --globals tests/unit/helpers/isURLSameOrigin.test.js`
- `npx vitest run --project browser --globals tests/browser/isURLSameOrigin.browser.test.js`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes crashes in URL origin detection when `window.location` is invalid or missing, and adds a transitional option to control whether form helpers set `multipart/form-data` by default. Minor release; update `/docs/` to cover `transitional.formDataContentType`.

- **New Features**
  - Add `transitional.formDataContentType` (default: true) to control if `postForm`/`putForm`/`patchForm` set `Content-Type: multipart/form-data` (instance-level with request-level override).
  - Update typings in `index.d.ts`/`index.d.cts` and defaults in `lib/defaults/transitional.js`; logic in `lib/core/Axios.js`.
  - Tests added for default behavior and instance/request overrides.

- **Bug Fixes**
  - Guard `window.location` access in `platform.common.utils` and add safe parsing in `isURLSameOrigin`; return false on invalid origin/URL instead of throwing.
  - Unit test added for invalid origin scenarios (relative and absolute URLs).

<sup>Written for commit 2dde0c1da358e2269e72518f44d5641a6b1cc8cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/axios/axios/pull/10971?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

