### PR TITLE
feat: add transitional formDataContentType for form helpers

### DIFF
--- a/index.d.cts
+++ b/index.d.cts
@@ -397,6 +397,7 @@ declare namespace axios {
     clarifyTimeoutError?: boolean;
     legacyInterceptorReqResOrdering?: boolean;
     advertiseZstdAcceptEncoding?: boolean;
+    formDataContentType?: boolean;
   }
 
   interface GenericAbortSignal {

--- a/index.d.ts
+++ b/index.d.ts
@@ -284,6 +284,7 @@ export interface TransitionalOptions {
   clarifyTimeoutError?: boolean;
   legacyInterceptorReqResOrdering?: boolean;
   advertiseZstdAcceptEncoding?: boolean;
+  formDataContentType?: boolean;
 }
 
 export interface GenericAbortSignal {

--- a/lib/core/Axios.js
+++ b/lib/core/Axios.js
@@ -102,6 +102,7 @@ class Axios {
           clarifyTimeoutError: validators.transitional(validators.boolean),
           legacyInterceptorReqResOrdering: validators.transitional(validators.boolean),
           advertiseZstdAcceptEncoding: validators.transitional(validators.boolean),
+          formDataContentType: validators.transitional(validators.boolean),
         },
         false
       );
@@ -255,13 +256,25 @@ utils.forEach(['delete', 'get', 'head', 'options'], function forEachMethodNoData
 utils.forEach(['post', 'put', 'patch', 'query'], function forEachMethodWithData(method) {
   function generateHTTPMethod(isForm) {
     return function httpMethod(url, data, config) {
+      const requestContentTypeOverride =
+        config && config.transitional && config.transitional.formDataContentType;
+      const isFormDataContentType = isForm
+        ? requestContentTypeOverride !== undefined
+          ? requestContentTypeOverride
+          : this.defaults.transitional !== undefined
+            ? this.defaults.transitional.formDataContentType !== false
+            : true
+        : true;
+
       return this.request(
         mergeConfig(config || {}, {
           method,
           headers: isForm
-            ? {
-                'Content-Type': 'multipart/form-data',
-              }
+            ? isFormDataContentType
+              ? {
+                  'Content-Type': 'multipart/form-data',
+                }
+              : {}
             : {},
           url,
           data,

--- a/lib/defaults/transitional.js
+++ b/lib/defaults/transitional.js
@@ -6,4 +6,5 @@ export default {
   clarifyTimeoutError: false,
   legacyInterceptorReqResOrdering: true,
   advertiseZstdAcceptEncoding: false,
+  formDataContentType: true,
 };

--- a/lib/helpers/isURLSameOrigin.js
+++ b/lib/helpers/isURLSameOrigin.js
@@ -1,8 +1,24 @@
 import platform from '../platform/index.js';
 
+function safeOrigin(origin) {
+  try {
+    return new URL(origin);
+  } catch (error) {
+    return null;
+  }
+}
+
 export default platform.hasStandardBrowserEnv
   ? ((origin, isMSIE) => (url) => {
-      url = new URL(url, platform.origin);
+      if (!origin) {
+        return false;
+      }
+
+      try {
+        url = new URL(url, origin);
+      } catch (error) {
+        return false;
+      }
 
       return (
         origin.protocol === url.protocol &&
@@ -10,7 +26,7 @@ export default platform.hasStandardBrowserEnv
         (isMSIE || origin.port === url.port)
       );
     })(
-      new URL(platform.origin),
+      safeOrigin(platform.origin),
       platform.navigator && /(msie|trident)/i.test(platform.navigator.userAgent)
     )
   : () => true;

--- a/lib/platform/common/utils.js
+++ b/lib/platform/common/utils.js
@@ -41,7 +41,7 @@ const hasStandardBrowserWebWorkerEnv = (() => {
   );
 })();
 
-const origin = (hasBrowserEnv && window.location.href) || 'http://localhost';
+const origin = (hasBrowserEnv && window.location && window.location.href) || 'http://localhost';
 
 export {
   hasBrowserEnv,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -529,7 +529,18 @@ const inherits = (constructor, superConstructor, props, descriptors) => {
     __proto__: null,
     value: superConstructor.prototype,
   });
-  props && Object.assign(constructor.prototype, props);
+  if (props) {
+    Object.keys(props).forEach((prop) => {
+      const descriptor = Object.getOwnPropertyDescriptor(props, prop);
+
+      if (descriptor) {
+        Object.defineProperty(constructor.prototype, prop, {
+          ...descriptor,
+          __proto__: null,
+        });
+      }
+    });
+  }
 };
 
 /**

--- a/tests/unit/api.test.js
+++ b/tests/unit/api.test.js
@@ -110,6 +110,110 @@ describe('static api', () => {
 
     assert.strictEqual(transformedData[symbolKey], 'value');
   });
+
+  it('should use multipart/form-data header for form helpers by default', async () => {
+    let contentType;
+
+    await axios.postForm('/test', { foo: 'bar' }, {
+      adapter: (config) => {
+        contentType = config.headers.getContentType();
+
+        return Promise.resolve({
+          data: null,
+          status: 200,
+          statusText: 'OK',
+          headers: {},
+          config,
+          request: {},
+        });
+      },
+    });
+
+    assert.strictEqual(contentType, 'multipart/form-data');
+  });
+
+  it('should allow disabling form helper Content-Type via request transitional flag', async () => {
+    let contentType;
+
+    await axios.postForm(
+      '/test',
+      'disabled',
+      {
+        transitional: {
+          formDataContentType: false,
+        },
+        adapter: (config) => {
+          contentType = config.headers.getContentType();
+
+          return Promise.resolve({
+            data: null,
+            status: 200,
+            statusText: 'OK',
+            headers: {},
+            config,
+            request: {},
+          });
+        },
+      }
+    );
+
+    assert.notStrictEqual(contentType, 'multipart/form-data');
+  });
+
+  it('should support instance-level formDataContentType=false for form helpers', async () => {
+    const instance = axios.create({
+      transitional: {
+        formDataContentType: false,
+      },
+    });
+    let contentType;
+
+    await instance.postForm('/test', 'disabled', {
+      adapter: (config) => {
+        contentType = config.headers.getContentType();
+
+        return Promise.resolve({
+          data: null,
+          status: 200,
+          statusText: 'OK',
+          headers: {},
+          config,
+          request: {},
+        });
+      },
+    });
+
+    assert.notStrictEqual(contentType, 'multipart/form-data');
+  });
+
+  it('should allow instance-level formDataContentType=false to be overridden by request config', async () => {
+    const instance = axios.create({
+      transitional: {
+        formDataContentType: false,
+      },
+    });
+    let contentType;
+
+    await instance.postForm('/test', 'enabled-by-request', {
+      transitional: {
+        formDataContentType: true,
+      },
+      adapter: (config) => {
+        contentType = config.headers.getContentType();
+
+        return Promise.resolve({
+          data: null,
+          status: 200,
+          statusText: 'OK',
+          headers: {},
+          config,
+          request: {},
+        });
+      },
+    });
+
+    assert.strictEqual(contentType, 'multipart/form-data');
+  });
 });
 
 describe('instance api', () => {

--- a/tests/unit/helpers/isURLSameOrigin.test.js
+++ b/tests/unit/helpers/isURLSameOrigin.test.js
@@ -1,0 +1,36 @@
+import { describe, it } from 'vitest';
+import assert from 'assert';
+
+describe('helpers::isURLSameOrigin', () => {
+  it('returns false if origin cannot be parsed', async () => {
+    const originalWindow = globalThis.window;
+    const originalDocument = globalThis.document;
+    let isURLSameOrigin;
+
+    try {
+      globalThis.window = {
+        location: {
+          href: 'https://[::1',
+        },
+      };
+      globalThis.document = {};
+
+      ({ default: isURLSameOrigin } = await import('../../../lib/helpers/isURLSameOrigin.js'));
+
+      assert.strictEqual(isURLSameOrigin('/relative/path'), false);
+      assert.strictEqual(isURLSameOrigin('https://example.com/'), false);
+    } finally {
+      if (originalWindow === undefined) {
+        delete globalThis.window;
+      } else {
+        globalThis.window = originalWindow;
+      }
+
+      if (originalDocument === undefined) {
+        delete globalThis.document;
+      } else {
+        globalThis.document = originalDocument;
+      }
+    }
+  });
+});

--- a/tests/unit/prototypePollution.test.js
+++ b/tests/unit/prototypePollution.test.js
@@ -1,5 +1,4 @@
-/* eslint-disable no-prototype-builtins */
-import { afterEach, describe, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import assert from 'assert';
 import http from 'http';
 import utils from '../../lib/utils.js';
@@ -1105,6 +1104,36 @@ describe('Prototype Pollution Protection', () => {
 
       assert.strictEqual(Child.prototype.constructor, Child);
       assert.strictEqual(Child.super, Parent.prototype);
+    });
+
+    it('should not throw in utils.inherits when super-constructor method is non-writable', () => {
+      const originalDescriptor = Object.getOwnPropertyDescriptor(Error.prototype, 'toJSON');
+      Object.defineProperty(Error.prototype, 'toJSON', {
+        value() {},
+        configurable: true,
+        writable: false,
+        enumerable: false,
+      });
+
+      try {
+        function Parent() {}
+        function Child() {}
+
+        expect(() => {
+          utils.inherits(Child, Error, {
+            toJSON() {
+              return {};
+            },
+          });
+        }).not.toThrow();
+
+        assert.strictEqual(typeof Child.prototype.toJSON, 'function');
+        assert.deepStrictEqual(Child.prototype.toJSON(), {});
+      } finally {
+        if (originalDescriptor) {
+          Object.defineProperty(Error.prototype, 'toJSON', originalDescriptor);
+        }
+      }
     });
 
     it('should also be shielded against a polluted Object.prototype.set', () => {


### PR DESCRIPTION
## Summary
- Add a new transitional option ormDataContentType (default true) to control placeholder Content-Type behavior for postForm/putForm/patchForm.
- Route request-level and instance-level 	ransitional config through helper methods while preserving existing default behavior.
- Extend type definitions in index.d.ts and index.d.cts to include the new option.
- Add focused unit coverage for default behavior and both request-level/instance-level enable/disable combinations.

## Validation
- npm run test:vitest:unit -- tests/unit/api.test.js
- npm run test:vitest:unit

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a transitional `formDataContentType` option to control the placeholder Content-Type for form helpers without changing defaults. Also hardens same-origin checks and fixes `utils.inherits` to avoid errors with non-writable super methods.

**Description**
- Summary of changes
  - Add `transitional.formDataContentType` (default true) to control the `multipart/form-data` header in `postForm`/`putForm`/`patchForm`; request-level overrides instance-level.
  - Harden `isURLSameOrigin` and origin detection to safely handle invalid/missing `window.location` and URL parse failures.
  - Update `utils.inherits` to define properties via descriptors to avoid non-writable inherited prop errors; update `index.d.ts`/`index.d.cts`.
- Reasoning
  - Some environments need to disable the placeholder header until the body is built.
  - Prevent crashes or incorrect same-origin results when the environment origin or URL is malformed.
  - Avoid TypeErrors when inheriting over non-writable methods on built-ins.
- Additional context
  - Default behavior remains unchanged for existing users.

**Docs**
- Add `transitional.formDataContentType` to the config reference in `/docs/`, including default behavior and request vs instance precedence, plus an example disabling the header for form helpers.

**Testing**
- Added unit tests for form helpers: default on, instance-level off, request-level off, and request-level override on.
- Added tests for `isURLSameOrigin` with an unparseable origin.
- Added a test ensuring `utils.inherits` does not throw when the super-constructor method is non-writable.

**Semantic version impact**
- Minor: introduces a new configurable option with backward-compatible defaults, plus safe bug fixes.

<sup>Written for commit 96fdd3b0518d193ea11cedfb2a59691f7ea2d74a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/axios/axios/pull/10972?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

