### PR TITLE
fix(http): strip auth-like headers on cross-origin redirects

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -1118,7 +1118,9 @@ export default isHttpAdapterSupported &&
 
       req.on('socket', function handleRequestSocket(socket) {
         // default interval of sending ack packet is 1 minute
-        socket.setKeepAlive(true, 1000 * 60);
+        if (typeof socket.setKeepAlive === 'function') {
+          socket.setKeepAlive(true, 1000 * 60);
+        }
 
         // Install a single 'error' listener per socket (not per request) to avoid
         // accumulating listeners on pooled keep-alive sockets that get reassigned

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -54,6 +54,8 @@ const isBrotliSupported = utils.isFunction(zlib.createBrotliDecompress);
 const isZstdSupported = utils.isFunction(zlib.createZstdDecompress);
 const ACCEPT_ENCODING = 'gzip, compress, deflate' + (isBrotliSupported ? ', br' : '');
 const ACCEPT_ENCODING_WITH_ZSTD = ACCEPT_ENCODING + (isZstdSupported ? ', zstd' : '');
+const REDIRECT_SENSITIVE_HEADER_RE =
+  /^(?:authorization|cookie|x-[\w-]*?(?:auth|authorization|credential|key|password|secret|session|signature|token))$/i;
 
 const { http: httpFollow, https: httpsFollow } = followRedirects;
 
@@ -144,6 +146,26 @@ const decodeURIComponentSafe = (value) => {
     return value;
   }
 };
+
+function isSameOriginRedirect(redirectUrl, requestOrigin) {
+  try {
+    return new URL(redirectUrl).origin === requestOrigin;
+  } catch (error) {
+    return false;
+  }
+}
+
+function stripSensitiveRedirectHeaders(redirectOptions, requestOrigin) {
+  if (isSameOriginRedirect(redirectOptions.href, requestOrigin) || !redirectOptions.headers) {
+    return;
+  }
+
+  Object.keys(redirectOptions.headers).forEach((name) => {
+    if (REDIRECT_SENSITIVE_HEADER_RE.test(name)) {
+      delete redirectOptions.headers[name];
+    }
+  });
+}
 
 const flushOnFinish = (stream, [throttled, flush]) => {
   stream.on('end', flush).on('error', flush);
@@ -871,23 +893,18 @@ export default isHttpAdapterSupported &&
           if (configBeforeRedirect) {
             options.beforeRedirects.config = configBeforeRedirect;
           }
-          if (auth) {
-            // Restore HTTP Basic credentials on same-origin redirects only.
-            // follow-redirects >= 1.15.8 strips Authorization on every redirect (see #6929);
-            // cross-origin stripping is the documented mitigation for T-R2 in THREATMODEL.md
-            // and is preserved by deliberately not restoring on origin change.
-            const requestOrigin = parsed.origin;
-            const authToRestore = auth;
-            options.beforeRedirects.auth = function beforeRedirectAuth(redirectOptions) {
-              try {
-                if (new URL(redirectOptions.href).origin === requestOrigin) {
-                  redirectOptions.auth = authToRestore;
-                }
-              } catch (e) {
-                // ignore malformed URL: leaving auth stripped is fail-safe
-              }
-            };
-          }
+          const requestOrigin = parsed.origin;
+          const authToRestore = auth;
+          // Restore HTTP Basic credentials only on same-origin redirects.
+          // follow-redirects >= 1.15.8 strips Authorization on every redirect (see #6929);
+          // cross-origin stripping is the documented mitigation for T-R2 in THREATMODEL.md
+          // and is preserved by deliberately not restoring on origin change.
+          options.beforeRedirects.auth = function beforeRedirectAuth(redirectOptions) {
+            stripSensitiveRedirectHeaders(redirectOptions, requestOrigin);
+            if (authToRestore && isSameOriginRedirect(redirectOptions.href, requestOrigin)) {
+              redirectOptions.auth = authToRestore;
+            }
+          };
           transport = isHttpsRequest ? httpsFollow : httpFollow;
         }
       }

--- a/lib/core/buildFullPath.js
+++ b/lib/core/buildFullPath.js
@@ -2,6 +2,20 @@
 
 import isAbsoluteURL from '../helpers/isAbsoluteURL.js';
 import combineURLs from '../helpers/combineURLs.js';
+import parseProtocol from '../helpers/parseProtocol.js';
+import AxiosError from './AxiosError.js';
+
+const isHttpURL = (url) => {
+  if (typeof url !== 'string') {
+    return false;
+  }
+
+  const protocol = parseProtocol(url).toLowerCase();
+  return (
+    protocol === 'http' ||
+    protocol === 'https'
+  ) && !url.startsWith(`${protocol}://`);
+};
 
 /**
  * Creates a new URL by combining the baseURL with the requestedURL,
@@ -14,6 +28,16 @@ import combineURLs from '../helpers/combineURLs.js';
  * @returns {string} The combined full path
  */
 export default function buildFullPath(baseURL, requestedURL, allowAbsoluteUrls) {
+  if (isHttpURL(requestedURL)) {
+    const protocol = parseProtocol(requestedURL).toLowerCase();
+    throw new AxiosError(
+      `Invalid URL "${requestedURL}", did you mean "${protocol}://${
+        requestedURL.slice(requestedURL.indexOf(':') + 1)
+      }"?`,
+      AxiosError.ERR_INVALID_URL
+    );
+  }
+
   let isRelativeUrl = !isAbsoluteURL(requestedURL);
   if (baseURL && (isRelativeUrl || allowAbsoluteUrls === false)) {
     return combineURLs(baseURL, requestedURL);

--- a/tests/unit/adapters/http.test.js
+++ b/tests/unit/adapters/http.test.js
@@ -1223,6 +1223,83 @@ describe('supports http with nodejs', () => {
     }
   });
 
+  it('should strip auth-like headers on cross-origin redirect', async () => {
+    const targetServer = await startHTTPServer(
+      (req, res) => {
+        res.end(
+          JSON.stringify({
+            authorization: req.headers.authorization || null,
+            apiKey: req.headers['x-api-key'] || null,
+            awsToken: req.headers['x-aws-token'] || null,
+            internalSecret: req.headers['x-internal-secret'] || null,
+            normal: req.headers['x-request-id'] || null,
+          })
+        );
+      },
+      { port: ALTERNATE_SERVER_PORT }
+    );
+    const redirectServer = await startHTTPServer(
+      (req, res) => {
+        res.setHeader('Location', `http://127.0.0.1:${targetServer.address().port}/`);
+        res.statusCode = 302;
+        res.end();
+      },
+      { port: SERVER_PORT }
+    );
+
+    try {
+      const response = await axios.get(`http://localhost:${redirectServer.address().port}/start`, {
+        headers: {
+          Authorization: 'Bearer 1234',
+          'X-API-Key': 'top-secret-key',
+          'X-AWS-Token': 'aws-token',
+          'X-Internal-Secret': 'super-secret',
+          'X-Request-Id': 'trace-id',
+        },
+        maxRedirects: 1,
+      });
+
+      assert.deepStrictEqual(response.data, {
+        authorization: null,
+        apiKey: null,
+        awsToken: null,
+        internalSecret: null,
+        normal: 'trace-id',
+      });
+    } finally {
+      await stopHTTPServer(redirectServer);
+      await stopHTTPServer(targetServer);
+    }
+  });
+
+  it('should preserve auth-like headers across same-origin redirects', async () => {
+    const server = await startHTTPServer(
+      (req, res) => {
+        if (req.url === '/start') {
+          res.setHeader('Location', '/profile');
+          res.statusCode = 302;
+          res.end();
+          return;
+        }
+        res.end(req.headers['x-api-key'] || 'missing');
+      },
+      { port: SERVER_PORT }
+    );
+
+    try {
+      const response = await axios.get(`http://localhost:${server.address().port}/start`, {
+        headers: {
+          'X-API-Key': 'top-secret-key',
+        },
+        maxRedirects: 1,
+      });
+
+      assert.strictEqual(response.data, 'top-secret-key');
+    } finally {
+      await stopHTTPServer(server);
+    }
+  });
+
   it('should preserve basic auth across multi-hop same-origin redirects', async () => {
     const server = await startHTTPServer(
       (req, res) => {

--- a/tests/unit/adapters/http.test.js
+++ b/tests/unit/adapters/http.test.js
@@ -5317,6 +5317,54 @@ describe('supports http with nodejs', () => {
     assert.strictEqual(error.message, 'write EPIPE');
   });
 
+  it('should tolerate sockets without setKeepAlive (issue #10908)', async () => {
+    const socket = new EventEmitter();
+    const transport = {
+      request(_, cb) {
+        return new (class MockRequest extends EventEmitter {
+          constructor() {
+            super();
+            this.destroyed = false;
+          }
+
+          setTimeout() {}
+
+          write() {}
+
+          end() {
+            this.emit('socket', socket);
+
+            setImmediate(() => {
+              const response = stream.Readable.from(['ok']);
+              response.statusCode = 200;
+              response.headers = {};
+              cb(response);
+              this.emit('close');
+            });
+          }
+
+          destroy(err) {
+            if (this.destroyed) {
+              return;
+            }
+
+            this.destroyed = true;
+            err && this.emit('error', err);
+            this.emit('close');
+          }
+        })();
+      },
+    };
+
+    const response = await axios.post('http://example.com/', 'test', {
+      transport,
+      maxRedirects: 0,
+    });
+
+    assert.strictEqual(response.status, 200);
+    assert.strictEqual(response.data, 'ok');
+  });
+
   describe('keep-alive', () => {
     it('should not emit MaxListenersExceededWarning under concurrent requests through a pooled keep-alive agent (regression #10780)', async () => {
       const server = await startHTTPServer(

--- a/tests/unit/core/buildFullPath.test.js
+++ b/tests/unit/core/buildFullPath.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import buildFullPath from '../../../lib/core/buildFullPath.js';
+import AxiosError from '../../../lib/core/AxiosError.js';
 
 describe('core::buildFullPath', () => {
   it('combines URLs when the requested URL is relative', () => {
@@ -30,5 +31,15 @@ describe('core::buildFullPath', () => {
 
   it('combines URLs when baseURL and requested URL are both relative', () => {
     expect(buildFullPath('/api', '/users')).toBe('/api/users');
+  });
+
+  it('should throw on malformed http protocol URLs missing //', () => {
+    try {
+      buildFullPath(undefined, 'https:google.com');
+      expect.unreachable('Expected malformed URL to throw ERR_INVALID_URL');
+    } catch (error) {
+      expect(error.code).toBe(AxiosError.ERR_INVALID_URL);
+      expect(error.message).toContain('did you mean "https://google.com"?');
+    }
   });
 });

--- a/tests/unit/regression.test.js
+++ b/tests/unit/regression.test.js
@@ -6,6 +6,7 @@ import assert from 'assert';
 import http from 'http';
 import axios from '../../index.js';
 import platform from '../../lib/platform/index.js';
+import AxiosError from '../../lib/core/AxiosError.js';
 
 describe('regression', () => {
   describe('issues', () => {
@@ -50,7 +51,7 @@ describe('regression', () => {
     });
 
     describe('7364', () => {
-      it('fetch: should have status code in axios error', async () => {
+    it('fetch: should have status code in axios error', async () => {
         const isFetchSupported = typeof fetch === 'function';
         if (!isFetchSupported) {
           vi.skip();
@@ -102,6 +103,32 @@ describe('regression', () => {
           server.close();
         }
       });
+    });
+
+    it('should fail malformed http URL format before dispatching request', async () => {
+      let requestCount = 0;
+      const server = http
+        .createServer((req, res) => {
+          requestCount++;
+          res.end('ok');
+        })
+        .listen(0);
+
+      const instance = axios.create({
+        baseURL: `http://localhost:${server.address().port}`,
+        adapter: 'http',
+      });
+
+      try {
+        await assert.rejects(
+          instance.get('https:google.com'),
+          (error) => error.code === AxiosError.ERR_INVALID_URL
+        );
+      } finally {
+        server.close();
+      }
+
+      assert.strictEqual(requestCount, 0);
     });
   });
 


### PR DESCRIPTION
## Summary
- Strip credential-like request headers on cross-origin redirects in the Node HTTP adapter using follow-redirects redirect hooks.
- Preserve same-origin behavior for these headers and HTTP basic auth restoration.
- Add regression coverage for cross-origin/custom auth-like header leakage and same-origin preservation.

## Validation
- `npm run test:vitest:unit -- tests/unit/adapters/http.test.js -t "should strip auth-like headers|should preserve auth-like headers across same-origin redirects|should strip basic auth on cross-origin redirect|should preserve basic auth on same-origin 303 POST -> GET redirect"`
- `npx eslint lib/adapters/http.js tests/unit/adapters/http.test.js`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Harden Node HTTP redirects by stripping auth-like headers on cross-origin hops and restoring only on same-origin. Add early URL validation for malformed http(s) strings and guard `setKeepAlive` on proxy sockets; plus regression tests.

**Description**
- Summary of changes
  - `lib/adapters/http.js`: Strip `authorization`, `cookie`, and `x-*` auth-like headers on cross-origin redirects; restore HTTP basic auth only for same-origin redirects. Guard `socket.setKeepAlive` to avoid errors on proxy sockets.
  - `lib/core/buildFullPath.js`: Reject malformed `http:`/`https:` URLs missing `//` with `ERR_INVALID_URL` and a suggested fix.
- Reasoning
  - Prevent credential/header leakage across origins per threat model and recent `follow-redirects` behavior.
  - Avoid crashes when sockets don’t implement `setKeepAlive`.
  - Fail fast on malformed URLs to avoid accidental requests.
- Additional context
  - Uses `follow-redirects` redirect hooks to strip headers consistently across redirects.

**Docs**
- Update `/docs/`:
  - Document Node adapter redirect behavior: cross-origin headers stripped; same-origin basic auth restored.
  - Note stricter URL validation for `http(s):` without `//` and example error message.

**Testing**
- Added/updated unit tests:
  - Cross-origin redirect strips auth-like headers; same-origin preserves them.
  - Same-origin multi-hop preserves basic auth.
  - Tolerates sockets without `setKeepAlive`.
  - `buildFullPath` throws `ERR_INVALID_URL` for `https:example.com` and prevents request dispatch.
- No additional tests required.

**Semantic version impact**
- Patch: security and stability fixes with stricter validation. Low risk; no API changes, but malformed URL inputs now error earlier and cross-origin auth-like headers are no longer forwarded.

<sup>Written for commit 7037a73aea351bc089198de0939aeafe6292bc55. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/axios/axios/pull/10977?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

