### PR TITLE
fix(utils): use defineProperty in inherits to handle non-writable inherited props

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -583,7 +583,9 @@ const inherits = (constructor, superConstructor, props, descriptors) => {
     __proto__: null,
     value: superConstructor.prototype,
   });
-  props && Object.assign(constructor.prototype, props);
+  props && Object.keys(props).forEach((key) =>
+    Object.defineProperty(constructor.prototype, key, Object.getOwnPropertyDescriptor(props, key))
+  );
 };
 
 /**

--- a/tests/unit/utils/inherits.test.js
+++ b/tests/unit/utils/inherits.test.js
@@ -1,0 +1,79 @@
+import { describe, it, afterEach } from 'vitest';
+import assert from 'assert';
+import utils from '../../../lib/utils.js';
+
+describe('utils::inherits', () => {
+  let savedDescriptor;
+
+  afterEach(() => {
+    // Restore Error.prototype.toJSON to whatever it was before the test.
+    if (savedDescriptor !== undefined) {
+      Object.defineProperty(Error.prototype, 'toJSON', savedDescriptor);
+    } else if (Object.prototype.hasOwnProperty.call(Error.prototype, 'toJSON')) {
+      delete Error.prototype.toJSON;
+    }
+    savedDescriptor = undefined;
+  });
+
+  it('should set up prototype chain and constructor reference', () => {
+    function Parent() {}
+    Parent.prototype.greet = function () {
+      return 'hello';
+    };
+
+    function Child() {}
+    utils.inherits(Child, Parent);
+
+    assert.strictEqual(Child.prototype.constructor, Child);
+    assert.strictEqual(Child.super, Parent.prototype);
+    assert.strictEqual(new Child().greet(), 'hello');
+  });
+
+  it('should copy props onto the child prototype', () => {
+    function Parent() {}
+    function Child() {}
+    utils.inherits(Child, Parent, {
+      foo() {
+        return 42;
+      },
+    });
+
+    assert.strictEqual(new Child().foo(), 42);
+  });
+
+  it('should not throw when a non-writable inherited property shares a name with props', () => {
+    // Simulate a third-party library freezing Error.prototype.toJSON as non-writable.
+    // utils.inherits must use Object.defineProperty semantics (not [[Set]]) so it
+    // can write directly to the child prototype without tripping over the inherited
+    // non-writable descriptor.
+    savedDescriptor = Object.getOwnPropertyDescriptor(Error.prototype, 'toJSON');
+
+    Object.defineProperty(Error.prototype, 'toJSON', {
+      configurable: true,
+      writable: false,
+      enumerable: false,
+      value: function () {
+        return {};
+      },
+    });
+
+    function MyError(message) {
+      this.message = message;
+    }
+
+    assert.doesNotThrow(() => {
+      utils.inherits(MyError, Error, {
+        toJSON() {
+          return { message: this.message };
+        },
+      });
+    }, 'inherits must not throw due to non-writable inherited toJSON');
+
+    const err = new MyError('boom');
+    assert.deepStrictEqual(
+      err.toJSON(),
+      { message: 'boom' },
+      'own toJSON on child prototype should shadow the inherited non-writable one'
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Closes #6690

`utils.inherits` passes `props` to `Object.assign(constructor.prototype, props)`. `Object.assign` uses `[[Set]]` semantics, which respects inherited property descriptors. When a third-party library freezes a property on `Error.prototype` as non-writable (a real pattern used by logging and serialization libraries), the `[[Set]]` operation throws:

```
TypeError: Cannot assign to read only property 'toJSON' of object 'Error'
```

## Fix

Replace `Object.assign` with per-key `Object.defineProperty` calls. `Object.defineProperty` writes an own property directly onto the target object and does not consult the prototype chain's writability constraints.

```js
// before
props && Object.assign(constructor.prototype, props);

// after
props && Object.keys(props).forEach((key) =>
  Object.defineProperty(constructor.prototype, key, Object.getOwnPropertyDescriptor(props, key))
);
```

## Reproduction

```js
Object.defineProperty(Error.prototype, 'toJSON', {
  configurable: true,
  writable: false,
  enumerable: false,
  value: function () { return {}; },
});

import utils from 'axios/lib/utils.js';

function MyError(msg) { this.message = msg; }

// Before fix: throws TypeError
// After fix:  succeeds, own toJSON is set on MyError.prototype
utils.inherits(MyError, Error, {
  toJSON() { return { message: this.message }; },
});
```

## Verification

New test file `tests/unit/utils/inherits.test.js` covers:
1. Basic prototype-chain wiring (constructor, super, inherited method)
2. Props correctly placed on the child prototype
3. **Bug case**: does not throw when an inherited non-writable property shares a name with a props key; the own prop shadows it correctly

```
✓ should set up prototype chain and constructor reference
✓ should copy props onto the child prototype
✓ should not throw when a non-writable inherited property shares a name with props
```

:surfer:

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash in `utils.inherits` when props conflict with non-writable inherited properties by defining own properties with `Object.defineProperty`. Adds unit tests to cover the non-writable `Error.prototype` case and prevent regressions.

- **Bug Fixes**
  - Replaced `Object.assign` with per-key `Object.defineProperty` using source descriptors to shadow non-writable inherited props (e.g., `Error.prototype.toJSON`).
  - Tests: Added `tests/unit/utils/inherits.test.js` for prototype wiring, props copy, and the non-writable inheritance case.
  - Docs: Please add a short note in `/docs/` explaining that `utils.inherits` defines own props and safely shadows non-writable inherited ones.
  - SemVer: Patch (bug fix, no API changes).

<sup>Written for commit fd732e9fa0c7d3ebc9c2f083a0946f9b90e222ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/axios/axios/pull/11045?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

