### PR TITLE
fix: avoid multipart placeholder for form helpers

### DIFF
--- a/lib/core/Axios.js
+++ b/lib/core/Axios.js
@@ -9,6 +9,7 @@ import buildFullPath from './buildFullPath.js';
 import validator from '../helpers/validator.js';
 import AxiosHeaders from './AxiosHeaders.js';
 import transitionalDefaults from '../defaults/transitional.js';
+import toFormData from '../helpers/toFormData.js';
 
 const validators = validator.validators;
 
@@ -255,14 +256,27 @@ utils.forEach(['delete', 'get', 'head', 'options'], function forEachMethodNoData
 utils.forEach(['post', 'put', 'patch', 'query'], function forEachMethodWithData(method) {
   function generateHTTPMethod(isForm) {
     return function httpMethod(url, data, config) {
+      if (
+        isForm &&
+        data &&
+        !utils.isFormData(data) &&
+        (utils.isObject(data) || utils.isFileList(data))
+      ) {
+        const currentConfig = config || {};
+        const env = currentConfig.env || this.defaults.env;
+        const formSerializer = currentConfig.formSerializer || this.defaults.formSerializer;
+
+        data = toFormData(
+          data,
+          env && env.FormData ? new env.FormData() : undefined,
+          formSerializer
+        );
+      }
+
       return this.request(
         mergeConfig(config || {}, {
           method,
-          headers: isForm
-            ? {
-                'Content-Type': 'multipart/form-data',
-              }
-            : {},
+          headers: {},
           url,
           data,
         })

--- a/tests/unit/adapters/http.test.js
+++ b/tests/unit/adapters/http.test.js
@@ -3642,6 +3642,28 @@ describe('supports http with nodejs', () => {
   });
 
   describe('FormData', () => {
+    it('should set a multipart boundary for form helper payloads', async () => {
+      let contentType;
+
+      const server = await startHTTPServer(
+        (req, res) => {
+          req.resume();
+          req.once('end', () => {
+            contentType = req.headers['content-type'];
+            res.end('OK');
+          });
+        },
+        { port: SERVER_PORT }
+      );
+
+      try {
+        await axios.postForm(`http://localhost:${server.address().port}/`, { foo: 'bar' });
+        assert.match(contentType, /^multipart\/form-data; boundary=/i);
+      } finally {
+        await stopHTTPServer(server);
+      }
+    });
+
     describe('form-data instance (https://www.npmjs.com/package/form-data)', () => {
       it('should allow passing FormData', async () => {
         const form = new FormDataLegacy();
@@ -3705,6 +3727,32 @@ describe('supports http with nodejs', () => {
     });
 
     describe('SpecCompliant FormData', () => {
+      it('should set boundary for form helper FormData payloads', async () => {
+        let contentType;
+
+        const server = await startHTTPServer(
+          (req, res) => {
+            req.resume();
+            req.once('end', () => {
+              contentType = req.headers['content-type'];
+              res.end('OK');
+            });
+          },
+          { port: 0 }
+        );
+
+        try {
+          const form = new FormDataSpecCompliant();
+
+          form.append('foo', 'bar');
+
+          await axios.postForm(`http://localhost:${server.address().port}`, form);
+          assert.match(contentType, /^multipart\/form-data; boundary=/i);
+        } finally {
+          await stopHTTPServer(server);
+        }
+      });
+
       it('should allow passing FormData', { retry: 2 }, async () => {
         // Use an ephemeral port and a non-keep-alive agent. Sharing the fixed
         // SERVER_PORT across tests can leave keep-alive sockets in the global

--- a/tests/unit/api.test.js
+++ b/tests/unit/api.test.js
@@ -110,6 +110,61 @@ describe('static api', () => {
 
     assert.strictEqual(transformedData[symbolKey], 'value');
   });
+
+  ['postForm', 'putForm', 'patchForm'].forEach((method) => {
+    it(`should not set bare multipart/form-data header by default for ${method}`, async () => {
+      let contentType;
+
+      await axios[method](
+        '/test',
+        { foo: 'bar' },
+        {
+          adapter: (config) => {
+            contentType = config.headers.getContentType();
+
+            return Promise.resolve({
+              data: null,
+              status: 200,
+              statusText: 'OK',
+              headers: {},
+              config,
+              request: {},
+            });
+          },
+        }
+      );
+
+      assert.notStrictEqual(contentType, 'multipart/form-data');
+    });
+  });
+
+  it('should preserve user-provided Content-Type for form helpers', async () => {
+    let contentType;
+
+    await axios.postForm(
+      '/test',
+      { foo: 'bar' },
+      {
+        headers: {
+          'Content-Type': 'application/custom',
+        },
+        adapter: (config) => {
+          contentType = config.headers.getContentType();
+
+          return Promise.resolve({
+            data: null,
+            status: 200,
+            statusText: 'OK',
+            headers: {},
+            config,
+            request: {},
+          });
+        },
+      }
+    );
+
+    assert.strictEqual(contentType, 'application/custom');
+  });
 });
 
 describe('instance api', () => {


### PR DESCRIPTION
## Summary\n- stop injecting placeholder \multipart/form-data\ header in post/put/patch form helpers\n- generate FormData for object/FileList inputs in form helpers while preserving user-supplied Content-Type\n- add unit coverage for header behavior and boundary generation\n\n## Validation\n- npm run test:vitest:unit -- tests/unit/api.test.js tests/unit/adapters/http.test.js

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops injecting a bare multipart/form-data header in `postForm`/`putForm`/`patchForm` and auto-builds `FormData` for object and `FileList` inputs. This preserves user-set Content-Type and lets the runtime/adapter set a correct boundary.

## Description

- Summary of changes: Removed default multipart header in form helpers; build `FormData` via `toFormData` for plain objects/`FileList`; honor any user-provided Content-Type; respect `env.FormData` and `formSerializer`.
- Reasoning: A bare multipart header (no boundary) is invalid and breaks some servers; helpers should handle common payloads without forcing headers.
- Additional context: Boundary is now added by the runtime/adapter when sending `FormData`.

## Docs

Suggest updating `/docs/` to clarify:
- Form helpers no longer set a default multipart header.
- Objects and `FileList` are auto-converted to `FormData`.
- How to override headers when needed.

## Testing

- Added unit tests to ensure no bare multipart header by default and that custom Content-Type is preserved (`tests/unit/api.test.js`).
- Added HTTP adapter tests to assert a multipart boundary is present for helper payloads and passed `FormData` (`tests/unit/adapters/http.test.js`).

## Semantic version impact

Patch: bug fix with no API changes.

<sup>Written for commit f6fc516c0d98b2459d9453710ae29e94f8e3c4cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/axios/axios/pull/10974?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

