### PR TITLE
docs: add ScrapingBee sponsor

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,6 +376,48 @@
             </p>
         </td>
     </tr>
+    <tr width="33.333333333333336%">
+        <td align="center" width="33.333333333333336%">
+            <a
+                href="https://www.scrapingbee.com/?utm_source=axios_docs_website&utm_medium=website&utm_campaign=axios_open_collective_sponsorship"
+                style="padding: 10px; display: inline-block"
+                target="_blank"
+            >
+                <img
+                    width="90px"
+                    height="90px"
+                    src="https://images.opencollective.com/scrapingbee/6d5dc95/logo.png"
+                    alt="ScrapingBee"
+                />
+            </a>
+            <p
+                align="center"
+            >
+                Scrape websites with a powerful web scraping API without managing proxies, browsers, or anti-bot defenses.
+            </p>
+            <p align="center">
+                <a
+                    href="https://www.scrapingbee.com/?utm_source=axios_docs_website&utm_medium=website&utm_campaign=axios_open_collective_sponsorship"
+                    target="_blank"
+                    ><b>scrapingbee.com</b></a
+                >
+            </p>
+        </td>
+        <td align="center" width="33.333333333333336%">
+            <a
+                href="https://opencollective.com/axios/contribute"
+                target="_blank"
+                >💜 Become a sponsor</a
+            >
+        </td>
+        <td align="center" width="33.333333333333336%">
+            <a
+                href="https://opencollective.com/axios/contribute"
+                target="_blank"
+                >💜 Become a sponsor</a
+            >
+        </td>
+    </tr>
 </table>
 
 <!--<div>marker</div>-->


### PR DESCRIPTION
## Summary

- add ScrapingBee to the README Gold sponsors table
- use the canonical OpenCollective logo and tracked ScrapingBee website link
- preserve the three-column layout with sponsor placeholders

## Validation

- `git diff --check`
- verified balanced README table tags
- verified one ScrapingBee card and two tracked ScrapingBee links

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add ScrapingBee as a Gold sponsor in the README using the OpenCollective logo and tracked links, while preserving the 3-column layout with placeholders.

**Description**
- Change: Add ScrapingBee to Gold sponsors in README with canonical logo and tracked `scrapingbee.com` links; keep two placeholder sponsor cells.
- Reason: Acknowledge the sponsor and keep the table layout consistent.
- Context: Verified balanced table tags and correct link tracking.

**Docs**
- Update any sponsor section in `/docs/` (if present) to include ScrapingBee with the same tracked link and logo.

**Testing**
- No tests added or modified; docs-only change.
- Manual checks: one ScrapingBee card, two tracked links, table renders correctly.

**Semantic version impact**
- None. Docs-only; no release needed.

<sup>Written for commit 927716d06a2f8d7c6188cfa9d693a58695e9a52b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/axios/axios/pull/11137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

