### PR TITLE
types: make AxiosResponse headers methods always available

### DIFF
--- a/index.d.cts
+++ b/index.d.cts
@@ -595,7 +595,7 @@ declare namespace axios {
     data: T;
     status: number;
     statusText: string;
-    headers: (H & RawAxiosResponseHeaders) | AxiosResponseHeaders;
+    headers: AxiosResponseHeaders & H;
     config: InternalAxiosRequestConfig<D>;
     request?: any;
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -488,7 +488,7 @@ export interface AxiosResponse<T = any, D = any, H = {}> {
   data: T;
   status: number;
   statusText: string;
-  headers: (H & RawAxiosResponseHeaders) | AxiosResponseHeaders;
+  headers: AxiosResponseHeaders & H;
   config: InternalAxiosRequestConfig<D>;
   request?: any;
 }

--- a/tests/module/cjs/tests/helpers/cjs-typing.ts
+++ b/tests/module/cjs/tests/helpers/cjs-typing.ts
@@ -51,6 +51,8 @@ const handleResponse = (response: axios.AxiosResponse) => {
   console.log(response.data);
   console.log(response.status);
   console.log(response.statusText);
+  console.log(response.headers.get('content-type'));
+  console.log(response.headers.getContentType());
   console.log(response.headers);
   console.log(response.config);
 };
@@ -114,6 +116,7 @@ const handleUserResponse = (response: axios.AxiosResponse<User>) => {
   console.log(response.data.name);
   console.log(response.status);
   console.log(response.statusText);
+  console.log(response.headers.get('x-header'));
   console.log(response.headers);
   console.log(response.config);
 };

--- a/tests/module/esm/tests/helpers/esm-index.ts
+++ b/tests/module/esm/tests/helpers/esm-index.ts
@@ -73,6 +73,8 @@ const handleResponse = (response: AxiosResponse) => {
   console.log(response.data);
   console.log(response.status);
   console.log(response.statusText);
+  console.log(response.headers.get('content-type'));
+  console.log(response.headers.getContentType());
   console.log(response.headers);
   console.log(response.config);
 };
@@ -136,6 +138,7 @@ const handleUserResponse = (response: AxiosResponse<User>) => {
   console.log(response.data.name);
   console.log(response.status);
   console.log(response.statusText);
+  console.log(response.headers.get('x-header'));
   console.log(response.headers);
   console.log(response.config);
 };


### PR DESCRIPTION
## Summary
Make `AxiosResponse` header typing always expose Axios response header helpers.

### Changes
- Updated `AxiosResponse` typing in both declarations:
  - `index.d.ts`
  - `index.d.cts`
  - changed `headers` from `(H & RawAxiosResponseHeaders) | AxiosResponseHeaders` to `AxiosResponseHeaders & H`
- Extended module typing validation fixtures:
  - `tests/module/cjs/tests/helpers/cjs-typing.ts`
  - `tests/module/esm/tests/helpers/esm-index.ts`
- These updates ensure `.get()` / `.getContentType()` and typed custom headers are available on `response.headers`.

## Validation
- Focused module typing tests were executed:
  - `npm run test:module:cjs`
  - `npm run test:module:esm`
- Result: both suites currently fail in this workspace because module fixture runtime setup cannot resolve local `axios` package (`Cannot find module ''axios''`) from generated temp test project. No functional runtime code changes were made.

## Notes
- Non-doc change only (types + type tests).
- Commit is signed-off-by.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure `AxiosResponse.headers` always exposes helper methods by typing it as `AxiosResponseHeaders & H`. Adds CJS/ESM typing checks for `.get()`, `.getContentType()`, and typed custom headers.

## Description

- Summary of changes
  - Updated `AxiosResponse['headers']` to `AxiosResponseHeaders & H` in `index.d.ts` and `index.d.cts`.
  - Extended typing fixtures to assert `headers.get()`, `headers.getContentType()`, and typed custom headers.
- Reasoning
  - The previous union could hide header helpers at the type level.
  - Aligns types with runtime and improves DX.
- Additional context
  - Type-only change; no runtime behavior modified.

## Docs

- Update `/docs/` to state `response.headers` always exposes `.get()` and `.getContentType()`, and show typed custom header access via the `H` generic.

## Testing

- Modified typing fixtures in CJS and ESM to cover header helper methods and a custom header.
- No runtime tests added; not needed for this type-only fix.
- Note: module fixture runners may fail to resolve local `axios` in temp projects; unrelated to this change.

## Semantic version impact

- Patch: TypeScript typings fix that reflects actual behavior without breaking runtime APIs.

<sup>Written for commit 34799104b6af9181451d1885135a88df69138b87. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/axios/axios/pull/10979?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

