### PR TITLE
fix(auth): UTF-8 encode basic auth username to match password encoding

### DIFF
--- a/lib/helpers/resolveConfig.js
+++ b/lib/helpers/resolveConfig.js
@@ -55,7 +55,7 @@ function resolveConfig(config) {
     try {
       headers.set(
         'Authorization',
-        'Basic ' + btoa(username + ':' + (password ? encodeUTF8(password) : ''))
+        'Basic ' + btoa(encodeUTF8(username) + ':' + encodeUTF8(password))
       );
     } catch (e) {
       throw AxiosError.from(e, AxiosError.ERR_BAD_OPTION_VALUE, config);

--- a/tests/unit/helpers/resolveConfig.test.js
+++ b/tests/unit/helpers/resolveConfig.test.js
@@ -82,6 +82,35 @@ describe('helpers::resolveConfig', () => {
     }
   });
 
+  it('should UTF-8 encode a non-ASCII basic auth username, not just the password', () => {
+    const config = resolveConfig({
+      url: '/foo',
+      auth: { username: 'naïve', password: 'naïve' },
+    });
+
+    const decoded = Buffer.from(
+      config.headers.get('Authorization').replace(/^Basic /, ''),
+      'base64'
+    ).toString('utf8');
+    assert.strictEqual(decoded, 'naïve:naïve');
+  });
+
+  it('should not throw for a basic auth username outside Latin-1', () => {
+    let config;
+    assert.doesNotThrow(() => {
+      config = resolveConfig({
+        url: '/foo',
+        auth: { username: 'π', password: 'x' },
+      });
+    });
+
+    const decoded = Buffer.from(
+      config.headers.get('Authorization').replace(/^Basic /, ''),
+      'base64'
+    ).toString('utf8');
+    assert.strictEqual(decoded, 'π:x');
+  });
+
   it('should wrap invalid auth encoding as AxiosError', () => {
     assert.throws(
       () =>


### PR DESCRIPTION
## Summary

`resolveConfig` build the basic auth header as `btoa(username + ':' + encodeUTF8(password))` — it UTF-8 encodes the password but passes the username to `btoa` raw, so the two halves of the same credential are encoded inconsistently.

- A username char in U+0080..U+00FF is emitted as single Latin-1 byte instead of its UTF-8 sequence (`naïve` → `0xEF` where password half correctly gives `0xC3 0xAF`), so a server decoding per RFC 7617 gets broken username.
- A username char above U+00FF makes `btoa` throw `ERR_BAD_OPTION_VALUE` — even though the same char is handled fine in password.

RFC 7617 base64-encodes the octet form of `user-id:password`, so both fields need same treatment. This encodes both with `encodeUTF8`. `encodeUTF8('')` is `''`, so empty-credential behavior is unchanged, and the existing lone-surrogate rejection still throws.

## Linked issue

N/A

## Changes

- Encode the Basic auth username with `encodeUTF8`, matching the password
- Add regression tests: a non-ASCII username round-trips, and a beyond-Latin-1 username no longer throws

#### Checklist
- [x] Tests added or updated
- [ ] Docs/types updated if public API changed (N/A — no public API change)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
UTF-8 encodes the Basic auth username in `resolveConfig` to match the password and RFC 7617. Previously the username went to `btoa` raw, which mis-encoded U+0080..U+00FF and threw for >U+00FF; now both fields use `encodeUTF8`, fixing non-ASCII usernames without changing empty-credential behavior.

- Description
  - Encodes `username` with `encodeUTF8` and builds `Authorization: Basic ...` from UTF-8 `user:pass` per RFC 7617.
  - Preserves empty-credential behavior; still wraps invalid encoding as `AxiosError.ERR_BAD_OPTION_VALUE`.
  - Docs: optional note in `/docs/` to state both Basic auth fields are UTF-8 encoded.
  - Semantic version impact: patch.

- Testing
  - Added two regression tests in `tests/unit/helpers/resolveConfig.test.js`: non-ASCII username round-trips; characters beyond Latin-1 no longer throw.

<sup>Written for commit 0735af41259f8337bf8319557f0cb10dfa8e408e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/axios/axios/pull/11159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

