### PR TITLE
refactor(helpers): remove Internet Explorer detection from isURLSameOrigin

### DIFF
--- a/lib/helpers/isURLSameOrigin.js
+++ b/lib/helpers/isURLSameOrigin.js
@@ -1,16 +1,13 @@
 import platform from '../platform/index.js';
 
 export default platform.hasStandardBrowserEnv
-  ? ((origin, isMSIE) => (url) => {
+  ? ((origin) => (url) => {
       url = new URL(url, platform.origin);
 
       return (
         origin.protocol === url.protocol &&
         origin.host === url.host &&
-        (isMSIE || origin.port === url.port)
+        origin.port === url.port
       );
-    })(
-      new URL(platform.origin),
-      platform.navigator && /(msie|trident)/i.test(platform.navigator.userAgent)
-    )
+    })(new URL(platform.origin))
   : () => true;


### PR DESCRIPTION
## Summary

`lib/helpers/isURLSameOrigin.js` still sniffs the user agent for Internet Explorer:

```js
platform.navigator && /(msie|trident)/i.test(platform.navigator.userAgent)
```

and uses the result to skip the port comparison when deciding whether a URL is same-origin (`isMSIE || origin.port === url.port`).

This PR removes the IE detection and the port-check bypass.

## Why this is safe to remove

- The IE special-casing dates back to **2014** (7aef479, "Adding xsrf protection"), when IE's URL handling required workarounds. The 2024 rewrite to the URL API (#6714 / 0a8d6e1) removed the DOM-parsing workaround but kept the `isMSIE` port bypass.
- **Internet Explorer 11 reached end of support on 2022-06-15**, and Trident-based IE modes cannot run current axios anyway (the codebase targets ES2017+).
- The project's own **Browser support table in the README lists Chrome, Firefox, Safari, Opera and Edge ("Latest") — IE is not listed** as a supported browser.
- Behavior is unchanged for every supported browser: `isMSIE` is always `false` outside IE, so the port comparison already runs everywhere the library supports. The only environment whose behavior would change is one that is no longer supported.
- No test references the IE path (`tests/browser/isURLSameOrigin.browser.test.js` covers the same-origin/cross-origin cases, which behave identically after this change).

## Changes

- Remove the `msie|trident` user-agent sniff and the `isMSIE` parameter from `isURLSameOrigin`.
- Same-origin check now always compares protocol, host and port.

Found while auditing long-lived workarounds in popular open-source projects.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
## Description

Removes the Internet Explorer user-agent sniff from `isURLSameOrigin` so the same-origin check always compares protocol, host, and port regardless of browser.

- IE is outside the supported browser set (end of support in 2022, not listed in the README browser support table), so behavior is unchanged for every supported browser.
- No tests reference the IE path, so existing `isURLSameOrigin` browser tests still cover all behavior.

## Docs

No documentation update needed; the README browser support table already omits IE.

## Testing

No tests were added; the existing browser tests for `isURLSameOrigin` cover same-origin and cross-origin cases, which behave identically after this change.

## Semantic version impact

Patch version change: dead code removal only, no behavior change for supported environments, so no breaking or minor impact.

<sup>Written for commit bcfcb1d44a3a92b3d6b120648343bd913c75eeeb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/axios/axios/pull/11174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

