### PR TITLE
build: generate sourcemaps only for published bundles

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "dist/node/axios.cjs"
   ],
   "scripts": {
-    "build": "gulp clear && cross-env NODE_ENV=production rollup -c -m",
+    "build": "gulp clear && cross-env NODE_ENV=production rollup -c",
     "version": "npm run build && git add package.json",
     "preversion": "gulp version",
     "test": "npm run test:vitest",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -28,6 +28,7 @@ const buildConfig = ({ es5, browser = true, minifiedVersion = true, alias, ...co
     output: {
       ...config.output,
       file: `${path.dirname(file)}/${basename}.${(minified ? ['min', ...extArr] : extArr).join('.')}`,
+      sourcemap: minified,
     },
     plugins: [
       aliasPlugin({


### PR DESCRIPTION
## Summary

This PR updates the build configuration so that source maps are generated only for the bundles whose `.map` files are published in the npm package.

Previously, Rollup generated source map references for all bundles because the global `-m` flag enabled sourcemaps everywhere. However, only the minified source map files are published, resulting in non-minified bundles referencing source maps that do not exist in the published package.

## Linked issue

Related to #11052

## Changes

- Removed the global `-m` flag from the Rollup build command in `package.json`.
- Enabled sourcemaps only for minified bundles in `rollup.config.js`.
- Preserved source maps for published minified bundles.
- Prevented non-minified bundles from referencing unpublished source map files.

#### Checklist

- [x] Tests added or updated (or N/A with reason)
  - N/A. No runtime functionality was changed. The implementation only modifies the build configuration. The project was built successfully and existing tests were executed. The remaining test failure was caused by a missing local Playwright browser installation rather than this change.
- [x] Docs/types updated if public API changed (`index.d.ts` and `index.d.cts`)
  - N/A
- [x] No breaking changes (or called out explicitly above)

:surfer:

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Generates sourcemaps only for minified bundles that are published. Fixes broken source map references in non‑minified builds without changing runtime behavior.

- **Bug Fixes**
  - Removed global `-m` from the `rollup` build script in `package.json`.
  - Set `sourcemap` only for minified outputs in `rollup.config.js`.
  - Non‑minified bundles no longer reference unpublished `.map` files.
  - Docs: Suggest a short note in `/docs/` about which bundles ship with sourcemaps.
  - Testing: No new tests. Build‑only change; existing tests cover runtime.

- **Semantic version impact**
  - Patch: build output metadata only; no API or runtime changes.

<sup>Written for commit 98806a05c025034f6cfa0d813d57a4067695018b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/axios/axios/pull/11054?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

