### PR TITLE
[codex] Avoid prototype collisions in header parsing

### DIFF
--- a/PRE_RELEASE_CHANGELOG.md
+++ b/PRE_RELEASE_CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## Bug Fixes
 
+- **Headers:** Raw response header parsing now preserves valid header names such as `constructor`, `toString`, and `__proto__`, and singleton duplicate detection no longer depends on inherited `Object.prototype` values.
 - **Params serialization:** Custom `paramsSerializer.encode` functions now receive the active `AxiosURLSearchParams` instance as `this`, matching the intended `encoder.call(this, value, defaultEncode)` behavior during query string construction. (**#11019**)
 - **Runtime and types hardening:** Guarded several edge-case crashes in cookie decoding, data URI parsing, form serialization, config merging, option validation, XHR cleanup, and Node HTTP URL serialization error handling. Type declarations now expose missing `CanceledError`, `CancelToken`, `AxiosHeaders`, `SerializerOptions`, and Cloudflare 52x status-code members that already exist at runtime. (**#10959**)
 - **HTTP Adapter - native env proxy:** Avoid double-applying environment proxy handling when Node.js native HTTP proxy support is active for the selected agent. Axios still resolves env proxies itself when the selected agent is not using Node's `proxyEnv` support. (**#10942**, closes **#7299**)

--- a/lib/helpers/parseHeaders.js
+++ b/lib/helpers/parseHeaders.js
@@ -39,7 +39,7 @@ const ignoreDuplicateOf = utils.toObjectSet([
  * @returns {Object} Headers parsed into an object
  */
 export default (rawHeaders) => {
-  const parsed = {};
+  const parsed = Object.create(null);
   let key;
   let val;
   let i;
@@ -50,7 +50,7 @@ export default (rawHeaders) => {
       key = line.substring(0, i).trim().toLowerCase();
       val = line.substring(i + 1).trim();
 
-      if (!key || (parsed[key] && ignoreDuplicateOf[key])) {
+      if (!key || (utils.hasOwnProp(parsed, key) && ignoreDuplicateOf[key])) {
         return;
       }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -789,7 +789,7 @@ const freezeMethods = (obj) => {
  * @returns {Object} An object with keys from the array or string, values set to true.
  */
 const toObjectSet = (arrayOrString, delimiter) => {
-  const obj = {};
+  const obj = Object.create(null);
 
   const define = (arr) => {
     arr.forEach((value) => {

--- a/tests/unit/helpers/parseHeaders.test.js
+++ b/tests/unit/helpers/parseHeaders.test.js
@@ -40,4 +40,24 @@ describe('helpers::parseHeaders', () => {
     expect(parsed.age).toEqual('age-a');
     expect(parsed.foo).toEqual('foo-a, foo-b');
   });
+
+  it('should parse header names that match Object prototype properties', () => {
+    const parsed = parseHeaders(
+      '__proto__: proto-value\n' +
+        'Constructor: constructor-value\n' +
+        'ToString: tostring-value'
+    );
+
+    expect(Object.getPrototypeOf(parsed)).toBeNull();
+    expect(Object.prototype.hasOwnProperty.call(parsed, '__proto__')).toBe(true);
+    expect(parsed['__proto__']).toEqual('proto-value');
+    expect(parsed.constructor).toEqual('constructor-value');
+    expect(parsed.tostring).toEqual('tostring-value');
+  });
+
+  it('should ignore duplicate singleton headers even when the first value is empty', () => {
+    const parsed = parseHeaders('Content-Type:\nContent-Type: text/plain');
+
+    expect(parsed['content-type']).toEqual('');
+  });
 });


### PR DESCRIPTION
## Summary
- Use null-prototype objects for raw header parsing so valid header names like constructor and __proto__ do not collide with Object.prototype.

## Validation
- axios unit tests passed; eslint and diff check passed.

## Notes
- Opened as a draft PR for maintainer review.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix header parsing to avoid prototype collisions by using null-prototype objects. Preserves header names like `constructor`, `toString`, and `__proto__`, and makes singleton duplicate detection reliable.

- **Bug Fixes**
  - Parse into `Object.create(null)` in `parseHeaders`; singleton duplicate checks now use `utils.hasOwnProp`.
  - `utils.toObjectSet` now returns a null-prototype map to avoid inherited key collisions.
  - Tests added for prototype-like header names and for singleton headers when the first value is empty.
  - Docs: Add a short note in `/docs/headers.md` about preserving prototype-like names and singleton duplicate behavior.
  - Semantic version impact: Patch.

<sup>Written for commit c123a42604f60a7c73af4ca4953e64052e37f652. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/axios/axios/pull/11047?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

