### PR TITLE
docs: add missing fs import to README stream example

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ axios({
 
 ```js
 // GET request for remote image in node.js
+import fs from 'fs';
 const response = await axios({
   method: "get",
   url: "https://bit.ly/2mTM3nY",


### PR DESCRIPTION
Adds the missing `fs` import to the "GET request for remote image in node.js" example in README.md.

Copy-pasting the current snippet without the import throws `ReferenceError: fs is not defined`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the missing `fs` import to the README Node.js stream example so the snippet runs as-is. Prevents `ReferenceError: fs is not defined` when copy-pasting.

## Description

- Summary of changes: Added `import fs from 'fs';` to the "GET request for remote image in node.js" example in README.md.
- Reasoning: The snippet failed with `ReferenceError` without the import.
- Additional context: Ensures the example works out of the box in Node.js ESM.

## Docs

Please mirror this fix in any equivalent stream example on the website and update `/docs/` if it includes the same snippet.

## Testing

No tests added or modified. Not needed for a documentation-only change.

## Semantic version impact

None. Documentation-only change; no code or API updates.

<sup>Written for commit 1e68d38038923e641e9589d0e75783aa1b08a8d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/axios/axios/pull/11111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

