### PR TITLE
fix(headers): parse quoted header parameters

### DIFF
--- a/PRE_RELEASE_CHANGELOG.md
+++ b/PRE_RELEASE_CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## Bug Fixes
 
+- **Headers:** Parsed header parameters from `AxiosHeaders#get(name, true)` now strip RFC 9110 quoted-string delimiters and trim trailing optional whitespace. (closes **#11050**)
 - **AxiosError:** `AxiosError#toJSON()` now serializes `Set` values in request config snapshots as arrays instead of empty objects. (**#11044**, refs **#5910**)
 - **HTTP Adapter - download progress:** Flushed the final `onDownloadProgress` callback before streamed responses emit `close`, preventing trailing progress notifications after consumers observe the stream as closed. (closes **#6878**)
 - **URL construction:** `combineURLs()` now removes repeated trailing slashes from `baseURL` before joining a relative request URL, avoiding unintended double slashes in the final request path. (**#11038**)

--- a/lib/core/AxiosHeaders.js
+++ b/lib/core/AxiosHeaders.js
@@ -20,11 +20,19 @@ function normalizeValue(value) {
 
 function parseTokens(str) {
   const tokens = Object.create(null);
-  const tokensRE = /([^\s,;=]+)\s*(?:=\s*([^,;]+))?/g;
+  const tokensRE = /([^\s,;=]+)\s*(?:=\s*("(?:[^"\\]|\\.)*"|[^,;]*))?/g;
   let match;
 
   while ((match = tokensRE.exec(str))) {
-    tokens[match[1]] = match[2];
+    let value = match[2];
+
+    if (value && value[0] === '"') {
+      value = value.slice(1, -1).replace(/\\([\s\S])/g, '$1');
+    } else if (value) {
+      value = value.trim();
+    }
+
+    tokens[match[1]] = value;
   }
 
   return tokens;

--- a/lib/core/AxiosHeaders.js
+++ b/lib/core/AxiosHeaders.js
@@ -26,7 +26,7 @@ function parseTokens(str) {
   while ((match = tokensRE.exec(str))) {
     let value = match[2];
 
-    if (value && value[0] === '"') {
+    if (value && value[0] === '"' && value[value.length - 1] === '"') {
       value = value.slice(1, -1).replace(/\\([\s\S])/g, '$1');
     } else if (value) {
       value = value.trim();

--- a/tests/unit/axiosHeaders.test.js
+++ b/tests/unit/axiosHeaders.test.js
@@ -305,6 +305,14 @@ describe('AxiosHeaders', () => {
       assert.strictEqual(headers.get('content-type', true).charset, 'utf-8');
     });
 
+    it('should preserve malformed quote-prefixed header parameters', () => {
+      const headers = new AxiosHeaders();
+
+      headers.set('content-type', 'text/plain; foo="unterminated');
+
+      assert.strictEqual(headers.get('content-type', true).foo, '"unterminated');
+    });
+
     describe('filter', () => {
       it('should support RegExp', () => {
         const headers = new AxiosHeaders();

--- a/tests/unit/axiosHeaders.test.js
+++ b/tests/unit/axiosHeaders.test.js
@@ -281,6 +281,30 @@ describe('AxiosHeaders', () => {
   });
 
   describe('get', () => {
+    it('should strip quoted-string delimiters from parsed header parameters', () => {
+      const headers = new AxiosHeaders();
+
+      headers.set('content-type', 'multipart/form-data; boundary="----=_Part_123"');
+
+      assert.strictEqual(headers.get('content-type', true).boundary, '----=_Part_123');
+    });
+
+    it('should preserve delimiters inside quoted header parameters', () => {
+      const headers = new AxiosHeaders();
+
+      headers.set('content-type', 'multipart/form-data; boundary="abc;def,ghi"');
+
+      assert.strictEqual(headers.get('content-type', true).boundary, 'abc;def,ghi');
+    });
+
+    it('should trim trailing whitespace from parsed header parameters', () => {
+      const headers = new AxiosHeaders();
+
+      headers.set('content-type', 'text/plain; charset=utf-8   ; format=flowed');
+
+      assert.strictEqual(headers.get('content-type', true).charset, 'utf-8');
+    });
+
     describe('filter', () => {
       it('should support RegExp', () => {
         const headers = new AxiosHeaders();


### PR DESCRIPTION
:surfer:

## Summary
- strip RFC 9110 quoted-string delimiters when parsing `AxiosHeaders#get(name, true)` parameters
- preserve delimiters such as `;` and `,` inside quoted-string values
- trim trailing optional whitespace from unquoted parameter values

Closes #11050.

## Verification
- `npm run test:vitest:unit -- tests/unit/axiosHeaders.test.js`
- `npm run lint -- lib/core/AxiosHeaders.js tests/unit/axiosHeaders.test.js`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes parsing of quoted header parameters in `AxiosHeaders#get(name, true)` per RFC 9110. Quoted values are unquoted and unescaped, delimiters inside quotes are preserved, trailing whitespace on unquoted values is trimmed, and malformed quote-prefixed values are kept as-is.

**Description**
- Implemented quoted-string parsing with unquoting and backslash unescaping; preserves “;” and “,” inside quotes; trims trailing OWS for unquoted values; preserves malformed quote-prefixed parameters as-is.
- Updated changelog; closes #11050; Semantic version: Patch (bug fix, no API changes).
- Docs: Add a short note in `/docs/headers.md` explaining quoted parameter parsing, whitespace trimming, and behavior for malformed quotes.

**Testing**
- Added four unit tests for: unquoting a quoted boundary, preserving “;” and “,” inside quotes, trimming trailing whitespace on unquoted values, and preserving malformed quote-prefixed parameters.

<sup>Written for commit ba3c1782681cffad412becea477757d3ee568f65. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/axios/axios/pull/11074?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

