### PR TITLE
fix(core): reject malformed http(s) URLs without //

### DIFF
--- a/lib/core/buildFullPath.js
+++ b/lib/core/buildFullPath.js
@@ -2,6 +2,20 @@
 
 import isAbsoluteURL from '../helpers/isAbsoluteURL.js';
 import combineURLs from '../helpers/combineURLs.js';
+import parseProtocol from '../helpers/parseProtocol.js';
+import AxiosError from './AxiosError.js';
+
+const isHttpURL = (url) => {
+  if (typeof url !== 'string') {
+    return false;
+  }
+
+  const protocol = parseProtocol(url).toLowerCase();
+  return (
+    protocol === 'http' ||
+    protocol === 'https'
+  ) && !url.startsWith(`${protocol}://`);
+};
 
 /**
  * Creates a new URL by combining the baseURL with the requestedURL,
@@ -14,6 +28,16 @@ import combineURLs from '../helpers/combineURLs.js';
  * @returns {string} The combined full path
  */
 export default function buildFullPath(baseURL, requestedURL, allowAbsoluteUrls) {
+  if (isHttpURL(requestedURL)) {
+    const protocol = parseProtocol(requestedURL).toLowerCase();
+    throw new AxiosError(
+      `Invalid URL "${requestedURL}", did you mean "${protocol}://${
+        requestedURL.slice(requestedURL.indexOf(':') + 1)
+      }"?`,
+      AxiosError.ERR_INVALID_URL
+    );
+  }
+
   let isRelativeUrl = !isAbsoluteURL(requestedURL);
   if (baseURL && (isRelativeUrl || allowAbsoluteUrls === false)) {
     return combineURLs(baseURL, requestedURL);

--- a/tests/unit/core/buildFullPath.test.js
+++ b/tests/unit/core/buildFullPath.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import buildFullPath from '../../../lib/core/buildFullPath.js';
+import AxiosError from '../../../lib/core/AxiosError.js';
 
 describe('core::buildFullPath', () => {
   it('combines URLs when the requested URL is relative', () => {
@@ -30,5 +31,15 @@ describe('core::buildFullPath', () => {
 
   it('combines URLs when baseURL and requested URL are both relative', () => {
     expect(buildFullPath('/api', '/users')).toBe('/api/users');
+  });
+
+  it('should throw on malformed http protocol URLs missing //', () => {
+    try {
+      buildFullPath(undefined, 'https:google.com');
+      expect.unreachable('Expected malformed URL to throw ERR_INVALID_URL');
+    } catch (error) {
+      expect(error.code).toBe(AxiosError.ERR_INVALID_URL);
+      expect(error.message).toContain('did you mean "https://google.com"?');
+    }
   });
 });

--- a/tests/unit/regression.test.js
+++ b/tests/unit/regression.test.js
@@ -6,6 +6,7 @@ import assert from 'assert';
 import http from 'http';
 import axios from '../../index.js';
 import platform from '../../lib/platform/index.js';
+import AxiosError from '../../lib/core/AxiosError.js';
 
 describe('regression', () => {
   describe('issues', () => {
@@ -50,7 +51,7 @@ describe('regression', () => {
     });
 
     describe('7364', () => {
-      it('fetch: should have status code in axios error', async () => {
+    it('fetch: should have status code in axios error', async () => {
         const isFetchSupported = typeof fetch === 'function';
         if (!isFetchSupported) {
           vi.skip();
@@ -102,6 +103,32 @@ describe('regression', () => {
           server.close();
         }
       });
+    });
+
+    it('should fail malformed http URL format before dispatching request', async () => {
+      let requestCount = 0;
+      const server = http
+        .createServer((req, res) => {
+          requestCount++;
+          res.end('ok');
+        })
+        .listen(0);
+
+      const instance = axios.create({
+        baseURL: `http://localhost:${server.address().port}`,
+        adapter: 'http',
+      });
+
+      try {
+        await assert.rejects(
+          instance.get('https:google.com'),
+          (error) => error.code === AxiosError.ERR_INVALID_URL
+        );
+      } finally {
+        server.close();
+      }
+
+      assert.strictEqual(requestCount, 0);
     });
   });
 


### PR DESCRIPTION
## Summary
This PR adds a pre-dispatch validation for malformed http/https URLs in uildFullPath.

### Why
https:google.com is treated as a valid scheme by URL parsing today and can bypass URL intent checks. It is now rejected early with ERR_INVALID_URL and a hint to use https://.

### Changes
- Added malformed http/https scheme validation in lib/core/buildFullPath.js.
- Added regression coverage in 	ests/unit/core/buildFullPath.test.js.

### Validation
- 
pm test -- tests/unit/core/buildFullPath.test.js
- 
pm test -- tests/unit/core

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects malformed `http`/`https` URLs missing `//` in `buildFullPath`, throwing `ERR_INVALID_URL` with a suggested fix. Adds a regression test to ensure the error happens before any request is sent.

## Description

- Summary of changes
  - Added pre-dispatch validation in `lib/core/buildFullPath.js` to detect `http`/`https` without `//` and throw `AxiosError.ERR_INVALID_URL` with a “did you mean 'protocol://…'?” hint.
  - Added unit test in `tests/unit/core/buildFullPath.test.js` for the malformed URL case.
  - Added regression test in `tests/unit/regression.test.js` to confirm no request is dispatched (server count stays 0) when calling `axios.get('https:google.com')`.
- Reasoning
  - Some parsers accept `https:google.com` as a valid scheme, allowing it to slip past intent checks. We now enforce `http(s)://`.
- Additional context
  - Uses `parseProtocol` and limits the check to `http`/`https` only.
  - No change for relative URLs or other schemes.

## Docs

- Update URL and error-handling docs in `/docs/` to note that malformed `http(s):example.com` is rejected with `ERR_INVALID_URL`, and show the correct `http(s)://example.com` form with an example.

## Testing

- Added unit and regression tests asserting `ERR_INVALID_URL`, the suggestion text, and that no request is sent.
- Existing tests for `buildFullPath` remain unchanged.

## Semantic version impact

- Patch: bug fix tightening validation. Inputs like `https:google.com` now throw `ERR_INVALID_URL`.

<sup>Written for commit 2769afbfbbb687614d05da407cf1c8c8b61ba084. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/axios/axios/pull/10975?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

