### PR TITLE
fix: normalize parsed protocols to lowercase

### DIFF
--- a/lib/helpers/parseProtocol.js
+++ b/lib/helpers/parseProtocol.js
@@ -2,5 +2,5 @@
 
 export default function parseProtocol(url) {
   const match = /^([-+\w]{1,25}):(?:\/\/)?/.exec(url);
-  return (match && match[1]) || '';
+  return (match && match[1].toLowerCase()) || '';
 }

--- a/tests/unit/parseProtocol.test.js
+++ b/tests/unit/parseProtocol.test.js
@@ -29,4 +29,9 @@ describe('helpers::parseProtocol', () => {
   it('should not match URLs without a colon separator', () => {
     assert.strictEqual(parseProtocol('http//example.com'), '');
   });
+
+  it('should normalize protocols to lowercase', () => {
+    assert.strictEqual(parseProtocol('HTTP://example.com'), 'http');
+    assert.strictEqual(parseProtocol('DATA:text/plain,hello'), 'data');
+  });
 });


### PR DESCRIPTION
## Summary

Normalize parsed URL protocols to lowercase. URL schemes are case-insensitive, but the browser adapter compares the parsed value against a lowercase allowlist. As a result, valid uppercase schemes such as HTTP: and DATA: could be rejected as unsupported.

## Linked issue

N/A - strict, self-contained bug fix.

## Changes

- Lowercase matched protocols in parseProtocol.
- Add regression coverage for uppercase HTTP and DATA schemes.

#### Checklist

- [x] Tests added or updated
- [x] Docs/types updated if public API changed (N/A; no public API change)
- [x] No breaking changes

Validation: npm run test:vitest:unit -- tests/unit/parseProtocol.test.js tests/unit/fromDataURI.test.js; focused ESLint passed.

:surfer: AI assistance disclosure: OpenAI Codex was used to identify, implement, and validate this fix. The account owner explicitly requested the contribution and will handle maintainer follow-up.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
## Description

Normalizes parsed URL protocols to lowercase so case-insensitive schemes are accepted consistently. Previously `parseProtocol` returned the matched scheme as-is, causing uppercase schemes (e.g., HTTP:, DATA:) to be rejected by a lowercase allowlist; it now always returns lowercase.

- Summary of changes: Lowercase the matched protocol in `parseProtocol`; add regression tests for uppercase HTTP and DATA.
- Reasoning: Ensure valid URLs with uppercase schemes are not incorrectly rejected.
- Additional context: One-line change in the helper; no public API changes.

## Docs

No API docs required. If the docs reference protocol parsing, add a note that protocols are normalized to lowercase and schemes are case-insensitive. Update any examples in `/docs/` that display mixed-case outputs.

## Testing

Unit tests updated: added cases verifying uppercase schemes are normalized and parsed correctly in `tests/unit/parseProtocol.test.js`. All existing tests continue to pass.

## Semantic version impact

Patch: backward-compatible bug fix with no API changes.

<sup>Written for commit 11e55dc702c89b5413a33cf50875cf95edbd560e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/axios/axios/pull/11163?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

