### PR TITLE
fix(utils): serialize Map values in toJSONObject

### DIFF
--- a/PRE_RELEASE_CHANGELOG.md
+++ b/PRE_RELEASE_CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## Bug Fixes
 
-- **AxiosError:** `AxiosError#toJSON()` now serializes `Map` values in request config snapshots as arrays of key/value pairs instead of empty objects, matching the existing `Set` handling. (**#TBD**)
+- **AxiosError:** `AxiosError#toJSON()` now serializes `Map` values in request config snapshots as arrays of key/value pairs instead of empty objects, matching the existing `Set` handling. (**#11064**)
 - **AxiosError:** `AxiosError#toJSON()` now serializes `Set` values in request config snapshots as arrays instead of empty objects. (**#11044**, refs **#5910**)
 - **HTTP Adapter - download progress:** Flushed the final `onDownloadProgress` callback before streamed responses emit `close`, preventing trailing progress notifications after consumers observe the stream as closed. (closes **#6878**)
 - **URL construction:** `combineURLs()` now removes repeated trailing slashes from `baseURL` before joining a relative request URL, avoiding unintended double slashes in the final request path. (**#11038**)

--- a/PRE_RELEASE_CHANGELOG.md
+++ b/PRE_RELEASE_CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## Bug Fixes
 
-- **AxiosError:** `AxiosError#toJSON()` now serializes `Map` values in request config snapshots as arrays of key/value pairs instead of empty objects, matching the existing `Set` handling. (**#11064**)
+- **AxiosError:** `AxiosError#toJSON()` now serializes `Map` values in request config snapshots as arrays of key/value pairs instead of empty objects, matching the existing `Set` handling. `WeakMap`/`WeakSet` values, whose entries can't be enumerated, now serialize as `"[WeakMap]"`/`"[WeakSet]"` placeholders instead of empty objects. (**#11064**)
 - **AxiosError:** `AxiosError#toJSON()` now serializes `Set` values in request config snapshots as arrays instead of empty objects. (**#11044**, refs **#5910**)
 - **HTTP Adapter - download progress:** Flushed the final `onDownloadProgress` callback before streamed responses emit `close`, preventing trailing progress notifications after consumers observe the stream as closed. (closes **#6878**)
 - **URL construction:** `combineURLs()` now removes repeated trailing slashes from `baseURL` before joining a relative request URL, avoiding unintended double slashes in the final request path. (**#11038**)

--- a/PRE_RELEASE_CHANGELOG.md
+++ b/PRE_RELEASE_CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## Bug Fixes
 
+- **AxiosError:** `AxiosError#toJSON()` now serializes `Map` values in request config snapshots as arrays of key/value pairs instead of empty objects, matching the existing `Set` handling. (**#TBD**)
 - **AxiosError:** `AxiosError#toJSON()` now serializes `Set` values in request config snapshots as arrays instead of empty objects. (**#11044**, refs **#5910**)
 - **HTTP Adapter - download progress:** Flushed the final `onDownloadProgress` callback before streamed responses emit `close`, preventing trailing progress notifications after consumers observe the stream as closed. (closes **#6878**)
 - **URL construction:** `combineURLs()` now removes repeated trailing slashes from `baseURL` before joining a relative request URL, avoiding unintended double slashes in the final request path. (**#11038**)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -283,6 +283,7 @@ const isBlob = kindOfTest('Blob');
  */
 const isFileList = kindOfTest('FileList');
 const isSet = kindOfTest('Set');
+const isMap = kindOfTest('Map');
 
 /**
  * Determine if a value is a Stream
@@ -856,6 +857,12 @@ const toJSONObject = (obj) => {
           for (const value of source) {
             const reducedValue = visit(value);
             !isUndefined(reducedValue) && target.push(reducedValue);
+          }
+        } else if (isMap(source)) {
+          target = [];
+          for (const [key, value] of source) {
+            const reducedValue = visit(value);
+            !isUndefined(reducedValue) && target.push([visit(key), reducedValue]);
           }
         } else {
           target = isArray(source) ? [] : {};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -284,6 +284,8 @@ const isBlob = kindOfTest('Blob');
 const isFileList = kindOfTest('FileList');
 const isSet = kindOfTest('Set');
 const isMap = kindOfTest('Map');
+const isWeakSet = kindOfTest('WeakSet');
+const isWeakMap = kindOfTest('WeakMap');
 
 /**
  * Determine if a value is a Stream
@@ -852,7 +854,13 @@ const toJSONObject = (obj) => {
 
         let target;
 
-        if (isSet(source)) {
+        if (isWeakSet(source)) {
+          // WeakSet entries aren't enumerable (no iteration API), so contents can't be serialized.
+          target = '[WeakSet]';
+        } else if (isWeakMap(source)) {
+          // WeakMap entries aren't enumerable (no iteration API), so contents can't be serialized.
+          target = '[WeakMap]';
+        } else if (isSet(source)) {
           target = [];
           for (const value of source) {
             const reducedValue = visit(value);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -861,8 +861,11 @@ const toJSONObject = (obj) => {
         } else if (isMap(source)) {
           target = [];
           for (const [key, value] of source) {
+            const reducedKey = visit(key);
             const reducedValue = visit(value);
-            !isUndefined(reducedValue) && target.push([visit(key), reducedValue]);
+            !isUndefined(reducedKey) &&
+              !isUndefined(reducedValue) &&
+              target.push([reducedKey, reducedValue]);
           }
         } else {
           target = isArray(source) ? [] : {};

--- a/tests/unit/core/AxiosError.test.js
+++ b/tests/unit/core/AxiosError.test.js
@@ -51,6 +51,22 @@ describe('core::AxiosError', () => {
     });
   });
 
+  it('serializes Map values in config snapshots', () => {
+    const error = new AxiosError('Boom!', 'ESOMETHING', {
+      tags: new Map([['a', 1]]),
+      nested: {
+        ids: new Map([['b', 2]]),
+      },
+    });
+
+    expect(error.toJSON().config).toEqual({
+      tags: [['a', 1]],
+      nested: {
+        ids: [['b', 2]],
+      },
+    });
+  });
+
   describe('AxiosError.from', () => {
     it('adds config, code, request and response to the wrapped error', () => {
       const error = new Error('Boom!');

--- a/tests/unit/utils.test.js
+++ b/tests/unit/utils.test.js
@@ -202,6 +202,83 @@ describe('utils', () => {
         });
       });
     });
+
+    describe('Map handling', () => {
+      it('should convert a flat Map to an array of key/value pairs', () => {
+        const result = utils.toJSONObject(
+          new Map([
+            ['a', 1],
+            ['b', 2],
+          ])
+        );
+
+        assert.deepStrictEqual(result, [
+          ['a', 1],
+          ['b', 2],
+        ]);
+      });
+
+      it('should convert a Map nested inside a plain object', () => {
+        const result = utils.toJSONObject({ tags: new Map([['a', 1]]) });
+
+        assert.deepStrictEqual(result, { tags: [['a', 1]] });
+      });
+
+      it('should convert a cross-realm Map to an array of key/value pairs', () => {
+        const map = vm.runInNewContext('new Map([["a", 1]])');
+
+        assert.strictEqual(map instanceof Map, false);
+        assert.deepStrictEqual(utils.toJSONObject({ tags: map }), { tags: [['a', 1]] });
+      });
+
+      it('should convert nested Maps recursively', () => {
+        const inner = new Map([['x', 'y']]);
+        const outer = new Map([
+          ['inner', inner],
+          ['n', 1],
+        ]);
+
+        assert.deepStrictEqual(utils.toJSONObject(outer), [
+          ['inner', [['x', 'y']]],
+          ['n', 1],
+        ]);
+      });
+
+      it('should skip entries whose value is undefined (mirrors object/array behaviour)', () => {
+        const result = utils.toJSONObject(
+          new Map([
+            ['a', 1],
+            ['b', undefined],
+            ['c', 3],
+          ])
+        );
+
+        assert.deepStrictEqual(result, [
+          ['a', 1],
+          ['c', 3],
+        ]);
+      });
+
+      it('should handle a Map that appears in multiple places (DAG, not cycle)', () => {
+        const shared = new Map([['k', 42]]);
+        const source = { a: shared, b: shared };
+
+        assert.deepStrictEqual(utils.toJSONObject(source), {
+          a: [['k', 42]],
+          b: [['k', 42]],
+        });
+      });
+
+      it('should not follow a Map whose value directly contains itself (self-cycle)', () => {
+        const m = new Map();
+        m.set('self', m); // self-referential
+        m.set('n', 1);
+
+        // The cyclic self-reference is skipped; other values are kept.
+        const result = utils.toJSONObject(m);
+        assert.deepStrictEqual(result, [['n', 1]]);
+      });
+    });
   });
 
   describe('Buffer RangeError Fix', () => {

--- a/tests/unit/utils.test.js
+++ b/tests/unit/utils.test.js
@@ -278,6 +278,17 @@ describe('utils', () => {
         const result = utils.toJSONObject(m);
         assert.deepStrictEqual(result, [['n', 1]]);
       });
+
+      it('should drop an entry whose key directly contains itself (cyclic key)', () => {
+        const m = new Map();
+        m.set(m, 1); // the key is the map itself
+        m.set('n', 2);
+
+        // A cyclic key resolves to undefined and must not surface as `[null, value]`;
+        // the whole entry is dropped, other entries are kept.
+        const result = utils.toJSONObject(m);
+        assert.deepStrictEqual(result, [['n', 2]]);
+      });
     });
   });
 

--- a/tests/unit/utils.test.js
+++ b/tests/unit/utils.test.js
@@ -290,6 +290,26 @@ describe('utils', () => {
         assert.deepStrictEqual(result, [['n', 2]]);
       });
     });
+
+    describe('WeakSet and WeakMap handling', () => {
+      it('should convert a WeakSet to a placeholder string (entries are not enumerable)', () => {
+        const result = utils.toJSONObject(new WeakSet());
+
+        assert.strictEqual(result, '[WeakSet]');
+      });
+
+      it('should convert a WeakMap to a placeholder string (entries are not enumerable)', () => {
+        const result = utils.toJSONObject(new WeakMap());
+
+        assert.strictEqual(result, '[WeakMap]');
+      });
+
+      it('should convert a WeakSet/WeakMap nested inside a plain object', () => {
+        const result = utils.toJSONObject({ a: new WeakSet(), b: new WeakMap() });
+
+        assert.deepStrictEqual(result, { a: '[WeakSet]', b: '[WeakMap]' });
+      });
+    });
   });
 
   describe('Buffer RangeError Fix', () => {


### PR DESCRIPTION
:surfer:

## Summary

`#11044` recently fixed `utils.toJSONObject` to serialize `Set` values as arrays instead of empty objects, but left `Map` with the same gap: a `Map` has no own enumerable string keys, so `forEach`'s `Object.keys(map)` returns `[]` and the map silently becomes `{}`.

`AxiosError#toJSON()` uses `toJSONObject` to serialize `config`, so any `Map` reachable from an axios request config currently vanishes from the serialized error instead of surfacing its contents.

### Repro (before fix)

```js
import utils from './lib/utils.js';

console.log(utils.toJSONObject(new Map([['a', 1], ['b', 2]]))); // {}
console.log(JSON.stringify(utils.toJSONObject({ data: new Map([['x', 1]]) }))); // {"data":{}}
```

### After fix

```js
console.log(utils.toJSONObject(new Map([['a', 1], ['b', 2]]))); // [['a',1],['b',2]]
```

A `Map` is serialized as an array of `[key, value]` pairs (mirroring `Array.from(map.entries())`), since — unlike `Set` — both the key and the value need to be preserved and a `Map` key is not restricted to strings.

## Linked issue

N/A — direct follow-up to the `Set` fix in #11044, same root cause and same fix pattern, with a reproduction included above.

## Changes

- `lib/utils.js`: added `isMap`, and a `Map` branch in `toJSONObject` that serializes entries as `[key, value]` pairs (mirrors the existing `Set` branch).
- `tests/unit/utils.test.js`: added a `Map handling` test suite mirroring the existing `Set handling` suite (flat, nested-in-object, cross-realm, recursive, undefined-value skipping, shared-reference DAG, self-cycle).
- `tests/unit/core/AxiosError.test.js`: added a test asserting `AxiosError#toJSON()` serializes `Map` values in the config snapshot.
- `PRE_RELEASE_CHANGELOG.md`: added a Bug Fixes entry.

#### Checklist

- [x] Tests added or updated (or N/A with reason)
- [x] Docs/types updated if public API changed (`index.d.ts` and `index.d.cts`) — N/A, `toJSONObject`/`isMap` are internal helpers, not public API
- [x] No breaking changes (or called out explicitly above)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serialize `Map` values in `utils.toJSONObject` as arrays of `[key, value]`, and emit `"[WeakMap]"`/`"[WeakSet]"` placeholders so `AxiosError#toJSON()` preserves Map data and the presence of Weak collections in config snapshots. Also drop entries whose key or value resolves to a cycle or `undefined`.

## Description

- Summary of changes
  - Added `isMap`, `isWeakSet`, and `isWeakMap` checks; added branches in `toJSONObject`.
  - `Map` serializes to `[key, value]` pairs; skips entries with `undefined` keys/values (including cyclic keys/values); supports nested and cross-realm maps.
  - `WeakMap`/`WeakSet` serialize as `"[WeakMap]"`/`"[WeakSet]"` placeholders.
  - Updated changelog entry.
- Reasoning
  - `Map` previously serialized to `{}` and lost data; `WeakMap`/`WeakSet` also collapsed to `{}` and hid their presence.
- Additional context
  - Follow-up to the recent `Set` serialization fix for consistent error output.

## Docs

Add notes in `/docs/`:
- `AxiosError#toJSON()` now serializes `Map` values as `[key, value]` arrays.
- `WeakMap`/`WeakSet` appear as placeholder strings.
- Entries with cyclic or `undefined` keys/values are skipped.

## Testing

- Added unit tests in `tests/unit/utils.test.js` for `Map` (flat, nested, cross-realm, nested maps, `undefined` skipping, DAGs, self-cycles, cyclic key drop).
- Added tests for `WeakSet`/`WeakMap` placeholders (top-level and nested).
- Added `tests/unit/core/AxiosError.test.js` to assert `AxiosError#toJSON()` includes `Map` values in the config snapshot.
- No further tests needed.

## Semantic version impact

- Patch: bug fix with no breaking API changes.

<sup>Written for commit 9e37958a48ff5903f9e5d1ede93be50620d2ac6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/axios/axios/pull/11064?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

