### PR TITLE
fix(core): reject comma from AxiosHeaders valid header name pattern

### DIFF
--- a/PRE_RELEASE_CHANGELOG.md
+++ b/PRE_RELEASE_CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## Bug Fixes
 
-- **Headers:** `AxiosHeaders#set()` no longer treats a comma-containing string as a valid single header name; comma is a delimiter, not a `tchar`, per RFC 7230 section 3.2.6. (**#TBD**)
+- **Headers:** `AxiosHeaders#set()` no longer treats a comma-containing string as a valid single header name; comma is a delimiter, not a `tchar`, per RFC 7230 section 3.2.6. (**#11063**)
 - **AxiosError:** `AxiosError#toJSON()` now serializes `Set` values in request config snapshots as arrays instead of empty objects. (**#11044**, refs **#5910**)
 - **HTTP Adapter - download progress:** Flushed the final `onDownloadProgress` callback before streamed responses emit `close`, preventing trailing progress notifications after consumers observe the stream as closed. (closes **#6878**)
 - **URL construction:** `combineURLs()` now removes repeated trailing slashes from `baseURL` before joining a relative request URL, avoiding unintended double slashes in the final request path. (**#11038**)

--- a/PRE_RELEASE_CHANGELOG.md
+++ b/PRE_RELEASE_CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## Bug Fixes
 
+- **Headers:** `AxiosHeaders#set()` no longer treats a comma-containing string as a valid single header name; comma is a delimiter, not a `tchar`, per RFC 7230 section 3.2.6. (**#TBD**)
 - **AxiosError:** `AxiosError#toJSON()` now serializes `Set` values in request config snapshots as arrays instead of empty objects. (**#11044**, refs **#5910**)
 - **HTTP Adapter - download progress:** Flushed the final `onDownloadProgress` callback before streamed responses emit `close`, preventing trailing progress notifications after consumers observe the stream as closed. (closes **#6878**)
 - **URL construction:** `combineURLs()` now removes repeated trailing slashes from `baseURL` before joining a relative request URL, avoiding unintended double slashes in the final request path. (**#11038**)

--- a/lib/core/AxiosHeaders.js
+++ b/lib/core/AxiosHeaders.js
@@ -88,7 +88,11 @@ class AxiosHeaders {
     function setHeader(_value, _header, _rewrite) {
       const lHeader = normalizeHeader(_header);
 
-      if (!lHeader) {
+      // Reject at the point of storage so every input shape (plain object,
+      // Map/iterable, or a raw header-text line already split into name/value
+      // by parseHeaders) is covered, not just a bare string used directly as
+      // the header name.
+      if (!lHeader || !isValidHeaderName(lHeader)) {
         return;
       }
 

--- a/lib/core/AxiosHeaders.js
+++ b/lib/core/AxiosHeaders.js
@@ -30,7 +30,7 @@ function parseTokens(str) {
   return tokens;
 }
 
-const isValidHeaderName = (str) => /^[-_a-zA-Z0-9^`|~,!#$%&'*+.]+$/.test(str.trim());
+const isValidHeaderName = (str) => /^[-_a-zA-Z0-9^`|~!#$%&'*+.]+$/.test(str.trim());
 
 function matchHeaderValue(context, value, header, filter, isHeaderNameFilter) {
   if (utils.isFunction(filter)) {

--- a/tests/unit/axiosHeaders.test.js
+++ b/tests/unit/axiosHeaders.test.js
@@ -267,6 +267,16 @@ describe('AxiosHeaders', () => {
       assert.strictEqual(headers.get('x'), 'y');
       assert.strictEqual(Object.keys(headers).length, 2);
     });
+
+    // Regression: comma is a delimiter, not a tchar, per RFC 7230 section 3.2.6 -
+    // it must not be accepted as part of a single header name.
+    it('should not treat a comma-containing string as a valid header name', () => {
+      const headers = new AxiosHeaders();
+
+      headers.set('X-Foo,Bar', 'value');
+
+      assert.strictEqual(headers.has('X-Foo,Bar'), false);
+    });
   });
 
   it('should support uppercase name mapping for names overlapped by class methods', () => {

--- a/tests/unit/axiosHeaders.test.js
+++ b/tests/unit/axiosHeaders.test.js
@@ -269,13 +269,17 @@ describe('AxiosHeaders', () => {
     });
 
     // Regression: comma is a delimiter, not a tchar, per RFC 7230 section 3.2.6 -
-    // it must not be accepted as part of a single header name.
-    it('should not treat a comma-containing string as a valid header name', () => {
+    // it must not be accepted as part of a header name, on any input path.
+    it('should reject a comma-containing header name on every input path', () => {
       const headers = new AxiosHeaders();
 
-      headers.set('X-Foo,Bar', 'value');
+      assert.doesNotThrow(() => headers.set('X-Foo,Bar', 'value'));
+      assert.doesNotThrow(() => headers.set({ 'X-Foo,Bar': 'value' }));
+      assert.doesNotThrow(() => headers.set('X-Foo,Bar: value'));
+      assert.doesNotThrow(() => headers.set(new Map([['X-Foo,Bar', 'value']])));
 
       assert.strictEqual(headers.has('X-Foo,Bar'), false);
+      assert.strictEqual(Object.keys(headers).length, 0);
     });
   });
 


### PR DESCRIPTION
:surfer:

## Summary

`isValidHeaderName` in `lib/core/AxiosHeaders.js` incorrectly accepts a comma (`,`) as part of a valid header name. Per [RFC 7230 §3.2.6](https://www.rfc-editor.org/rfc/rfc7230#section-3.2.6), a header field-name is a `token` made only of `tchar` characters, and a comma is explicitly listed as a `delimiter`, not a `tchar`.

Because `AxiosHeaders#set(header, ...)` uses `isValidHeaderName` to decide whether a string argument is a single header *name* (vs. a raw multi-header text blob to hand to `parseHeaders`), a comma-containing string is wrongly treated as one literal header name instead of being rejected or parsed as raw header text. The invalid name then survives untouched through `AxiosHeaders` and only fails later, as a confusing low-level error thrown by Node's `http` module (`ERR_INVALID_HTTP_TOKEN`) or the browser's `XHR`/`fetch` header APIs (`SyntaxError`), instead of being caught consistently at the axios layer.

### Repro (before fix)

```js
import AxiosHeaders from './lib/core/AxiosHeaders.js';

const headers = new AxiosHeaders();
headers.set('X-Foo,Bar', 'value');

console.log(headers.has('X-Foo,Bar')); // true (should be false / rejected)
```

## Linked issue

N/A — one-character regex fix with a clear RFC citation and reproduction included above; no separate issue filed.

## Changes

- `lib/core/AxiosHeaders.js`: removed `,` from the `isValidHeaderName` character class.
- `tests/unit/axiosHeaders.test.js`: added a regression test asserting a comma-containing string is not treated as a valid header name.
- `PRE_RELEASE_CHANGELOG.md`: added a Bug Fixes entry.

#### Checklist

- [x] Tests added or updated (or N/A with reason)
- [x] Docs/types updated if public API changed (`index.d.ts` and `index.d.cts`) — N/A, `isValidHeaderName` is an internal helper, not public API
- [x] No breaking changes (or called out explicitly above)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject commas in header names in AxiosHeaders per RFC 7230, and validate names when storing headers so all input paths are covered. This prevents invalid names like "X-Foo,Bar" from being accepted and failing later in Node/browser APIs.

**Description**
- Summary of changes: removed comma from `isValidHeaderName` pattern; validate header name at storage time in `AxiosHeaders#set` for strings, objects, maps/iterables, and raw header lines; updated changelog with PR reference.
- Reasoning: comma is a delimiter, not a token; reject early to align with RFC 7230 and surface clear errors.
- Additional context: invalid names are now ignored on set rather than slipping through to transport layers.

**Docs**
- Add a short note in `/docs/` headers section that header names must be RFC 7230 tokens (no commas).

**Testing**
- Added a regression test that verifies comma-containing names are rejected across all input paths; no further tests needed.

**Semantic version impact**
- Patch: behavior correction only; no public API changes.

<sup>Written for commit 6d8ea08eeeac49af65471e2558713bac52d9bf45. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/axios/axios/pull/11063?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

