### PR TITLE
fix: remove forced multipart/form-data placeholder header in postForm/putForm/patchForm

### DIFF
--- a/lib/core/Axios.js
+++ b/lib/core/Axios.js
@@ -258,11 +258,7 @@ utils.forEach(['post', 'put', 'patch', 'query'], function forEachMethodWithData(
       return this.request(
         mergeConfig(config || {}, {
           method,
-          headers: isForm
-            ? {
-                'Content-Type': 'multipart/form-data',
-              }
-            : {},
+          headers: isForm ? {} : {},
           url,
           data,
         })


### PR DESCRIPTION
Fixes axios/axios #10886.

Removes the forced bare `Content-Type: multipart/form-data` placeholder header in `postForm`/`putForm`/`patchForm` helper methods. The adapter now correctly sets the Content-Type with the proper boundary.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the forced multipart/form-data placeholder header from form helpers so the adapter sets the correct Content-Type with boundary. Fixes #10886 and ensures proper multipart uploads.

**Description**
- Summary of changes
  - Stop setting a bare `Content-Type: multipart/form-data` in `postForm`/`putForm`/`patchForm`.
  - Leave headers empty so the adapter can add `multipart/form-data; boundary=...`.
- Reasoning
  - The placeholder header blocked the adapter from adding the required boundary.
- Additional context
  - Applies to all adapters/environments; behavior only changes for requests using FormData helpers.

**Docs**
- Update `/docs/` to clarify:
  - Do not set `Content-Type` manually for FormData; `axios` sets it with the correct boundary.
  - Examples for `postForm`/`putForm`/`patchForm` should omit manual headers.

**Testing**
- No tests added in this PR.
- Recommended:
  - Add tests ensuring the request headers include `multipart/form-data; boundary=...` when using FormData with helpers.
  - Verify no bare `multipart/form-data` header is sent by default.
  - Confirm explicit user-provided `Content-Type` (if set) is respected.

**Semantic version impact**
- Patch: bug fix with no API changes.

<sup>Written for commit 56edece003813af460a5004da95194c88ca40472. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/axios/axios/pull/10980?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

