### PR TITLE
fix(core): synthesize AxiosError message from AggregateError.errors

### DIFF
--- a/PRE_RELEASE_CHANGELOG.md
+++ b/PRE_RELEASE_CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ## Bug Fixes
 
+- **AxiosError - aggregate errors:** `AxiosError.from()` now synthesizes a message from nested `AggregateError` entries when the outer message is blank, preserving dual-stack connection failure details in structured logs. (**#11059**, closes **#6721**)
 - **AxiosError:** `AxiosError#toJSON()` now serializes `Set` values in request config snapshots as arrays instead of empty objects. (**#11044**, refs **#5910**)
 - **HTTP Adapter - download progress:** Flushed the final `onDownloadProgress` callback before streamed responses emit `close`, preventing trailing progress notifications after consumers observe the stream as closed. (closes **#6878**)
 - **URL construction:** `combineURLs()` now removes repeated trailing slashes from `baseURL` before joining a relative request URL, avoiding unintended double slashes in the final request path. (**#11038**)

--- a/lib/core/AxiosError.js
+++ b/lib/core/AxiosError.js
@@ -72,6 +72,29 @@ function redactConfig(config, redactKeys) {
   return visit(config);
 }
 
+function stringifySafely(value) {
+  try {
+    return String(value);
+  } catch (err) {
+    return '';
+  }
+}
+
+function aggregateErrorMessage(error) {
+  const message = error.errors
+    .map((entry) => {
+      try {
+        return entry && entry.message ? stringifySafely(entry.message) : stringifySafely(entry);
+      } catch (err) {
+        return '';
+      }
+    })
+    .filter(Boolean)
+    .join('; ');
+
+  return message || error.name || 'AggregateError';
+}
+
 class AxiosError extends Error {
   static from(error, code, config, request, response, customProps) {
     // `AggregateError` (thrown by Node on dual-stack/Happy-Eyeballs connection
@@ -79,7 +102,7 @@ class AxiosError extends Error {
     // this, the wrapped error surfaces with a blank message (see #6721).
     let message = error.message;
     if (!message && utils.isArray(error.errors) && error.errors.length) {
-      message = error.errors.map(e => (e && e.message) || String(e)).filter(Boolean).join('; ');
+      message = aggregateErrorMessage(error);
     }
 
     const axiosError = new AxiosError(message, code || error.code, config, request, response);

--- a/lib/core/AxiosError.js
+++ b/lib/core/AxiosError.js
@@ -74,7 +74,15 @@ function redactConfig(config, redactKeys) {
 
 class AxiosError extends Error {
   static from(error, code, config, request, response, customProps) {
-    const axiosError = new AxiosError(error.message, code || error.code, config, request, response);
+    // `AggregateError` (thrown by Node on dual-stack/Happy-Eyeballs connection
+    // failures) has an empty `message`; its detail lives in `errors[]`. Without
+    // this, the wrapped error surfaces with a blank message (see #6721).
+    let message = error.message;
+    if (!message && utils.isArray(error.errors) && error.errors.length) {
+      message = error.errors.map(e => (e && e.message) || String(e)).filter(Boolean).join('; ');
+    }
+
+    const axiosError = new AxiosError(message, code || error.code, config, request, response);
     // Match native `Error` `cause` semantics: non-enumerable. The wrapped
     // error often carries circular internals (sockets, requests, agents), so
     // an enumerable `cause` makes structured loggers (pino/winston) and any

--- a/tests/unit/core/AxiosError.test.js
+++ b/tests/unit/core/AxiosError.test.js
@@ -92,15 +92,43 @@ describe('core::AxiosError', () => {
     });
 
     it('synthesizes a message from AggregateError.errors when the aggregate message is empty (#6721)', () => {
-      const timeout = Object.assign(new Error('connect ETIMEDOUT 1.2.3.4:443'), { code: 'ETIMEDOUT' });
-      const unreach = Object.assign(new Error('connect EHOSTUNREACH ::1:443'), { code: 'EHOSTUNREACH' });
+      const timeout = Object.assign(new Error('connect ETIMEDOUT 1.2.3.4:443'), {
+        code: 'ETIMEDOUT',
+      });
+      const unreach = Object.assign(new Error('connect EHOSTUNREACH ::1:443'), {
+        code: 'EHOSTUNREACH',
+      });
       const aggregate = new AggregateError([timeout, unreach]);
       expect(aggregate.message).toBe('');
 
       const axiosError = AxiosError.from(aggregate, 'ETIMEDOUT', { foo: 'bar' });
 
-      expect(axiosError.message).toContain('connect ETIMEDOUT 1.2.3.4:443');
-      expect(axiosError.message).toContain('connect EHOSTUNREACH ::1:443');
+      const expectedMessage = 'connect ETIMEDOUT 1.2.3.4:443; connect EHOSTUNREACH ::1:443';
+      expect(axiosError.message).toBe(expectedMessage);
+      expect(axiosError.toJSON().message).toBe(expectedMessage);
+    });
+
+    it('preserves an explicit AggregateError message', () => {
+      const aggregate = new AggregateError([new Error('inner failure')], 'outer failure');
+
+      const axiosError = AxiosError.from(aggregate, 'ETIMEDOUT', {});
+
+      expect(axiosError.message).toBe('outer failure');
+    });
+
+    it('ignores aggregate entries that cannot be converted to strings', () => {
+      const throwsOnCoercion = {
+        [Symbol.toPrimitive]() {
+          throw new Error('cannot convert');
+        },
+      };
+      const aggregate = new AggregateError([Object.create(null), throwsOnCoercion]);
+
+      const axiosError = AxiosError.from(aggregate, 'ETIMEDOUT', {});
+
+      expect(axiosError).toBeInstanceOf(AxiosError);
+      expect(axiosError.message).toBe('AggregateError');
+      expect(axiosError.cause).toBe(aggregate);
     });
 
     it('leaves a normal error message unchanged', () => {

--- a/tests/unit/core/AxiosError.test.js
+++ b/tests/unit/core/AxiosError.test.js
@@ -90,6 +90,24 @@ describe('core::AxiosError', () => {
 
       expect(axiosError.status).toBe(404);
     });
+
+    it('synthesizes a message from AggregateError.errors when the aggregate message is empty (#6721)', () => {
+      const timeout = Object.assign(new Error('connect ETIMEDOUT 1.2.3.4:443'), { code: 'ETIMEDOUT' });
+      const unreach = Object.assign(new Error('connect EHOSTUNREACH ::1:443'), { code: 'EHOSTUNREACH' });
+      const aggregate = new AggregateError([timeout, unreach]);
+      expect(aggregate.message).toBe('');
+
+      const axiosError = AxiosError.from(aggregate, 'ETIMEDOUT', { foo: 'bar' });
+
+      expect(axiosError.message).toContain('connect ETIMEDOUT 1.2.3.4:443');
+      expect(axiosError.message).toContain('connect EHOSTUNREACH ::1:443');
+    });
+
+    it('leaves a normal error message unchanged', () => {
+      const axiosError = AxiosError.from(new Error('Boom!'), 'ESOMETHING', {});
+
+      expect(axiosError.message).toBe('Boom!');
+    });
   });
 
   describe('cause serialization (regression #7205)', () => {


### PR DESCRIPTION
## Summary

Node throws an `AggregateError` on dual-stack / Happy-Eyeballs connection failures (e.g. `ETIMEDOUT` + `EHOSTUNREACH`). An `AggregateError` has an **empty** `message` — the useful detail lives in `error.errors[]`. `AxiosError.from()` used `error.message` directly, so these failures surfaced with a **blank message**, and `toJSON()` / structured loggers (pino, winston) showed nothing useful. This is the "swallowed error" reported in #6721.

## Linked issue

Closes #6721

## Changes

- `lib/core/AxiosError.js`: in `AxiosError.from()`, when the source error has no `message` but has a non-empty `errors[]` array (i.e. an `AggregateError`), synthesize the message by joining the sub-error messages. Normal errors are unchanged; the non-enumerable `cause` semantics from #7205 are untouched.
- `tests/unit/core/AxiosError.test.js`: add a regression test asserting the synthesized message contains both sub-errors, plus a test confirming a normal error message passes through unchanged.

### Before / after

```js
const agg = new AggregateError([
  Object.assign(new Error("connect ETIMEDOUT 1.2.3.4:443"), { code: "ETIMEDOUT" }),
  Object.assign(new Error("connect EHOSTUNREACH ::1:443"), { code: "EHOSTUNREACH" }),
]);
AxiosError.from(agg, "ETIMEDOUT", {}).message
// before: ""   (blank — the bug)
// after:  "connect ETIMEDOUT 1.2.3.4:443; connect EHOSTUNREACH ::1:443"
```

The added test fails on `v1.x` without the fix and passes with it; all existing `AxiosError` tests continue to pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes blank Axios error messages when Node throws an `AggregateError` by synthesizing a safe message from its sub-errors. Hardens edge cases, preserves explicit outer messages and `cause`, and closes #6721.

## Description

- Summary of changes
  - In `AxiosError.from()`, when `error.message` is empty and `error.errors[]` exists, build the message by safely joining sub-error messages; ignore non-stringable entries and fall back to `error.name` or `AggregateError`. Preserve non-enumerable `cause`.
- Reasoning
  - Node’s dual-stack/Happy-Eyeballs failures can throw an `AggregateError` with an empty message, yielding blank logs (see #6721).
- Additional context
  - Only affects aggregates; explicit outer messages are left as-is. `toJSON()` now carries the synthesized message.

## Docs

- Update `/docs/` error handling to note synthesized messages from `AggregateError.errors`, safe string coercion, and the fallback behavior for network/DNS failures.

## Testing

- Added four unit tests in `tests/unit/core/AxiosError.test.js`:
  - Synthesizes a joined message from sub-errors.
  - Preserves an explicit aggregate message.
  - Ignores entries that cannot be converted to strings and falls back correctly.
  - Leaves normal error messages unchanged.

## Semantic version impact

Patch: bug fix with no API changes.

<sup>Written for commit 6d12762b6df56ae72a398b6a0be3d7a56b943d7b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/axios/axios/pull/11059?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

:surfer:
