### PR TITLE
fix(AxiosURLSearchParams): use arrow function so encoder.call(this) receives the instance

### DIFF
--- a/PRE_RELEASE_CHANGELOG.md
+++ b/PRE_RELEASE_CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## Bug Fixes
 
+- **Params serialization:** Custom `paramsSerializer.encode` functions now receive the active `AxiosURLSearchParams` instance as `this`, matching the intended `encoder.call(this, value, defaultEncode)` behavior during query string construction. (**#11019**)
 - **HTTP Adapter - socketPath:** Path-only request URLs (e.g. `'/foo'`) now work again with `config.socketPath`, fixing the `TypeError [ERR_INVALID_URL]` regression introduced in 1.7.4 when `new URL()` was added to the dispatch path. A synthetic `http://localhost` base is supplied only when an own `socketPath` is set, so absolute URLs, non-socket requests, and prototype-polluted `socketPath` values are unaffected. (**#6611**)
 
 ## Release Tracking

--- a/lib/helpers/AxiosURLSearchParams.js
+++ b/lib/helpers/AxiosURLSearchParams.js
@@ -46,9 +46,7 @@ prototype.append = function append(name, value) {
 
 prototype.toString = function toString(encoder) {
   const _encode = encoder
-    ? function (value) {
-        return encoder.call(this, value, encode);
-      }
+    ? (value) => encoder.call(this, value, encode)
     : encode;
 
   return this._pairs

--- a/tests/unit/helpers/AxiosURLSearchParams.test.js
+++ b/tests/unit/helpers/AxiosURLSearchParams.test.js
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import AxiosURLSearchParams from '../../../lib/helpers/AxiosURLSearchParams.js';
+
+describe('AxiosURLSearchParams::toString', () => {
+  it('should pass the AxiosURLSearchParams instance as `this` to a custom encoder', () => {
+    const params = new AxiosURLSearchParams({ foo: 'bar', baz: 'qux' });
+    let capturedThis;
+
+    params.toString(function customEncoder(value, defaultEncode) {
+      capturedThis = this;
+      return defaultEncode(value);
+    });
+
+    expect(capturedThis).toBe(params);
+  });
+});

--- a/tests/unit/helpers/AxiosURLSearchParams.test.js
+++ b/tests/unit/helpers/AxiosURLSearchParams.test.js
@@ -4,13 +4,14 @@ import AxiosURLSearchParams from '../../../lib/helpers/AxiosURLSearchParams.js';
 describe('AxiosURLSearchParams::toString', () => {
   it('should pass the AxiosURLSearchParams instance as `this` to a custom encoder', () => {
     const params = new AxiosURLSearchParams({ foo: 'bar', baz: 'qux' });
-    let capturedThis;
+    const capturedThis = [];
 
-    params.toString(function customEncoder(value, defaultEncode) {
-      capturedThis = this;
+    const serialized = params.toString(function customEncoder(value, defaultEncode) {
+      capturedThis.push(this);
       return defaultEncode(value);
     });
 
-    expect(capturedThis).toBe(params);
+    expect(serialized).toBe('foo=bar&baz=qux');
+    expect(capturedThis).toEqual([params, params, params, params]);
   });
 });

--- a/tests/unit/helpers/buildURL.test.js
+++ b/tests/unit/helpers/buildURL.test.js
@@ -63,6 +63,21 @@ describe('helpers::buildURL', () => {
     ).toEqual('/foo?foo%5B%5D=bar&foo%5B%5D=baz');
   });
 
+  it('should pass the params serializer instance as `this` to custom encode', () => {
+    const capturedThis = [];
+
+    expect(
+      buildURL('/foo', { foo: 'bar', baz: 'qux' }, {
+        encode(value, defaultEncode) {
+          capturedThis.push(this);
+          return defaultEncode(value);
+        },
+      })
+    ).toEqual('/foo?foo=bar&baz=qux');
+    expect(capturedThis).toHaveLength(4);
+    expect(new Set(capturedThis).size).toBe(1);
+  });
+
   it('should support special char params', () => {
     expect(
       buildURL('/foo', {


### PR DESCRIPTION
## Summary

`AxiosURLSearchParams.prototype.toString` passes `undefined` as `this` to custom
encoders instead of the `AxiosURLSearchParams` instance, defeating the
`encoder.call(this, value, encode)` call that was always intended to forward
context.

## Root cause

The `_encode` helper was defined as a regular `function` expression:

```js
const _encode = encoder
  ? function (value) {
      return encoder.call(this, value, encode);
    }
  : encode;
```

Because `_encode` is invoked as a plain call (`_encode(pair[0])`) rather than as
a method, `this` inside the function body resolves to `undefined` in strict mode
(axios uses ES modules which are always strict).  The `encoder.call(this, ...)` 
therefore effectively becomes `encoder.call(undefined, ...)`.

## Fix

Use an arrow function so `this` is captured lexically from `toString`'s scope,
where it IS the `AxiosURLSearchParams` instance:

```js
const _encode = encoder
  ? (value) => encoder.call(this, value, encode)
  : encode;
```

## Verification

New unit test in `tests/unit/helpers/AxiosURLSearchParams.test.js`:

```
npx vitest run tests/unit/helpers/AxiosURLSearchParams.test.js
```

- **Before fix:** `expected undefined to be { Object (_pairs) }` ❌
- **After fix:** 1 test passed ✅

Full helper + core suite (242 tests) passes unchanged.

## Changes

- `lib/helpers/AxiosURLSearchParams.js` — arrow function for `_encode` (1 line)
- `tests/unit/helpers/AxiosURLSearchParams.test.js` — new focused test file

#### Checklist

- [x] Tests added or updated
- [x] No breaking changes (existing encoders that don't use `this` are unaffected; the previous `this = undefined` was a bug, not a feature)

:surfer:

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes params serialization so custom encoders receive the active `AxiosURLSearchParams` instance as `this` by switching the internal `_encode` wrapper to an arrow function. Adds focused tests to verify context propagation in `AxiosURLSearchParams.toString()` and `buildURL`’s `paramsSerializer.encode`.

**Description**
- Summary of changes
  - Use an arrow function for `_encode` in `lib/helpers/AxiosURLSearchParams.js`.
  - Add changelog entry in `PRE_RELEASE_CHANGELOG.md`.
- Reasoning
  - Regular functions lose `this` in strict mode; an arrow captures lexical `this` so `encoder.call(this, ...)` forwards the instance.
- Additional context
  - Ensures `AxiosURLSearchParams.toString()` and `buildURL`’s `paramsSerializer.encode` both receive the correct instance as `this`.

**Docs**
- Update `/docs/` to state that custom encoders for `AxiosURLSearchParams.toString()` and `paramsSerializer.encode` receive their instance as `this`.

**Testing**
- Added `tests/unit/helpers/AxiosURLSearchParams.test.js` to verify the encoder’s `this` is the params instance.
- Updated `tests/unit/helpers/buildURL.test.js` to verify `paramsSerializer.encode` receives the serializer instance as `this`.
- No other test changes needed.

**Semantic version impact**
- Patch: bug fix with no API changes.

<sup>Written for commit 3f3c13f63fb00c31e54e45b7eee73e69ec883014. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/axios/axios/pull/11019?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

