### PR TITLE
docs: add missing fs import to README stream example

### DIFF
--- a/README.md
+++ b/README.md
@@ -648,6 +648,7 @@ axios({
 
 ```js
 // GET request for remote image in node.js
+import fs from 'fs';
 const response = await axios({
   method: 'get',
   url: 'https://bit.ly/2mTM3nY',


### PR DESCRIPTION
Adds the missing fs import to the GET request for remote image in node.js example in README.md. Copy-pasting the current snippet without the import throws ReferenceError: fs is not defined. Replaces #11111.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the README Node.js GET image example by adding the missing `fs` import so the snippet runs without errors. No runtime or API changes.

**Description**
- Summary of changes: Add `import fs from 'fs';` to the Node.js GET image example in README.
- Reasoning: Prevents "ReferenceError: fs is not defined" when copy-pasting the snippet.
- Additional context: README-only update.

**Docs**
Please update the equivalent snippet in `/docs/` to include `import fs from 'fs';` so it matches the README.

**Testing**
No tests changed. Not needed for a docs-only update.

**Semantic version impact**
Patch — documentation update only.

<sup>Written for commit f7b005f708dc532018ebd8295e09bbadc6c62f41. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/axios/axios/pull/11113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

Re-targeted from main to 1.x and updated CI action pins for the 1.x workflow.