### PR TITLE
docs: add Deno to install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,6 +430,12 @@ Using bun:
 $ bun add axios
 ```
 
+Using Deno:
+
+```bash
+$ deno add axios
+```
+
 Once the package is installed, import it with `import` or `require`:
 
 ```js


### PR DESCRIPTION
## Summary

👋 Bartek from the Deno team here. This adds a Deno entry to the README "Installing → Package manager" section, alongside the existing npm / yarn / pnpm / bun entries. axios already runs Deno smoke tests in CI, so Deno is a supported runtime; this just gives Deno users a copy-pasteable install command in parity with the others.

## Linked issue

N/A — docs-only, trivial addition.

## Changes

- Add a `Using Deno:` block with `deno add axios` after the bun entry in the README "Installing" section.

#### Checklist

- [x] Tests added or updated (N/A — docs only)
- [x] Docs/types updated if public API changed (N/A — no API change)
- [x] No breaking changes

:surfer:

_Disclosure: I work on Deno, so I have an interest here. The goal is parity with the package managers you already list, not promotion. This PR was prepared with AI assistance under human supervision: I review every change myself and personally respond to any comments or review feedback._


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Deno install command to the README so users can copy-paste `deno add axios` alongside npm/yarn/pnpm/bun. No code changes; documentation parity for `axios` in the Deno ecosystem.

## Description
- Add “Using Deno” block with `deno add axios` after the bun entry in the README.
- Reasoning: `axios` supports Deno; this improves discoverability and parity for Deno users.

## Docs
- Mirror the Deno install command on the docs site under `/docs/` (installation page).

## Testing
- No tests added; docs-only change.
- Existing CI covers Deno smoke tests.

## Semantic version impact
- Patch: documentation update only; no API or behavior changes.

<sup>Written for commit e1a9f7ae2896dc8173936cabfd414c487c220a44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/axios/axios/pull/11023?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

