### PR TITLE
fix(security): update ws dependency to fix CVE-2024-37890

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9984,9 +9984,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -195,6 +195,9 @@
       "@commitlint/config-conventional"
     ]
   },
+  "overrides": {
+    "ws": ">=8.21.0"
+  },
   "lint-staged": {
     "*.{js,cjs,mjs,ts,json,md,yml,yaml}": "prettier --write"
   }


### PR DESCRIPTION
## Description

This PR fixes **CVE-2024-37890** (GHSA-96hv-2xvq-fx4p) - a **high severity** memory exhaustion Denial of Service vulnerability in the `ws` package.

### Impact
The `ws@8.20.1` package (a transitive dev dependency via `@vitest/browser`) is vulnerable to a DoS attack where an attacker can cause memory exhaustion by sending specially crafted frames.

### Fix
- Added `"overrides"` in `package.json` to force `ws >= 8.21.0`
- Updated `package-lock.json` to resolve `ws` to `8.21.0`
- Verified with `npm audit` - 0 vulnerabilities found

### References
- https://github.com/advisories/GHSA-96hv-2xvq-fx4p
- https://nvd.nist.gov/vuln/detail/CVE-2024-37890

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force `ws` to >=8.21.0 via `overrides` to patch CVE-2024-37890 and prevent a high‑severity DoS via memory exhaustion. This affects a transitive dev dependency from `@vitest/browser`; no runtime code changes.

## Description

- Summary of changes
  - Added `overrides` in `package.json` to require `ws >= 8.21.0`.
  - Updated `package-lock.json` to resolve `ws` to `8.21.0`.

- Reasoning
  - Addresses GHSA-96hv-2xvq-fx4p (CVE-2024-37890) in `ws`.
  - Ensures all resolutions use the patched version, including transitive dev deps.

- Additional context
  - `npm audit` shows 0 vulnerabilities after the update.
  - References: GHSA-96hv-2xvq-fx4p, CVE-2024-37890.

## Docs

Add a short note in `/docs/` about enforced dependency overrides, including the `ws` security pin, so contributors understand why it’s present and must not be removed.

## Testing

- No tests added or modified.
- Verified with `npm audit` (0 vulns). Recommend running the full test suite to confirm no regressions in dev/test flows that use `@vitest/browser`.

## Semantic version impact

Patch: dependency resolution change only; no public API or behavior changes.

<sup>Written for commit 72235c6f50a6bb85809aa85b5005bfbca363bba7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/axios/axios/pull/11034?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

