### PR TITLE
fix: correct 'the the' typo in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1432,7 +1432,7 @@ This functionality is considered as a fix.
 
 - fix: improve AxiosHeaders class [#5224](https://github.com/axios/axios/pull/5224)
 - fix: TypeScript type definitions for commonjs [#5196](https://github.com/axios/axios/pull/5196)
-- fix: type definition of use method on AxiosInterceptorManager to match the the README [#5071](https://github.com/axios/axios/pull/5071)
+- fix: type definition of use method on AxiosInterceptorManager to match the README [#5071](https://github.com/axios/axios/pull/5071)
 - fix: \_\_dirname is not defined in the sandbox [#5269](https://github.com/axios/axios/pull/5269)
 - fix: AxiosError.toJSON method to avoid circular references [#5247](https://github.com/axios/axios/pull/5247)
 - fix: Z_BUF_ERROR when content-encoding is set but the response body is empty [#5250](https://github.com/axios/axios/pull/5250)


### PR DESCRIPTION
## Summary
Fixed a duplicated word typo in CHANGELOG.md. Changed "the the" to "the" on line 1435.

## Linked issue
N/A

## Changes
- Fixed typo: "to match the the README" → "to match the README" in CHANGELOG.md

#### Checklist
- [x] Tests added or updated (or N/A with reason) — N/A, typo fix only
- [x] Docs/types updated if public API changed (`index.d.ts` and `index.d.cts`) — N/A
- [x] No breaking changes (or called out explicitly above) — no breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix duplicated word in `CHANGELOG.md` (“the the” → “the”) to clean up documentation. No code changes or runtime impact.

## Description

- Summary of changes
  - Corrected “to match the the README” → “to match the README” in `CHANGELOG.md` (around line 1435).
- Reasoning
  - Polish docs for clarity and professionalism.
- Additional context
  - No linked issue; docs-only tweak.

## Docs

No updates needed in `/docs/`. This change is limited to the changelog.

## Testing

No tests added. Not needed for a changelog typo fix.

## Semantic version impact

None. Documentation-only change; no package version update required.

<sup>Written for commit dbefbc563417bf1f12413daf13dac00484599464. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/axios/axios/pull/10984?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

