### PR TITLE
ci: use bundled npm for v0 publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,8 +24,6 @@ jobs:
           node-version: 26.x
           registry-url: "https://registry.npmjs.org"
           package-manager-cache: false
-      - name: Pin npm with staged-publishing support
-        run: npm install -g npm@11.15.0
       - name: Install dependencies
         run: npm ci --ignore-scripts
       - name: Build project

--- a/test/specs/formdata.spec.js
+++ b/test/specs/formdata.spec.js
@@ -1,14 +1,30 @@
 
 describe('FormData', function() {
+  beforeEach(function () {
+    jasmine.Ajax.install();
+  });
+
+  afterEach(function () {
+    jasmine.Ajax.uninstall();
+  });
+
   it('should allow FormData posting', function () {
-    return axios.postForm('http://httpbin.org/post', {
+    var response = axios.postForm('/foo', {
       a: 'foo',
       b: 'bar'
-    }).then(({data}) => {
-      expect(data.form).toEqual({
-        a: 'foo',
-        b: 'bar'
+    });
+
+    return getAjaxRequest().then(function (request) {
+      expect(request.params).toEqual(jasmine.any(FormData));
+      expect(request.params.get('a')).toEqual('foo');
+      expect(request.params.get('b')).toEqual('bar');
+
+      request.respondWith({
+        status: 200,
+        responseText: '{}'
       });
+
+      return response;
     });
   });
-})
+});


### PR DESCRIPTION
Matches #11083.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch v0 publish workflow to use the `npm` bundled with `actions/setup-node` and update the FormData test to remove external network usage for stability.

## Description
- CI: remove global `npm@11.15.0` pin and use bundled `npm` with Node 26 from `actions/setup-node`.
- Tests: rewrite `test/specs/formdata.spec.js` to use `jasmine.Ajax` and `getAjaxRequest()`; assert `FormData` params and stub the response.
- Reasoning: simplifies CI and avoids `npm` drift; makes tests deterministic and faster (no external HTTP).

## Docs
- Update `/docs/` to note v0 publishes use the bundled `npm`. Remove any note about pinning `npm`.

## Testing
- Modified test: replaced external FormData POST to `httpbin` with a local `jasmine.Ajax` stub and assertions on `FormData` content.
- No additional tests needed; changes are CI and test-only.

## Semantic version impact
- Patch: CI and test-only changes; no user-facing impact.

<sup>Written for commit 77fa2cb9f87600d64d842e416cc4c6341afb0219. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/axios/axios/pull/11084?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

