### PR TITLE
fix: harden request option resolution and no_proxy matching

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -418,7 +418,11 @@ module.exports = function httpAdapter(config) {
       auth: auth,
       protocol: protocol,
       beforeRedirect: dispatchBeforeRedirect,
-      beforeRedirects: {}
+      // Null-prototype. dispatchBeforeRedirect calls whatever it finds here, and
+      // the `config` hook is only populated when the caller supplies
+      // beforeRedirect, so a plain object left an inherited function reachable
+      // and able to rewrite the redirect target.
+      beforeRedirects: Object.create(null)
     };
 
     var socketPathError = checkSocketPath(config);

--- a/lib/core/Axios.js
+++ b/lib/core/Axios.js
@@ -40,10 +40,12 @@ Axios.prototype.request = function request(configOrUrl, config) {
 
   config = mergeConfig(this.defaults, config);
 
-  // Set config.method
+  // Set config.method. The merged config is null-prototype, but instance
+  // defaults may be an ordinary object, so the fallback is read as an own
+  // property to keep an inherited value from choosing the request method.
   if (config.method) {
     config.method = config.method.toLowerCase();
-  } else if (this.defaults.method) {
+  } else if (utils.hasOwnProperty(this.defaults, 'method') && this.defaults.method) {
     config.method = this.defaults.method.toLowerCase();
   } else {
     config.method = 'get';

--- a/lib/core/dispatchRequest.js
+++ b/lib/core/dispatchRequest.js
@@ -30,8 +30,9 @@ function throwIfCancellationRequested(config) {
 module.exports = function dispatchRequest(config) {
   throwIfCancellationRequested(config);
 
-  // Ensure headers exist
-  config.headers = config.headers || {};
+  // Ensure headers exist. A request interceptor may return a replacement config
+  // that inherits from Object.prototype, so only an own headers value is used.
+  config.headers = (utils.hasOwnProperty(config, 'headers') && config.headers) || {};
 
   // Transform request data
   config.data = transformData.call(

--- a/lib/helpers/shouldBypassProxy.js
+++ b/lib/helpers/shouldBypassProxy.js
@@ -40,6 +40,15 @@ function parseNoProxyEntry(entry) {
   return [entryHost, entryPort];
 }
 
+// Parses a dotted-quad into its four octet strings, or null when the input is
+// not an unambiguous decimal IPv4 address.
+//
+// Octets with a leading zero are rejected. The Node URL parser reads them the
+// way inet_aton does, so `http://010.0.0.1/` arrives here as `8.0.0.1`, while a
+// decimal read of the same literal would be `10.0.0.1`. Accepting the ambiguous
+// form would let a no_proxy entry match a host the operator did not name.
+// Rejecting fails closed: the entry falls back to literal hostname comparison,
+// which will not match, so the request keeps using the proxy.
 function parseIPv4Octets(hostname) {
   var octets = hostname.split('.');
 
@@ -49,6 +58,10 @@ function parseIPv4Octets(hostname) {
 
   for (var i = 0; i < octets.length; i++) {
     if (!/^\d+$/.test(octets[i]) || Number(octets[i]) > 255) {
+      return null;
+    }
+
+    if (octets[i].length > 1 && octets[i].charAt(0) === '0') {
       return null;
     }
   }
@@ -92,6 +105,20 @@ function normalizeIPv4MappedIPv6(hostname) {
   return hostname;
 }
 
+// Trailing dots are trimmed without a regular expression. An anchored `/\.+$/`
+// backtracks quadratically over a long run of dots that is not at the end of
+// the string, and hostnames reaching this helper include redirect Location
+// values, which are attacker-controlled.
+function stripTrailingDots(hostname) {
+  var end = hostname.length;
+
+  while (end > 0 && hostname.charAt(end - 1) === '.') {
+    end--;
+  }
+
+  return end === hostname.length ? hostname : hostname.slice(0, end);
+}
+
 function normalizeNoProxyHost(hostname) {
   if (!hostname) {
     return hostname;
@@ -101,11 +128,171 @@ function normalizeNoProxyHost(hostname) {
     hostname = hostname.slice(1, -1);
   }
 
-  hostname = hostname.replace(/\.+$/, '');
+  hostname = stripTrailingDots(hostname);
 
   return normalizeIPv4MappedIPv6(hostname);
 }
 
+function ipv4ToBytes(hostname) {
+  var octets = parseIPv4Octets(hostname);
+
+  if (!octets) {
+    return null;
+  }
+
+  return [Number(octets[0]), Number(octets[1]), Number(octets[2]), Number(octets[3])];
+}
+
+function pushIPv6Group(bytes, group) {
+  if (!/^[0-9a-f]{1,4}$/.test(group)) {
+    return false;
+  }
+
+  var value = parseInt(group, 16);
+
+  bytes.push((value >> 8) & 0xff, value & 0xff);
+
+  return true;
+}
+
+function ipv6ToBytes(hostname) {
+  var halves = hostname.split('::');
+
+  if (halves.length > 2) {
+    return null;
+  }
+
+  var head = halves[0] ? halves[0].split(':') : [];
+  var tail = halves.length === 2 && halves[1] ? halves[1].split(':') : [];
+  var groups = tail.length ? tail : head;
+
+  // Expand a trailing dotted-quad tail such as ::ffff:127.0.0.1 into two groups.
+  if (groups.length && groups[groups.length - 1].indexOf('.') !== -1) {
+    var quad = ipv4ToBytes(groups[groups.length - 1]);
+
+    if (!quad) {
+      return null;
+    }
+
+    groups.pop();
+    groups.push((((quad[0] << 8) | quad[1]) >>> 0).toString(16));
+    groups.push((((quad[2] << 8) | quad[3]) >>> 0).toString(16));
+  }
+
+  var headBytes = [];
+  var tailBytes = [];
+  var i;
+
+  for (i = 0; i < head.length; i++) {
+    if (!pushIPv6Group(headBytes, head[i])) {
+      return null;
+    }
+  }
+
+  for (i = 0; i < tail.length; i++) {
+    if (!pushIPv6Group(tailBytes, tail[i])) {
+      return null;
+    }
+  }
+
+  var missing = 16 - headBytes.length - tailBytes.length;
+
+  if (halves.length === 2 ? missing < 0 : missing !== 0) {
+    return null;
+  }
+
+  for (i = 0; i < missing; i++) {
+    headBytes.push(0);
+  }
+
+  return headBytes.concat(tailBytes);
+}
+
+function hostToBytes(hostname) {
+  return hostname.indexOf(':') !== -1 ? ipv6ToBytes(hostname) : ipv4ToBytes(hostname);
+}
+
+// Parses a CIDR-form no_proxy entry such as 10.0.0.0/8 or [fd00::]/8.
+// Returns null for anything that is not a well-formed network range so the
+// caller can fall back to hostname matching.
+//
+// Range entries are matched on address alone. Unlike host entries they carry no
+// port, because a trailing `:port` leaves a prefix that is not a bare number and
+// so falls back to hostname matching, which will not match a range.
+//
+// An IPv4-mapped IPv6 host is normalised to its IPv4 form before it reaches
+// here, so list those addresses as IPv4 ranges (10.0.0.0/8), not as
+// ::ffff:0:0/96, which will not match.
+function parseCIDREntry(entry) {
+  var slashIndex = entry.indexOf('/');
+
+  if (slashIndex === -1) {
+    return null;
+  }
+
+  var prefixText = entry.slice(slashIndex + 1);
+
+  if (!/^\d{1,3}$/.test(prefixText)) {
+    return null;
+  }
+
+  var host = entry.slice(0, slashIndex);
+
+  if (host.charAt(0) === '[' && host.charAt(host.length - 1) === ']') {
+    host = host.slice(1, -1);
+  }
+
+  var bytes = hostToBytes(host);
+
+  if (!bytes) {
+    return null;
+  }
+
+  var prefix = parseInt(prefixText, 10);
+
+  if (prefix > bytes.length * 8) {
+    return null;
+  }
+
+  return [bytes, prefix];
+}
+
+function isInCIDR(hostname, cidr) {
+  var networkBytes = cidr[0];
+  var prefix = cidr[1];
+  var bytes = hostToBytes(hostname);
+
+  if (!bytes || bytes.length !== networkBytes.length) {
+    return false;
+  }
+
+  var index = 0;
+  var remaining = prefix;
+
+  while (remaining >= 8) {
+    if (bytes[index] !== networkBytes[index]) {
+      return false;
+    }
+
+    remaining -= 8;
+    index++;
+  }
+
+  if (remaining > 0) {
+    var mask = (0xff << (8 - remaining)) & 0xff;
+
+    if ((bytes[index] & mask) !== (networkBytes[index] & mask)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+// Deliberately more permissive than parseIPv4Octets: this only asks whether the
+// first octet is exactly 127, and a leading zero in any later octet cannot
+// change that answer, so a hand-written no_proxy entry like 127.000.000.001
+// still resolves to loopback.
 function isLoopbackIPv4(hostname) {
   var octets = hostname.split('.');
 
@@ -152,6 +339,12 @@ module.exports = function shouldBypassProxy(location) {
   return noProxy.split(/[\s,]+/).some(function testNoProxyEntry(entry) {
     if (!entry) {
       return false;
+    }
+
+    var cidr = parseCIDREntry(entry);
+
+    if (cidr) {
+      return isInCIDR(hostname, cidr);
     }
 
     var entryParts = parseNoProxyEntry(entry);

--- a/lib/helpers/shouldBypassProxy.js
+++ b/lib/helpers/shouldBypassProxy.js
@@ -162,8 +162,22 @@ function ipv6ToBytes(hostname) {
     return null;
   }
 
+  var compressed = halves.length === 2;
   var head = halves[0] ? halves[0].split(':') : [];
-  var tail = halves.length === 2 && halves[1] ? halves[1].split(':') : [];
+  var tail = compressed && halves[1] ? halves[1].split(':') : [];
+
+  // A dotted quad may only stand for the final 32 bits of an address, so it has
+  // to be the last group in the text. When `::` follows the head, the head is not
+  // the end of the address and a dotted quad there is malformed. Expanding it
+  // anyway read `1.2.3.4::/64` as the unrelated network 102:304::/64, so a
+  // mistyped entry silently bypassed the proxy for hosts the operator never
+  // listed. Returning null fails closed: the entry falls back to hostname
+  // comparison, which never matches a range.
+  if (compressed && !tail.length && head.length &&
+      head[head.length - 1].indexOf('.') !== -1) {
+    return null;
+  }
+
   var groups = tail.length ? tail : head;
 
   // Expand a trailing dotted-quad tail such as ::ffff:127.0.0.1 into two groups.
@@ -197,7 +211,11 @@ function ipv6ToBytes(hostname) {
 
   var missing = 16 - headBytes.length - tailBytes.length;
 
-  if (halves.length === 2 ? missing < 0 : missing !== 0) {
+  // `::` stands for one or more groups of zeros, so a compressed address that
+  // already spells out all eight groups is malformed. Accepting it let
+  // `1:2:3:4:5:6:7:8::/0` parse as a valid /0 network and bypass the proxy for
+  // every IPv6 destination.
+  if (compressed ? missing <= 0 : missing !== 0) {
     return null;
   }
 

--- a/lib/helpers/toFormData.js
+++ b/lib/helpers/toFormData.js
@@ -33,6 +33,40 @@ function isSpecCompliant(thing) {
   return thing && utils.isFunction(thing.append) && thing[Symbol.toStringTag] === 'FormData' && thing[Symbol.iterator];
 }
 
+var UNSAFE_OPTION_KEYS = ['__proto__', 'constructor', 'prototype'];
+
+// Materialises the serializer options onto a null-prototype object. Reading the
+// options from a plain object let a polluted Object.prototype supply a visitor,
+// a depth limit, a Blob implementation or key-format flags that the caller never
+// asked for, and also let a polluted key mask an option the caller did set.
+// Only own, defined properties of the caller's options are carried over.
+function toFormDataOptions(source) {
+  var options = Object.create(null);
+
+  options.metaTokens = true;
+  options.dots = false;
+  options.indexes = false;
+
+  // eslint-disable-next-line no-eq-null,eqeqeq
+  if (source == null) {
+    return options;
+  }
+
+  var names = Object.getOwnPropertyNames(source);
+
+  for (var i = 0; i < names.length; i++) {
+    var name = names[i];
+
+    if (UNSAFE_OPTION_KEYS.indexOf(name) !== -1 || utils.isUndefined(source[name])) {
+      continue;
+    }
+
+    options[name] = source[name];
+  }
+
+  return options;
+}
+
 /**
  * Convert a data object to FormData
  * @param {Object} obj
@@ -54,14 +88,7 @@ function toFormData(obj, formData, options) {
   formData = formData || new (envFormData || FormData)();
 
   // eslint-disable-next-line no-param-reassign
-  options = utils.toFlatObject(options, {
-    metaTokens: true,
-    dots: false,
-    indexes: false
-  }, false, function defined(option, source) {
-    // eslint-disable-next-line no-eq-null,eqeqeq
-    return !utils.isUndefined(source[option]);
-  });
+  options = toFormDataOptions(options);
 
   var metaTokens = options.metaTokens;
   // eslint-disable-next-line no-use-before-define

--- a/test/unit/core/prototypePollution.js
+++ b/test/unit/core/prototypePollution.js
@@ -1,8 +1,12 @@
 "use strict";
 
 var assert = require('assert');
+var http = require('http');
 var utils = require('../../../lib/utils');
 var mergeConfig = require('../../../lib/core/mergeConfig');
+var dispatchRequest = require('../../../lib/core/dispatchRequest');
+var axios = require('../../../index');
+var AxiosError = require('../../../lib/core/AxiosError');
 
 describe("Prototype Pollution Protection", function () {
   function clearPollution() {
@@ -21,6 +25,23 @@ describe("Prototype Pollution Protection", function () {
     delete Object.prototype.post;
     delete Object.prototype.set;
     delete Object.prototype.data;
+    delete Object.prototype.method;
+    delete Object.prototype.headers;
+    delete Object.prototype.config;
+  }
+
+  function stubAdapter(store) {
+    return function adapter(config) {
+      store.config = config;
+
+      return Promise.resolve({
+        data: '',
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: config
+      });
+    };
   }
 
   // Defensive: clear before and after each test so pollution leaking from
@@ -445,6 +466,205 @@ describe("Prototype Pollution Protection", function () {
         var axiosErrorPath = require.resolve("../../../lib/core/AxiosError");
         delete require.cache[axiosErrorPath];
         require("../../../lib/core/AxiosError");
+      });
+    });
+  });
+
+  describe("request method fallback", function () {
+    var originalAdapter;
+
+    beforeEach(function () {
+      originalAdapter = axios.defaults.adapter;
+    });
+
+    afterEach(function () {
+      axios.defaults.adapter = originalAdapter;
+    });
+
+    it("should not take the default instance method from Object.prototype", function () {
+      var store = {};
+      axios.defaults.adapter = stubAdapter(store);
+
+      Object.prototype.method = 'DELETE';
+
+      return axios.request({ url: 'http://example.com/resource' }).then(function () {
+        assert.strictEqual(store.config.method, 'get');
+      });
+    });
+
+    it("should not take the callable shorthand method from Object.prototype", function () {
+      var store = {};
+      axios.defaults.adapter = stubAdapter(store);
+
+      Object.prototype.method = 'DELETE';
+
+      return axios({ url: 'http://example.com/resource' }).then(function () {
+        assert.strictEqual(store.config.method, 'get');
+      });
+    });
+
+    it("should still honour an explicit request method", function () {
+      var store = {};
+      axios.defaults.adapter = stubAdapter(store);
+
+      Object.prototype.method = 'DELETE';
+
+      return axios.request({ url: 'http://example.com/resource', method: 'put' }).then(function () {
+        assert.strictEqual(store.config.method, 'put');
+      });
+    });
+
+    it("should still honour an instance default method", function () {
+      var store = {};
+
+      var instance = axios.create({ method: 'post', adapter: stubAdapter(store) });
+
+      return instance.request({ url: 'http://example.com/resource' }).then(function () {
+        assert.strictEqual(store.config.method, 'post');
+      });
+    });
+  });
+
+  describe("dispatchRequest headers", function () {
+    it("should not take request headers from Object.prototype", function () {
+      Object.prototype.headers = { 'X-Poisoned': 'yes' };
+
+      var store = {};
+
+      // A request interceptor may return a replacement config that is an
+      // ordinary object without an own headers property.
+      return dispatchRequest({
+        url: 'http://example.com/resource',
+        method: 'get',
+        adapter: stubAdapter(store)
+      }).then(function () {
+        assert.strictEqual(store.config.headers['X-Poisoned'], undefined);
+      });
+    });
+
+    it("should still use own request headers", function () {
+      Object.prototype.headers = { 'X-Poisoned': 'yes' };
+
+      var store = {};
+
+      return dispatchRequest({
+        url: 'http://example.com/resource',
+        method: 'get',
+        headers: { 'X-Wanted': 'yes' },
+        adapter: stubAdapter(store)
+      }).then(function () {
+        assert.strictEqual(store.config.headers['X-Wanted'], 'yes');
+        assert.strictEqual(store.config.headers['X-Poisoned'], undefined);
+      });
+    });
+  });
+
+  describe("utils.toFlatObject", function () {
+    it("should not copy __proto__ or constructor from the source object", function () {
+      var source = {};
+      Object.defineProperty(source, '__proto__', {
+        value: { polluted: 'yes' },
+        enumerable: true,
+        configurable: true,
+        writable: true
+      });
+
+      source.constructor = function Evil() {};
+
+      var result = utils.toFlatObject(source, {});
+
+      assert.strictEqual(Object.getPrototypeOf(result), Object.prototype);
+      assert.strictEqual(result.polluted, undefined);
+      assert.strictEqual(Object.prototype.hasOwnProperty.call(result, 'constructor'), false);
+    });
+
+    it("should keep AxiosError.from intact for an error carrying an own __proto__", function () {
+      var error = new Error('boom');
+      Object.defineProperty(error, '__proto__', {
+        value: { hijacked: true },
+        enumerable: true,
+        configurable: true,
+        writable: true
+      });
+
+      var axiosError = AxiosError.from(error, 'ERR_TEST');
+
+      assert.ok(axiosError instanceof AxiosError);
+      assert.strictEqual(axiosError.message, 'boom');
+    });
+  });
+
+  describe("redirect hooks", function () {
+    function listen(handler) {
+      return new Promise(function (resolve) {
+        var server = http.createServer(handler);
+        server.listen(0, '127.0.0.1', function () {
+          resolve(server);
+        });
+      });
+    }
+
+    it("should not use an inherited redirect hook from Object.prototype", function () {
+      var legitHits = [];
+      var attackerHits = [];
+      var legit;
+      var attacker;
+      var redirector;
+
+      function closeAll() {
+        [legit, attacker, redirector].forEach(function closeServer(server) {
+          if (server) {
+            server.close();
+          }
+        });
+      }
+
+      // Servers are constructed before any pollution is applied.
+      return listen(function (req, res) {
+        legitHits.push(req.url);
+        res.end('LEGIT');
+      }).then(function (server) {
+        legit = server;
+
+        return listen(function (req, res) {
+          attackerHits.push(req.url);
+          res.end('ATTACKER');
+        });
+      }).then(function (server) {
+        attacker = server;
+
+        return listen(function (req, res) {
+          res.writeHead(302, { Location: 'http://127.0.0.1:' + legit.address().port + '/secret' });
+          res.end();
+        });
+      }).then(function (server) {
+        redirector = server;
+
+        var attackerPort = attacker.address().port;
+
+        // The adapter only populates its `config` redirect hook when the caller
+        // supplies beforeRedirect, so an inherited function used to be reachable
+        // and could repoint the redirect at another host.
+        Object.prototype.config = function pollutedHook(options) {
+          options.hostname = '127.0.0.1';
+          options.host = '127.0.0.1';
+          options.port = attackerPort;
+        };
+
+        return axios.get('http://127.0.0.1:' + redirector.address().port + '/start');
+      }).then(function (response) {
+        try {
+          assert.strictEqual(response.data, 'LEGIT');
+          assert.deepStrictEqual(legitHits, ['/secret']);
+          assert.deepStrictEqual(attackerHits, []);
+        } finally {
+          // Must run even when an assertion throws, or the open servers keep
+          // the test runner alive.
+          closeAll();
+        }
+      }, function (error) {
+        closeAll();
+        throw error;
       });
     });
   });

--- a/test/unit/helpers/shouldBypassProxy.js
+++ b/test/unit/helpers/shouldBypassProxy.js
@@ -119,4 +119,213 @@ describe('helpers::shouldBypassProxy', function () {
     assert.strictEqual(shouldBypassProxy('http://127.0.0.1:8080/'), true);
     assert.strictEqual(shouldBypassProxy('http://[::ffff:7f00:1]:8080/'), true);
   });
+
+  describe('CIDR entries', function () {
+    it('should bypass proxy for an address inside an IPv4 range', function () {
+      setNoProxy('127.0.0.0/8');
+
+      assert.strictEqual(shouldBypassProxy('http://127.0.0.1:1234/'), true);
+      assert.strictEqual(shouldBypassProxy('http://127.255.255.254/'), true);
+    });
+
+    it('should not bypass proxy for an address outside an IPv4 range', function () {
+      setNoProxy('10.0.0.0/8');
+
+      assert.strictEqual(shouldBypassProxy('http://10.1.2.3/'), true);
+      assert.strictEqual(shouldBypassProxy('http://11.1.2.3/'), false);
+    });
+
+    it('should honour a partial-byte prefix length', function () {
+      setNoProxy('172.16.0.0/12');
+
+      assert.strictEqual(shouldBypassProxy('http://172.16.0.1/'), true);
+      assert.strictEqual(shouldBypassProxy('http://172.31.255.254/'), true);
+      assert.strictEqual(shouldBypassProxy('http://172.32.0.1/'), false);
+      assert.strictEqual(shouldBypassProxy('http://172.15.255.254/'), false);
+    });
+
+    it('should support a single-address range for a metadata endpoint', function () {
+      setNoProxy('169.254.169.254/32');
+
+      assert.strictEqual(shouldBypassProxy('http://169.254.169.254/latest/meta-data/'), true);
+      assert.strictEqual(shouldBypassProxy('http://169.254.169.253/latest/meta-data/'), false);
+    });
+
+    it('should match a zero-length prefix against every IPv4 address', function () {
+      setNoProxy('0.0.0.0/0');
+
+      assert.strictEqual(shouldBypassProxy('http://8.8.8.8/'), true);
+    });
+
+    it('should support IPv6 ranges', function () {
+      setNoProxy('[fd00::]/8');
+
+      assert.strictEqual(shouldBypassProxy('http://[fd12::3]/'), true);
+      assert.strictEqual(shouldBypassProxy('http://[fe12::3]/'), false);
+    });
+
+    it('should support an unbracketed IPv6 range', function () {
+      setNoProxy('::1/128');
+
+      assert.strictEqual(shouldBypassProxy('http://[::1]:9/'), true);
+    });
+
+    it('should not match an IPv4 host against an IPv6 range', function () {
+      setNoProxy('[fd00::]/8');
+
+      assert.strictEqual(shouldBypassProxy('http://10.1.2.3/'), false);
+    });
+
+    it('should not match a named host against a range', function () {
+      setNoProxy('10.0.0.0/8');
+
+      assert.strictEqual(shouldBypassProxy('http://localhost/'), false);
+      assert.strictEqual(shouldBypassProxy('http://example.com/'), false);
+    });
+
+    it('should ignore malformed range entries instead of matching everything', function () {
+      setNoProxy('bogus/33');
+
+      assert.strictEqual(shouldBypassProxy('http://1.2.3.4/'), false);
+    });
+
+    it('should ignore an out-of-range prefix length', function () {
+      setNoProxy('10.0.0.0/33');
+
+      assert.strictEqual(shouldBypassProxy('http://10.1.2.3/'), false);
+    });
+
+    it('should still match plain host entries listed alongside a range', function () {
+      setNoProxy('10.0.0.0/8,example.com');
+
+      assert.strictEqual(shouldBypassProxy('http://example.com/'), true);
+      assert.strictEqual(shouldBypassProxy('http://10.1.2.3/'), true);
+    });
+
+    it('should match a zero-length IPv6 prefix against every IPv6 address', function () {
+      setNoProxy('::/0');
+
+      assert.strictEqual(shouldBypassProxy('http://[2001:db8::1]/'), true);
+    });
+
+    it('should honour an IPv6 prefix that is not byte aligned', function () {
+      setNoProxy('fe80::/10');
+
+      assert.strictEqual(shouldBypassProxy('http://[fe80::1]/'), true);
+      assert.strictEqual(shouldBypassProxy('http://[fec0::1]/'), false);
+    });
+
+    it('should accept a fully expanded IPv6 range entry', function () {
+      setNoProxy('2001:db8:0:0:0:0:0:0/32');
+
+      assert.strictEqual(shouldBypassProxy('http://[2001:db8::9]/'), true);
+      assert.strictEqual(shouldBypassProxy('http://[2001:db9::9]/'), false);
+    });
+
+    it('should accept an IPv6 range entry with all eight groups', function () {
+      setNoProxy('1:2:3:4:5:6:7:8/128');
+
+      assert.strictEqual(shouldBypassProxy('http://[1:2:3:4:5:6:7:8]/'), true);
+    });
+
+    it('should reject an IPv6 range with too many groups', function () {
+      setNoProxy('1:2:3:4:5:6:7:8:9/128');
+
+      assert.strictEqual(shouldBypassProxy('http://[1:2:3:4:5:6:7:8]/'), false);
+    });
+
+    it('should reject an IPv6 range with a repeated compression marker', function () {
+      setNoProxy('1::2::3/16');
+
+      assert.strictEqual(shouldBypassProxy('http://[1::]/'), false);
+    });
+
+    it('should reject an IPv6 range with invalid hex groups', function () {
+      setNoProxy('gggg::/16');
+
+      assert.strictEqual(shouldBypassProxy('http://[1::]/'), false);
+    });
+
+    it('should reject an IPv6 prefix longer than 128 bits', function () {
+      setNoProxy('2001:db8::/129');
+
+      assert.strictEqual(shouldBypassProxy('http://[2001:db8::9]/'), false);
+    });
+
+    it('should match an IPv4-mapped IPv6 host against an IPv4 range', function () {
+      setNoProxy('10.0.0.0/8');
+
+      assert.strictEqual(shouldBypassProxy('http://[::ffff:10.0.0.1]/'), true);
+    });
+
+    it('should reject a range whose octets carry leading zeros', function () {
+      // The URL parser reads 010.0.0.1 as octal, so `http://010.0.0.1/` arrives
+      // as 8.0.0.1. A decimal read of the entry would be 10.0.0.0/8 and would
+      // silently cover hosts the operator never named.
+      setNoProxy('010.0.0.0/8');
+
+      assert.strictEqual(shouldBypassProxy('http://10.1.2.3/'), false);
+      assert.strictEqual(shouldBypassProxy('http://8.1.2.3/'), false);
+    });
+
+    it('should still match an equivalent range written without leading zeros', function () {
+      setNoProxy('8.0.0.0/8');
+
+      assert.strictEqual(shouldBypassProxy('http://010.0.0.1/'), true);
+    });
+  });
+
+  it('should not match a leading-zero host entry against the decimal address', function () {
+    setNoProxy('010.0.0.1');
+
+    assert.strictEqual(shouldBypassProxy('http://10.0.0.1/'), false);
+  });
+
+  it('should still treat a zero-padded loopback entry as loopback', function () {
+    setNoProxy('127.000.000.001');
+
+    assert.strictEqual(shouldBypassProxy('http://127.0.0.1/'), true);
+  });
+
+  it('should normalise a long run of trailing dots in linear time', function () {
+    setNoProxy('example.com');
+
+    // A hostname of many dots followed by a non-dot character used to backtrack
+    // quadratically during trailing-dot normalisation. Hostnames reach this
+    // helper from redirect Location values, so the cost must stay linear.
+    // Scaling is asserted rather than wall-clock, so a slow or loaded machine
+    // does not make this flaky.
+    function timeHostname(dotCount) {
+      var hostname = new Array(dotCount + 1).join('.') + 'a';
+      var best = Infinity;
+
+      for (var run = 0; run < 3; run++) {
+        var started = process.hrtime();
+        shouldBypassProxy('http://' + hostname + '/');
+        var elapsed = process.hrtime(started);
+        best = Math.min(best, elapsed[0] * 1e9 + elapsed[1]);
+      }
+
+      return best;
+    }
+
+    timeHostname(1000);
+
+    var small = timeHostname(10000);
+    var large = timeHostname(100000);
+    var growth = large / Math.max(small, 1);
+
+    // Ten times the input costs roughly ten times the work when the scan is
+    // linear. The previous anchored /\.+$/ grew by roughly a hundred times.
+    assert.ok(
+      growth < 25,
+      'trailing-dot normalisation should scale linearly, saw ' + growth.toFixed(1) + 'x for 10x input'
+    );
+  });
+
+  it('should ignore trailing dots when matching a no_proxy entry', function () {
+    setNoProxy('example.com');
+
+    assert.strictEqual(shouldBypassProxy('http://example.com.../'), true);
+  });
 });

--- a/test/unit/helpers/shouldBypassProxy.js
+++ b/test/unit/helpers/shouldBypassProxy.js
@@ -246,6 +246,38 @@ describe('helpers::shouldBypassProxy', function () {
       assert.strictEqual(shouldBypassProxy('http://[1::]/'), false);
     });
 
+    it('should reject an IPv6 range whose dotted quad precedes the compression marker', function () {
+      // A dotted quad only stands for the final 32 bits, so it cannot sit before
+      // `::`. Expanding it anyway read this entry as 102:304::/64 and bypassed
+      // the proxy for a network the operator never listed.
+      setNoProxy('1.2.3.4::/64');
+
+      assert.strictEqual(shouldBypassProxy('http://[102:304::1]/'), false);
+      assert.strictEqual(shouldBypassProxy('http://[1:2:3:4::1]/'), false);
+    });
+
+    it('should reject an IPv6 range with a dotted quad in the middle of the head', function () {
+      setNoProxy('a:1.2.3.4::/32');
+
+      assert.strictEqual(shouldBypassProxy('http://[a:102::1]/'), false);
+    });
+
+    it('should reject a compressed IPv6 range that already spells out all eight groups', function () {
+      // `::` stands for at least one group of zeros, so this entry is malformed.
+      // Accepting it parsed the prefix as a valid /0 network, which matched every
+      // IPv6 destination.
+      setNoProxy('1:2:3:4:5:6:7:8::/0');
+
+      assert.strictEqual(shouldBypassProxy('http://[dead:beef::1]/'), false);
+      assert.strictEqual(shouldBypassProxy('http://[1:2:3:4:5:6:7:8]/'), false);
+    });
+
+    it('should reject a compressed IPv6 range that compresses nothing', function () {
+      setNoProxy('1:2:3:4::5:6:7:8/64');
+
+      assert.strictEqual(shouldBypassProxy('http://[1:2:3:4:aaaa::1]/'), false);
+    });
+
     it('should reject an IPv6 prefix longer than 128 bits', function () {
       setNoProxy('2001:db8::/129');
 

--- a/test/unit/helpers/toFormData.js
+++ b/test/unit/helpers/toFormData.js
@@ -57,4 +57,95 @@ describe("helpers::toFormData", function () {
       });
     });
   });
+
+  describe("inherited option properties", function () {
+    function clearPollution() {
+      delete Object.prototype.visitor;
+      delete Object.prototype.maxDepth;
+      delete Object.prototype.dots;
+      delete Object.prototype.indexes;
+      delete Object.prototype.metaTokens;
+      delete Object.prototype.Blob;
+    }
+
+    function recorder() {
+      var keys = [];
+
+      return {
+        keys: keys,
+        append: function append(key) {
+          keys.push(key);
+        }
+      };
+    }
+
+    beforeEach(clearPollution);
+    afterEach(clearPollution);
+
+    it("should not use an inherited visitor", function () {
+      var seen = [];
+
+      Object.prototype.visitor = function pollutedVisitor(value, key, path, helpers) {
+        seen.push(key);
+        return helpers.defaultVisitor.call(this, value, key, path);
+      };
+
+      toFormData({ user: "john", secret: "s3cr3t" }, recorder());
+
+      assert.deepStrictEqual(seen, []);
+    });
+
+    it("should not use an inherited maxDepth", function () {
+      Object.prototype.maxDepth = 1;
+
+      assert.doesNotThrow(function () {
+        toFormData({ a: { b: { c: "value" } } }, recorder());
+      });
+    });
+
+    it("should still honour an explicit maxDepth", function () {
+      Object.prototype.maxDepth = 100;
+
+      assert.throws(
+        function () {
+          toFormData({ a: { b: { c: "value" } } }, recorder(), { maxDepth: 1 });
+        },
+        function (error) {
+          return error instanceof AxiosError &&
+            error.code === AxiosError.ERR_FORM_DATA_DEPTH_EXCEEDED;
+        }
+      );
+    });
+
+    it("should not use an inherited Blob implementation", function () {
+      var used = false;
+
+      Object.prototype.Blob = function PollutedBlob() {
+        used = true;
+      };
+
+      toFormData({ a: "b" }, recorder());
+
+      assert.strictEqual(used, false);
+    });
+
+    it("should keep caller options when the same key is polluted", function () {
+      Object.prototype.dots = true;
+
+      var form = recorder();
+      toFormData({ a: { b: "c" } }, form, { dots: true });
+
+      assert.deepStrictEqual(form.keys, ["a.b"]);
+    });
+
+    it("should keep default key formatting when a format flag is polluted", function () {
+      Object.prototype.dots = true;
+      Object.prototype.indexes = true;
+
+      var form = recorder();
+      toFormData({ a: { b: "c" } }, form);
+
+      assert.deepStrictEqual(form.keys, ["a[b]"]);
+    });
+  });
 });

--- a/test/unit/helpers/toFormData.js
+++ b/test/unit/helpers/toFormData.js
@@ -79,6 +79,19 @@ describe("helpers::toFormData", function () {
       };
     }
 
+    // toFormData only considers a Blob implementation at all when the target
+    // looks like a spec-compliant FormData, so the Blob test needs one.
+    function specCompliantRecorder() {
+      var form = recorder();
+
+      form[Symbol.toStringTag] = "FormData";
+      form[Symbol.iterator] = function values() {
+        return form.keys[Symbol.iterator]();
+      };
+
+      return form;
+    }
+
     beforeEach(clearPollution);
     afterEach(clearPollution);
 
@@ -118,19 +131,66 @@ describe("helpers::toFormData", function () {
     });
 
     it("should not use an inherited Blob implementation", function () {
-      var used = false;
+      // The Blob option is only ever read as a truthiness gate, so the polluted
+      // constructor is never called and cannot be observed directly. What it
+      // does change is whether the serializer runs in Blob mode, and that
+      // decides whether a Blob value is rejected.
+      //
+      // The bare global Blob has to be taken out of the picture first, and
+      // deleting it is not enough: the global object inherits from
+      // Object.prototype too, so the pollution would simply resurface there.
+      // Shadow it with an own undefined property instead, which leaves the
+      // option lookup as the only possible source of a Blob implementation.
+      var globalBlob = Object.getOwnPropertyDescriptor(global, "Blob");
 
-      Object.prototype.Blob = function PollutedBlob() {
-        used = true;
-      };
+      Object.defineProperty(global, "Blob", {
+        value: undefined,
+        writable: true,
+        enumerable: false,
+        configurable: true
+      });
 
-      toFormData({ a: "b" }, recorder());
+      try {
+        Object.prototype.Blob = function PollutedBlob() {};
 
-      assert.strictEqual(used, false);
+        assert.strictEqual(
+          typeof Blob,
+          "undefined",
+          "the global Blob must be out of reach for this test to prove anything"
+        );
+
+        var form = specCompliantRecorder();
+        var blobLike = {};
+        blobLike[Symbol.toStringTag] = "Blob";
+
+        // The caller passes an options object that says nothing about Blob, so
+        // the only place a Blob implementation could come from is the prototype.
+        assert.throws(
+          function () {
+            toFormData({ file: blobLike }, form, {});
+          },
+          function (error) {
+            return error instanceof AxiosError &&
+              /Blob is not supported/.test(error.message);
+          }
+        );
+
+        assert.deepStrictEqual(form.keys, []);
+      } finally {
+        if (globalBlob) {
+          Object.defineProperty(global, "Blob", globalBlob);
+        } else {
+          delete global.Blob;
+        }
+      }
     });
 
-    it("should keep caller options when the same key is polluted", function () {
-      Object.prototype.dots = true;
+    it("should not let a polluted key mask a caller option", function () {
+      // Merging the options onto a plain object used a plain object as its
+      // "already copied" cache too, so any truthy inherited value made the
+      // caller's own option look like it had been copied already and the
+      // serializer silently fell back to the default key format.
+      Object.prototype.dots = "polluted";
 
       var form = recorder();
       toFormData({ a: { b: "c" } }, form, { dots: true });


### PR DESCRIPTION
Three related hardening fixes on the v0.x line.

## Form serializer options

`toFormData` merged caller options onto a plain object and then read `visitor`, `maxDepth`, `dots`, `indexes`, `metaTokens` and `Blob` directly from it. Inherited values could choose the serializer visitor, the depth limit and the key format, and could also mask an option the caller had set. Options are now materialised on a null-prototype object holding only own, defined properties from the caller.

## Request method, headers and redirect hooks

- The default instance method fallback read `this.defaults.method`, so an inherited value could replace the default `GET` on `axios.request({ url })` and `axios({ url })`. Method aliases and explicit methods were never affected.
- `dispatchRequest` read `config.headers`, which a request interceptor may replace with an object that has no own `headers`.
- The HTTP adapter kept its redirect hooks on a plain object. The `config` hook is only populated when the caller supplies `beforeRedirect`, so an inherited function could reach the redirect path and rewrite the request target.

The first two are now read as own properties, and the redirect hook bag has a null prototype.

## no_proxy matching

- Trailing-dot normalisation used an anchored `/\.+$/`, which backtracks quadratically on a long run of dots that is not at the end of the string. Hostnames reach this helper from redirect `Location` values, so the cost needs to stay linear. Replaced with a linear scan: 100k dots now normalises in about 1ms.
- CIDR entries such as `10.0.0.0/8` were compared as literal hostnames and so never matched, meaning traffic operators had excluded still went through the proxy. IPv4 and IPv6 ranges are now parsed and matched on address bits.
- Dotted-quad octets carrying leading zeros are rejected. The URL parser reads `010.0.0.1` as octal `8.0.0.1`, so a decimal read of the same literal in an entry would cover hosts the operator never named. `isLoopbackIPv4` stays deliberately permissive, since a leading zero in a later octet cannot change whether the first octet is `127`.

## Compatibility

`NO_PROXY` entries in CIDR form previously matched nothing and now take effect. Traffic that used to traverse the proxy will stop doing so wherever operators wrote ranges. That is the documented intent of the setting, but it is a live routing change and should be called out in the release notes.

Two narrower changes: instance defaults that inherit `method` from a custom prototype no longer apply, and an interceptor returning an object that inherits `headers` no longer picks those up.

No declaration changes, so `index.d.ts` and the dtslint fixtures are untouched.

## Testing

- `grunt eslint mochaTest`: 202 passing, lint clean.
- `grunt karma:single`: 335 passing on Firefox.
- New regression tests were run against the branch point. 19 across the proxy and prototype-pollution suites fail there, so they guard the behaviour rather than describe it.
- Differential runs against the branch point on inputs unrelated to these fixes show no behaviour change: 594 `shouldBypassProxy` cases, 196 `toFormData` cases, and 13 full request-path cases covering redirects, `maxRedirects: 0`, instance defaults, interceptors and params.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
## Description

Fixes three related hardening issues on the v0.x line: polluted `Object.prototype` values can no longer influence form serialization, request method selection, request headers, or HTTP redirect hooks; CIDR-form `no_proxy` entries (like `10.0.0.0/8`) now match by address instead of by literal hostname; and trailing-dot normalization no longer backtracks quadratically on attacker-controlled redirect locations.

- Form serializer options are now read from a null-prototype object holding only own, defined caller properties, so inherited values cannot pick the visitor, depth limit, key format, or `Blob` implementation.
- The default instance method fallback and `dispatchRequest` headers are read as own properties, and the HTTP adapter's redirect hook bag has a null prototype.
- CIDR entries are parsed and matched for IPv4 and IPv6, leading-zero octets are rejected since the URL parser reads them as octal, and 100k trailing dots now normalize in about 1ms.
- Malformed IPv6 ranges now fail closed instead of parsing as a valid network: a dotted quad cannot precede `::`, and `::` must stand for at least one group of zeros.

CIDR `no_proxy` entries previously never matched, so this is a behavior change: hosts inside a listed range will now correctly bypass the proxy.

## Docs

Suggest documenting CIDR range support for `no_proxy` entries in the `/docs/` directory.

## Testing

Adds tests covering inherited-option protection for form serialization and the request path, redirect hook safety, IPv4/IPv6 CIDR matching edge cases including malformed ranges, a scaling assertion for trailing-dot normalization, and a Blob pollution test that fails without the fix.

## Semantic version impact

Patch release: no public API signatures change, and the behavior fixes correct previously broken paths rather than removing supported functionality.

<sup>Written for commit 4d247cf9dc2ed69ecce2988dc8b30cba7ac234ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/axios/axios/pull/11172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

