### PR TITLE
fix(core): tolerate non-string stack when decorating request errors

### DIFF
--- a/PRE_RELEASE_CHANGELOG.md
+++ b/PRE_RELEASE_CHANGELOG.md
@@ -4,4 +4,5 @@
 
 ## Bug Fixes
 
+- **Request error stacks:** Preserved original request failures when custom `Error` stack instrumentation returns non-string data or throws during optional stack decoration. (**#11109**, closes **#11108**)
 - **Interceptor storage:** Removed trailing interceptor tombstones after ejection so repeated register-then-eject cycles no longer grow the handlers array, while preserving its public array shape, interceptor iteration behavior, and interceptor ID identity across registrations. (**#11070**)

--- a/lib/core/Axios.js
+++ b/lib/core/Axios.js
@@ -47,7 +47,7 @@ class Axios {
 
         // slice off the Error: ... line
         const stack = (() => {
-          if (!dummy.stack) {
+          if (typeof dummy.stack !== 'string') {
             return '';
           }
 

--- a/lib/core/Axios.js
+++ b/lib/core/Axios.js
@@ -41,21 +41,21 @@ class Axios {
       return await this._request(configOrUrl, config);
     } catch (err) {
       if (err instanceof Error) {
-        let dummy = {};
+        try {
+          let dummy = {};
 
-        Error.captureStackTrace ? Error.captureStackTrace(dummy) : (dummy = new Error());
+          Error.captureStackTrace ? Error.captureStackTrace(dummy) : (dummy = new Error());
 
-        // slice off the Error: ... line
-        const stack = (() => {
-          if (typeof dummy.stack !== 'string') {
-            return '';
+          const dummyStack = dummy.stack;
+          let stack = '';
+
+          // slice off the Error: ... line
+          if (typeof dummyStack === 'string') {
+            const firstNewlineIndex = dummyStack.indexOf('\n');
+
+            stack = firstNewlineIndex === -1 ? '' : dummyStack.slice(firstNewlineIndex + 1);
           }
 
-          const firstNewlineIndex = dummy.stack.indexOf('\n');
-
-          return firstNewlineIndex === -1 ? '' : dummy.stack.slice(firstNewlineIndex + 1);
-        })();
-        try {
           if (!err.stack) {
             err.stack = stack;
             // match without the 2 top stack lines
@@ -71,7 +71,7 @@ class Axios {
             }
           }
         } catch (e) {
-          // ignore the case where "stack" is an un-writable property
+          // Ignore failures from custom stack hooks or un-writable stack properties.
         }
       }
 

--- a/tests/unit/core/Axios.test.js
+++ b/tests/unit/core/Axios.test.js
@@ -3,21 +3,53 @@ import axios from '../../../index.js';
 
 describe('core::Axios', () => {
   describe('request error stack decoration', () => {
+    async function expectAdapterFailurePreserved() {
+      const failure = new Error('adapter failure');
+
+      await expect(
+        axios.request({
+          url: 'http://localhost/test',
+          adapter: () => Promise.reject(failure),
+        })
+      ).rejects.toBe(failure);
+    }
+
     it('preserves the original error when Error.prepareStackTrace returns a non-string stack', async () => {
       const original = Error.prepareStackTrace;
       // Simulates instrumentation that overrides the V8 hook to return
       // structured call-site data instead of a formatted string.
       Error.prepareStackTrace = () => ({});
+
       try {
-        const failure = new Error('adapter failure');
-        await expect(
-          axios.request({
-            url: 'http://localhost/test',
-            adapter: () => Promise.reject(failure)
-          })
-        ).rejects.toBe(failure);
+        await expectAdapterFailurePreserved();
       } finally {
         Error.prepareStackTrace = original;
+      }
+    });
+
+    it('preserves the original error when Error.prepareStackTrace throws', async () => {
+      const original = Error.prepareStackTrace;
+      Error.prepareStackTrace = () => {
+        throw new Error('stack formatting failure');
+      };
+
+      try {
+        await expectAdapterFailurePreserved();
+      } finally {
+        Error.prepareStackTrace = original;
+      }
+    });
+
+    it('preserves the original error when Error.captureStackTrace throws', async () => {
+      const original = Error.captureStackTrace;
+      Error.captureStackTrace = () => {
+        throw new Error('stack capture failure');
+      };
+
+      try {
+        await expectAdapterFailurePreserved();
+      } finally {
+        Error.captureStackTrace = original;
       }
     });
   });

--- a/tests/unit/core/Axios.test.js
+++ b/tests/unit/core/Axios.test.js
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import axios from '../../../index.js';
+
+describe('core::Axios', () => {
+  describe('request error stack decoration', () => {
+    it('preserves the original error when Error.prepareStackTrace returns a non-string stack', async () => {
+      const original = Error.prepareStackTrace;
+      // Simulates instrumentation that overrides the V8 hook to return
+      // structured call-site data instead of a formatted string.
+      Error.prepareStackTrace = () => ({});
+      try {
+        const failure = new Error('adapter failure');
+        await expect(
+          axios.request({
+            url: 'http://localhost/test',
+            adapter: () => Promise.reject(failure)
+          })
+        ).rejects.toBe(failure);
+      } finally {
+        Error.prepareStackTrace = original;
+      }
+    });
+  });
+});


### PR DESCRIPTION
Fixes #11108

The stack-decoration block in `Axios.prototype.request`'s catch handler guards `dummy.stack` only for truthiness. When the global `Error.prepareStackTrace` is overridden to return a non-string (a common instrumentation pattern — APM agents and `callsites`-style libraries return raw CallSite data), `dummy.stack` is truthy but not a string, `.indexOf('\n')` throws, and **the original request error is replaced by an unrelated `TypeError`** (`dummy.stack.indexOf is not a function`; `.replace` on <= 1.12).

Since this runs in the error path, a purely cosmetic step ends up destroying the error it was meant to decorate. The adjacent `err.stack` manipulation a few lines below is already wrapped in `try/catch` for exactly this class of environment — this change applies the same defensiveness to the `dummy.stack` read:

```diff
-          if (!dummy.stack) {
+          if (typeof dummy.stack !== 'string') {
```

Repro (before this change):

```js
Error.prepareStackTrace = () => ({});
axios.get('http://127.0.0.1:1').catch(e => console.log(e.message));
// "dummy.stack.indexOf is not a function"  — real ECONNREFUSED is lost
```

Includes a regression test (`tests/unit/core/Axios.test.js`) that fails without the fix and passes with it. Full unit project passes: 55 files, 976 tests.

Real-world impact example: n8n users saw failed OAuth2 token refreshes as this opaque TypeError instead of the actual auth error (n8n-io/n8n#26453).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `axios` request-error stack decoration fail closed so we never mask the real error. Handles non-string or throwing stack hooks and preserves the original request failure.

- **Description**
  - Summary of changes
    - Wrap stack decoration in try/catch; ignore failures from custom hooks.
    - Use `typeof dummyStack === 'string'` before slicing; default to empty stack.
  - Reasoning
    - Some environments/APM hooks return objects or throw; previous logic crashed and hid the real error.
  - Additional context
    - Only affects the error path; normal string stacks behave the same.
    - Docs: add a note in `/docs/` about compatibility with custom `Error.prepareStackTrace`.

- **Testing**
  - Added unit tests covering: non-string `prepareStackTrace`, throwing `prepareStackTrace`, and throwing `captureStackTrace`; all preserve the original adapter error.
  - No further tests needed.
  - Semantic version impact: Patch (bug fix, no API changes).

<sup>Written for commit e02bd93def49bfc17520379fe8c7cb08cb5f6ce3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/axios/axios/pull/11109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

