### PR TITLE
chore(deps): bump form-data floor to ^4.0.6 to patch CRLF injection

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
   },
   "dependencies": {
     "follow-redirects": "^1.16.0",
-    "form-data": "^4.0.5",
+    "form-data": "^4.0.6",
     "https-proxy-agent": "^5.0.1",
     "proxy-from-env": "^2.1.0"
   },


### PR DESCRIPTION
## Summary

Bumps the `form-data` runtime dependency range floor from `^4.0.5` to `^4.0.6`.

`form-data` versions `>=4.0.0 <4.0.6` are affected by a CRLF injection via unescaped multipart field names and filenames ([GHSA-hmw2-7cc7-3qxx](https://github.com/advisories/GHSA-hmw2-7cc7-3qxx), high severity). The current `^4.0.5` floor still permits the vulnerable `4.0.5`, so consumers see `npm audit` warnings until they manually override the transitive resolution.

The committed `package-lock.json` already resolves `form-data@4.0.6` (via #11015), so this only raises the published floor so fresh installs and downstream consumers pick up the patched version by default. No lockfile change is required.

This mirrors the previous form-data security floor bump in #6978 (`4.0.0 → 4.0.4`).

## Changes

- `package.json`: `form-data` `^4.0.5` → `^4.0.6`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raises the `form-data` dependency floor to `^4.0.6` to patch a CRLF injection vulnerability and silence `npm audit` warnings for consumers. No code changes; ensures fresh installs resolve the patched version.

**Description**
- Change: `package.json` `form-data` `^4.0.5` → `^4.0.6`
- Reason: fix CRLF injection in `>=4.0.0 <4.0.6` (GHSA-hmw2-7cc7-3qxx)
- Context: lockfile already on `4.0.6`; no lock updates needed
- Docs: if dependency versions are documented, update `/docs/` to show `form-data@^4.0.6`
- Testing: no tests changed; none needed for a dependency floor bump

**Semantic version impact**
- Patch: no API changes; safer default dependency resolution

<sup>Written for commit e74394b4ce9dadc139b7ba5f6589f47294ad0b7f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/axios/axios/pull/11028?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

