### PR TITLE
fix(interceptors): remove ejected handlers

### DIFF
--- a/lib/core/InterceptorManager.js
+++ b/lib/core/InterceptorManager.js
@@ -2,9 +2,12 @@
 
 import utils from '../utils.js';
 
+const $interceptorId = Symbol('interceptorId');
+
 class InterceptorManager {
   constructor() {
     this.handlers = [];
+    this.nextId = 0;
   }
 
   /**
@@ -17,13 +20,17 @@ class InterceptorManager {
    * @return {Number} An ID used to remove interceptor later
    */
   use(fulfilled, rejected, options) {
+    const id = this.nextId++;
+
     this.handlers.push({
+      [$interceptorId]: id,
       fulfilled,
       rejected,
       synchronous: options ? options.synchronous : false,
       runWhen: options ? options.runWhen : null,
     });
-    return this.handlers.length - 1;
+
+    return id;
   }
 
   /**
@@ -34,8 +41,12 @@ class InterceptorManager {
    * @returns {void}
    */
   eject(id) {
-    if (this.handlers[id]) {
-      this.handlers[id] = null;
+    const index = this.handlers.findIndex(function findHandler(h) {
+      return h[$interceptorId] === id;
+    });
+
+    if (index !== -1) {
+      this.handlers.splice(index, 1);
     }
   }
 
@@ -53,18 +64,13 @@ class InterceptorManager {
   /**
    * Iterate over all the registered interceptors
    *
-   * This method is particularly useful for skipping over any
-   * interceptors that may have become `null` calling `eject`.
-   *
    * @param {Function} fn The function to call for each interceptor
    *
    * @returns {void}
    */
   forEach(fn) {
     utils.forEach(this.handlers, function forEachHandler(h) {
-      if (h !== null) {
-        fn(h);
-      }
+      fn(h);
     });
   }
 }

--- a/tests/unit/core/InterceptorManager.test.js
+++ b/tests/unit/core/InterceptorManager.test.js
@@ -1,0 +1,49 @@
+import { describe, it } from 'vitest';
+import assert from 'assert';
+import InterceptorManager from '../../../lib/core/InterceptorManager.js';
+
+describe('InterceptorManager', () => {
+  it('does not retain ejected interceptors as null slots', () => {
+    const manager = new InterceptorManager();
+
+    for (let i = 0; i < 10000; i++) {
+      const id = manager.use((config) => config);
+      manager.eject(id);
+    }
+
+    assert.strictEqual(manager.handlers.length, 0);
+  });
+
+  it('does not let stale ejected ids remove later interceptors', () => {
+    const manager = new InterceptorManager();
+    const first = () => 'first';
+    const second = () => 'second';
+    const firstId = manager.use(first);
+
+    manager.eject(firstId);
+    manager.use(second);
+    manager.eject(firstId);
+
+    const handlers = [];
+    manager.forEach((handler) => handlers.push(handler.fulfilled));
+
+    assert.deepStrictEqual(handlers, [second]);
+  });
+
+  it('preserves insertion order when ejecting from the middle', () => {
+    const manager = new InterceptorManager();
+    const first = () => 'first';
+    const second = () => 'second';
+    const third = () => 'third';
+
+    manager.use(first);
+    const secondId = manager.use(second);
+    manager.use(third);
+    manager.eject(secondId);
+
+    const handlers = [];
+    manager.forEach((handler) => handlers.push(handler.fulfilled));
+
+    assert.deepStrictEqual(handlers, [first, third]);
+  });
+});


### PR DESCRIPTION
:surfer:

## Summary
- remove ejected interceptor records instead of leaving null slots behind
- keep stable interceptor ids so stale ids cannot remove later handlers after compaction
- add focused InterceptorManager regression tests for compaction, stale ids, and order preservation

## Verification
- npm run test:vitest:unit -- tests/unit/core/InterceptorManager.test.js
- npx eslint lib/core/InterceptorManager.js tests/unit/core/InterceptorManager.test.js

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes ejected interceptors instead of leaving null slots and introduces stable numeric IDs to prevent stale removals. Adds focused tests to verify compaction, order, and stale ID safety.

**Description**
- Summary of changes
  - Remove ejected handlers with splice; no more null slots.
  - Add stable numeric IDs via a private symbol and `nextId`.
  - Keep `forEach` simple since there are no nulls to skip.
- Reasoning
  - Avoid sparse arrays and reduce memory growth.
  - Prevent stale IDs from removing later handlers.
  - Preserve insertion order after ejections.
- Additional context
  - Public API is unchanged: `use` returns a number; `eject(id)` still works.
  - Behavior is backward compatible and internal-only.

**Docs**
- Update `/docs/` interceptor docs to clarify:
  - IDs are stable and not tied to array indices.
  - Ejected handlers are removed, not set to null.
  - `forEach` no longer needs to account for null entries.

**Testing**
- Added unit tests in `tests/unit/core/InterceptorManager.test.js`:
  - Ensures no null slots remain after many add/eject cycles.
  - Verifies stale IDs cannot remove newer handlers.
  - Confirms insertion order is preserved after middle ejections.

**Semantic version impact**
- Patch: internal behavior change with no public API breakage.

<sup>Written for commit 15424b918204778bbe74017348d32070fabaa48b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/axios/axios/pull/11077?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

