### PR TITLE
fix(http): normalize the configured proxy protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,8 +494,9 @@ These are the available config options for making requests. Only the `url` is re
   // supplies credentials.
   // This will set an `Proxy-Authorization` header, overwriting any existing
   // `Proxy-Authorization` custom headers you have set using `headers`.
-  // The proxy protocol defaults to `http` when omitted.
-  // If the proxy server uses HTTPS, then you must set the protocol to `https`.
+  // Set the protocol to `http` for a plaintext proxy or `https` for a TLS proxy.
+  // If omitted, the proxy connection inherits the target URL's protocol.
+  // A plaintext proxy for an HTTPS target therefore requires explicit `http`.
   proxy: {
     protocol: 'https',
     host: '127.0.0.1',

--- a/README.md
+++ b/README.md
@@ -495,9 +495,12 @@ These are the available config options for making requests. Only the `url` is re
   // This will set an `Proxy-Authorization` header, overwriting any existing
   // `Proxy-Authorization` custom headers you have set using `headers`.
   // Set the protocol to `http` for a plaintext proxy or `https` for a TLS proxy.
+  // HTTP(S) schemes accept a trailing colon, any case, and surrounding whitespace.
   // If omitted, the proxy connection inherits the target URL's protocol.
+  // Empty strings and non-string values also leave the target protocol unchanged.
   // A plaintext proxy for an HTTPS target therefore requires explicit `http`.
-  // Unsupported non-empty protocol strings are rejected before connecting.
+  // Unsupported non-empty strings (e.g. `ftp`, `https://`, or whitespace-only)
+  // reject with `ERR_BAD_OPTION_VALUE` before connecting, without a fallback.
   proxy: {
     protocol: 'https',
     host: '127.0.0.1',

--- a/README.md
+++ b/README.md
@@ -497,6 +497,7 @@ These are the available config options for making requests. Only the `url` is re
   // Set the protocol to `http` for a plaintext proxy or `https` for a TLS proxy.
   // If omitted, the proxy connection inherits the target URL's protocol.
   // A plaintext proxy for an HTTPS target therefore requires explicit `http`.
+  // Unsupported non-empty protocol strings are rejected before connecting.
   proxy: {
     protocol: 'https',
     host: '127.0.0.1',

--- a/README.md
+++ b/README.md
@@ -494,6 +494,7 @@ These are the available config options for making requests. Only the `url` is re
   // supplies credentials.
   // This will set an `Proxy-Authorization` header, overwriting any existing
   // `Proxy-Authorization` custom headers you have set using `headers`.
+  // The proxy protocol defaults to `http` when omitted.
   // If the proxy server uses HTTPS, then you must set the protocol to `https`.
   proxy: {
     protocol: 'https',

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -126,6 +126,35 @@ function checkSocketPath(config) {
 }
 
 /**
+ * Normalize a configured proxy protocol to the `scheme:` form Node expects.
+ *
+ * `AxiosProxyConfig.protocol` is documented (and typed) as a bare scheme such
+ * as `'http'`, but the value is handed straight to `http.request` as
+ * `options.protocol`, where it is compared verbatim against the agent's own
+ * `protocol`. A missing colon therefore made every documented proxy config
+ * fail with `ERR_ASSERTION: protocol mismatch`. Schemes are case-insensitive,
+ * so fold to lower case as well.
+ *
+ * @param {*} protocol The configured proxy protocol
+ * @returns {string|undefined} The normalized protocol, or undefined when unusable
+ */
+function normalizeProxyProtocol(protocol) {
+  if (typeof protocol !== 'string') {
+    return undefined;
+  }
+
+  var normalized = protocol.trim().toLowerCase();
+
+  if (!normalized) {
+    return undefined;
+  }
+
+  return normalized.charAt(normalized.length - 1) === ':'
+    ? normalized
+    : normalized + ':';
+}
+
+/**
  *
  * @param {http.ClientRequestArgs} options
  * @param {AxiosProxyConfig} configProxy
@@ -178,8 +207,16 @@ function setProxy(options, configProxy, location) {
     options.host = proxy.host;
     options.port = proxy.port;
     options.path = location;
-    if (proxy.protocol) {
-      options.protocol = proxy.protocol;
+
+    // Only assign when the config actually carries a usable protocol, so a
+    // proxy object without one keeps the previous behaviour of inheriting the
+    // target's protocol.
+    var proxyProtocol = normalizeProxyProtocol(
+      utils.hasOwnProperty(proxy, 'protocol') ? proxy.protocol : undefined
+    );
+
+    if (proxyProtocol) {
+      options.protocol = proxyProtocol;
     }
   }
 

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -139,6 +139,10 @@ function checkSocketPath(config) {
  * @returns {string|undefined} The normalized protocol, or undefined when unusable
  */
 function normalizeProxyProtocol(protocol) {
+  if (typeof protocol === 'undefined') {
+    return 'http:';
+  }
+
   if (typeof protocol !== 'string') {
     return undefined;
   }
@@ -208,9 +212,8 @@ function setProxy(options, configProxy, location) {
     options.port = proxy.port;
     options.path = location;
 
-    // Only assign when the config actually carries a usable protocol, so a
-    // proxy object without one keeps the previous behaviour of inheriting the
-    // target's protocol.
+    // Default an absent proxy protocol to HTTP, independently of the target.
+    // Explicitly unusable values still leave the target protocol unchanged.
     var proxyProtocol = normalizeProxyProtocol(
       utils.hasOwnProperty(proxy, 'protocol') ? proxy.protocol : undefined
     );

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -136,10 +136,11 @@ function checkSocketPath(config) {
  * so fold to lower case as well.
  *
  * @param {*} protocol The configured proxy protocol
- * @returns {string|undefined} The normalized protocol, or undefined when unusable
+ * @returns {string|undefined} The normalized protocol, or undefined for non-strings or an empty string
+ * @throws {AxiosError} If a non-empty string is not an HTTP(S) protocol
  */
 function normalizeProxyProtocol(protocol) {
-  if (typeof protocol !== 'string') {
+  if (typeof protocol !== 'string' || protocol === '') {
     return undefined;
   }
 
@@ -153,7 +154,12 @@ function normalizeProxyProtocol(protocol) {
     return normalized;
   }
 
-  return undefined;
+  // Never infer a transport from an explicitly invalid string: an HTTP target
+  // could otherwise send HTTPS proxy credentials over a plaintext connection.
+  throw new AxiosError(
+    'proxy.protocol must be http or https',
+    AxiosError.ERR_BAD_OPTION_VALUE
+  );
 }
 
 /**
@@ -178,6 +184,11 @@ function setProxy(options, configProxy, location) {
     removeProxyAuthorization(options.headers);
   }
   if (proxy) {
+    // Validate before adding proxy credentials or configuring a connection.
+    var proxyProtocol = normalizeProxyProtocol(
+      utils.hasOwnProperty(proxy, 'protocol') ? proxy.protocol : undefined
+    );
+
     // Basic proxy authorization
     var proxyAuth = utils.hasOwnProperty(proxy, 'auth')
       ? proxy.auth
@@ -210,12 +221,8 @@ function setProxy(options, configProxy, location) {
     options.port = proxy.port;
     options.path = location;
 
-    // Preserve the target protocol for absent or unusable proxy protocols.
+    // Preserve the target protocol when no normalized proxy protocol is supplied.
     // Defaulting to HTTP here could downgrade an existing HTTPS proxy connection.
-    var proxyProtocol = normalizeProxyProtocol(
-      utils.hasOwnProperty(proxy, 'protocol') ? proxy.protocol : undefined
-    );
-
     if (proxyProtocol) {
       options.protocol = proxyProtocol;
     }

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -126,7 +126,7 @@ function checkSocketPath(config) {
 }
 
 /**
- * Normalize a configured proxy protocol to the `scheme:` form Node expects.
+ * Normalize a configured HTTP(S) proxy protocol to the `scheme:` form Node expects.
  *
  * `AxiosProxyConfig.protocol` is documented (and typed) as a bare scheme such
  * as `'http'`, but the value is handed straight to `http.request` as
@@ -139,23 +139,21 @@ function checkSocketPath(config) {
  * @returns {string|undefined} The normalized protocol, or undefined when unusable
  */
 function normalizeProxyProtocol(protocol) {
-  if (typeof protocol === 'undefined') {
-    return 'http:';
-  }
-
   if (typeof protocol !== 'string') {
     return undefined;
   }
 
   var normalized = protocol.trim().toLowerCase();
 
-  if (!normalized) {
-    return undefined;
+  if (normalized === 'http' || normalized === 'https') {
+    return normalized + ':';
   }
 
-  return normalized.charAt(normalized.length - 1) === ':'
-    ? normalized
-    : normalized + ':';
+  if (normalized === 'http:' || normalized === 'https:') {
+    return normalized;
+  }
+
+  return undefined;
 }
 
 /**
@@ -212,8 +210,8 @@ function setProxy(options, configProxy, location) {
     options.port = proxy.port;
     options.path = location;
 
-    // Default an absent proxy protocol to HTTP, independently of the target.
-    // Explicitly unusable values still leave the target protocol unchanged.
+    // Preserve the target protocol for absent or unusable proxy protocols.
+    // Defaulting to HTTP here could downgrade an existing HTTPS proxy connection.
     var proxyProtocol = normalizeProxyProtocol(
       utils.hasOwnProperty(proxy, 'protocol') ? proxy.protocol : undefined
     );

--- a/test/unit/adapters/http.js
+++ b/test/unit/adapters/http.js
@@ -1417,6 +1417,151 @@ describe("supports http with nodejs", function () {
       });
   });
 
+  it("should support a proxy protocol without a trailing colon", function (done) {
+    server = http
+      .createServer(function (req, res) {
+        res.setHeader("Content-Type", "text/html; charset=UTF-8");
+        res.end("12345");
+      })
+      .listen(4444, function () {
+        proxy = http
+          .createServer(function (request, response) {
+            var parsed = url.parse(request.url);
+
+            http.get(
+              {
+                host: parsed.hostname,
+                port: parsed.port,
+                path: parsed.path,
+              },
+              function (res) {
+                var body = "";
+                res.on("data", function (data) {
+                  body += data;
+                });
+                res.on("end", function () {
+                  response.setHeader(
+                    "Content-Type",
+                    "text/html; charset=UTF-8",
+                  );
+                  response.end(body + "6789");
+                });
+              },
+            );
+          })
+          .listen(4000, function () {
+            axios
+              .get("http://localhost:4444/", {
+                proxy: {
+                  host: "localhost",
+                  port: 4000,
+                  // Documented in the README as a bare scheme.
+                  protocol: "http",
+                },
+              })
+              .then(function (res) {
+                assert.equal(
+                  res.data,
+                  "123456789",
+                  "should pass through proxy",
+                );
+                done();
+              })
+              .catch(done);
+          });
+      });
+  });
+
+  it("should normalize the proxy protocol case", function (done) {
+    server = http
+      .createServer(function (req, res) {
+        res.end("12345");
+      })
+      .listen(4444, function () {
+        proxy = http
+          .createServer(function (request, response) {
+            var parsed = url.parse(request.url);
+
+            http.get(
+              {
+                host: parsed.hostname,
+                port: parsed.port,
+                path: parsed.path,
+              },
+              function (res) {
+                var body = "";
+                res.on("data", function (data) {
+                  body += data;
+                });
+                res.on("end", function () {
+                  response.end(body + "6789");
+                });
+              },
+            );
+          })
+          .listen(4000, function () {
+            axios
+              .get("http://localhost:4444/", {
+                proxy: {
+                  host: "localhost",
+                  port: 4000,
+                  protocol: "HTTP:",
+                },
+              })
+              .then(function (res) {
+                assert.equal(res.data, "123456789");
+                done();
+              })
+              .catch(done);
+          });
+      });
+  });
+
+  it("should ignore a non-string proxy protocol", function (done) {
+    server = http
+      .createServer(function (req, res) {
+        res.end("12345");
+      })
+      .listen(4444, function () {
+        proxy = http
+          .createServer(function (request, response) {
+            var parsed = url.parse(request.url);
+
+            http.get(
+              {
+                host: parsed.hostname,
+                port: parsed.port,
+                path: parsed.path,
+              },
+              function (res) {
+                var body = "";
+                res.on("data", function (data) {
+                  body += data;
+                });
+                res.on("end", function () {
+                  response.end(body + "6789");
+                });
+              },
+            );
+          })
+          .listen(4000, function () {
+            axios
+              .get("http://localhost:4444/", {
+                proxy: {
+                  host: "localhost",
+                  port: 4000,
+                  protocol: 1234,
+                },
+              })
+              .then(function (res) {
+                assert.equal(res.data, "123456789");
+                done();
+              })
+              .catch(done);
+          });
+      });
+  });
+
   it("should not pass through disabled proxy", function (done) {
     // set the env variable
     process.env.http_proxy = "http://does-not-exists.example.com:4242/";

--- a/test/unit/adapters/http.js
+++ b/test/unit/adapters/http.js
@@ -1358,6 +1358,71 @@ describe("supports http with nodejs", function () {
       });
   });
 
+  ["omitted", "undefined"].forEach(function (protocolCase) {
+    ["native", "follow", "redirect"].forEach(function (transportCase) {
+      it("should default an " + protocolCase + " proxy protocol to HTTP for an HTTPS target (" + transportCase + ")", function (done) {
+        var requests = [];
+        var target = "https://target.example/start";
+        var redirectedTarget = "https://redirected.example/finish";
+
+        // Respond as a plaintext forward proxy; no external target is contacted.
+        proxy = http.createServer(function (req, res) {
+          requests.push({url: req.url, host: req.headers.host});
+          if (transportCase === "redirect" && requests.length === 1) {
+            res.writeHead(302, {Location: redirectedTarget});
+            res.end();
+          } else {
+            res.end("proxied");
+          }
+        }).listen(0, "127.0.0.1", function () {
+          var proxyConfig = {
+            host: "127.0.0.1",
+            port: proxy.address().port,
+          };
+          if (protocolCase === "undefined") {
+            proxyConfig.protocol = undefined;
+          }
+          var config = {proxy: proxyConfig, timeout: 3000};
+          if (transportCase === "native") {
+            config.maxRedirects = 0;
+          }
+
+          axios.get(target, config).then(function (res) {
+            assert.equal(res.data, "proxied");
+            var expected = [{url: target, host: "target.example"}];
+            if (transportCase === "redirect") {
+              expected.push({url: redirectedTarget, host: "redirected.example"});
+            }
+            assert.deepStrictEqual(requests, expected);
+            done();
+          }).catch(done);
+        });
+      });
+    });
+  });
+
+  [null, false, 1234, {}, "", " "].forEach(function (protocol) {
+    it("should preserve the HTTPS target protocol for an unusable proxy protocol " + JSON.stringify(protocol), function () {
+      var capturedOptions;
+      var stopped = new Error("request inspected");
+
+      return axios.get("https://target.example/", {
+        proxy: {host: "127.0.0.1", port: 4000, protocol: protocol},
+        transport: {
+          request: function (options) {
+            capturedOptions = options;
+            throw stopped;
+          },
+        },
+      }).then(function () {
+        assert.fail("transport should stop the request");
+      }, function (err) {
+        assert.strictEqual(err, stopped);
+        assert.equal(capturedOptions.protocol, "https:");
+      });
+    });
+  });
+
   it("should support HTTPS proxies", function (done) {
     var options = {
       key: fs.readFileSync(path.join(__dirname, "key.pem")),

--- a/test/unit/adapters/http.js
+++ b/test/unit/adapters/http.js
@@ -1365,8 +1365,6 @@ describe("supports http with nodejs", function () {
     {name: "colon HTTP", protocol: " HTTP: ", secure: false},
     {name: "bare HTTPS", protocol: "https", secure: true},
     {name: "colon HTTPS", protocol: " HTTPS: ", secure: true},
-    {name: "unsupported", protocol: "ftp", secure: true},
-    {name: "malformed", protocol: "http://", secure: true},
   ].forEach(function (protocolCase) {
     ["native", "follow", "redirect"].forEach(function (transportCase) {
       it("should use " + (protocolCase.secure ? "HTTPS" : "HTTP") + " for an HTTPS target with " + protocolCase.name + " proxy protocol (" + transportCase + ")", function (done) {
@@ -1438,7 +1436,7 @@ describe("supports http with nodejs", function () {
     });
   });
 
-  [undefined, null, false, 1234, {}, "", " ", "ftp", "ftp:", "http://", "https://", "http::", "https::", "https:invalid"].forEach(function (protocol) {
+  [undefined, null, false, 1234, {}, ""].forEach(function (protocol) {
     ["http:", "https:"].forEach(function (targetProtocol) {
       it("should preserve the " + targetProtocol + " target protocol for an unusable proxy protocol " + JSON.stringify(protocol), function () {
         var capturedOptions;
@@ -1458,6 +1456,94 @@ describe("supports http with nodejs", function () {
           assert.strictEqual(err, stopped);
           assert.equal(capturedOptions.protocol, targetProtocol);
         });
+      });
+    });
+  });
+
+  [" ", "ftp", "ftp:", "http://", "https://", "http::", "https::", "https:invalid", "https://user:secret@proxy"].forEach(function (protocol) {
+    ["http:", "https:"].forEach(function (targetProtocol) {
+      ["native", "follow"].forEach(function (transportCase) {
+        it("should reject invalid proxy protocol " + JSON.stringify(protocol) + " before connecting (" + targetProtocol + ", " + transportCase + ")", function (done) {
+          var connections = 0;
+          proxy = http.createServer(function (req, res) {
+            res.end("unexpected proxy request");
+          });
+          proxy.on("connection", function () {
+            connections++;
+          });
+          proxy.listen(0, "127.0.0.1", function () {
+            var config = {
+              proxy: {
+                host: "127.0.0.1",
+                port: proxy.address().port,
+                protocol: protocol,
+                auth: {username: "proxy-user", password: "proxy-pass"},
+              },
+              timeout: 1000,
+              httpAgent: new http.Agent({keepAlive: false}),
+              httpsAgent: new https.Agent({keepAlive: false}),
+            };
+            if (transportCase === "native") {
+              config.maxRedirects = 0;
+            }
+
+            axios.get(targetProtocol + "//target.example/private", config).then(function () {
+              assert.fail("invalid proxy protocol must reject");
+            }, function (err) {
+              assert(axios.isAxiosError(err));
+              assert.equal(err.code, AxiosError.ERR_BAD_OPTION_VALUE);
+              // Do not echo malformed values that may contain credentials.
+              assert.equal(err.message, "proxy.protocol must be http or https");
+              assert.equal(connections, 0, "must reject before opening a proxy connection");
+            }).then(function () { done(); }, done);
+          });
+        });
+      });
+    });
+  });
+
+  [false, true].forEach(function (redirect) {
+    it("should reject an unsupported environment proxy protocol before connecting" + (redirect ? " on redirect" : ""), function (done) {
+      var connections = 0;
+      proxy = http.createServer(function (req, res) {
+        res.end("unexpected proxy request");
+      });
+      proxy.on("connection", function () {
+        connections++;
+      });
+      proxy.listen(0, "127.0.0.1", function () {
+        process.env.http_proxy = "socks5://proxy-user:proxy-pass@127.0.0.1:" + proxy.address().port;
+        process.env.no_proxy = "127.0.0.1";
+
+        function request(target) {
+          axios.get(target, {timeout: 1000, httpAgent: new http.Agent({keepAlive: false})}).then(function () {
+            assert.fail("unsupported environment proxy protocol must reject");
+          }, function (err) {
+            assert(axios.isAxiosError(err));
+            if (redirect) {
+              assert.equal(err.code, "ERR_FR_REDIRECTION_FAILURE");
+              var cause = err;
+              while (cause.cause) {
+                cause = cause.cause;
+              }
+              assert.equal(cause.code, AxiosError.ERR_BAD_OPTION_VALUE);
+            } else {
+              assert.equal(err.code, AxiosError.ERR_BAD_OPTION_VALUE);
+            }
+            assert.equal(connections, 0, "must reject before opening a proxy connection");
+          }).then(function () { done(); }, done);
+        }
+
+        if (redirect) {
+          server = http.createServer(function (req, res) {
+            res.writeHead(302, {Location: "http://target.example/private"});
+            res.end();
+          }).listen(0, "127.0.0.1", function () {
+            request("http://127.0.0.1:" + server.address().port + "/");
+          });
+        } else {
+          request("http://target.example/private");
+        }
       });
     });
   });

--- a/test/unit/adapters/http.js
+++ b/test/unit/adapters/http.js
@@ -1358,40 +1358,77 @@ describe("supports http with nodejs", function () {
       });
   });
 
-  ["omitted", "undefined"].forEach(function (protocolCase) {
+  [
+    {name: "omitted", secure: true},
+    {name: "undefined", protocol: undefined, secure: true},
+    {name: "bare HTTP", protocol: "http", secure: false},
+    {name: "colon HTTP", protocol: " HTTP: ", secure: false},
+    {name: "bare HTTPS", protocol: "https", secure: true},
+    {name: "colon HTTPS", protocol: " HTTPS: ", secure: true},
+    {name: "unsupported", protocol: "ftp", secure: true},
+    {name: "malformed", protocol: "http://", secure: true},
+  ].forEach(function (protocolCase) {
     ["native", "follow", "redirect"].forEach(function (transportCase) {
-      it("should default an " + protocolCase + " proxy protocol to HTTP for an HTTPS target (" + transportCase + ")", function (done) {
+      it("should use " + (protocolCase.secure ? "HTTPS" : "HTTP") + " for an HTTPS target with " + protocolCase.name + " proxy protocol (" + transportCase + ")", function (done) {
         var requests = [];
         var target = "https://target.example/start";
         var redirectedTarget = "https://redirected.example/finish";
+        var proxyAuthorization = "Basic " + Buffer.from("proxy-user:proxy-pass").toString("base64");
 
-        // Respond as a plaintext forward proxy; no external target is contacted.
-        proxy = http.createServer(function (req, res) {
-          requests.push({url: req.url, host: req.headers.host});
+        // Respond as a forward proxy; no external target is contacted.
+        var handleProxyRequest = function (req, res) {
+          requests.push({
+            url: req.url,
+            host: req.headers.host,
+            encrypted: req.socket.encrypted === true,
+            authorization: req.headers["proxy-authorization"],
+          });
           if (transportCase === "redirect" && requests.length === 1) {
             res.writeHead(302, {Location: redirectedTarget});
             res.end();
           } else {
             res.end("proxied");
           }
-        }).listen(0, "127.0.0.1", function () {
+        };
+        proxy = protocolCase.secure ? https.createServer({
+          key: fs.readFileSync(path.join(__dirname, "key.pem")),
+          cert: fs.readFileSync(path.join(__dirname, "cert.pem")),
+        }, handleProxyRequest) : http.createServer(handleProxyRequest);
+
+        proxy.listen(0, "127.0.0.1", function () {
           var proxyConfig = {
             host: "127.0.0.1",
             port: proxy.address().port,
+            auth: {username: "proxy-user", password: "proxy-pass"},
           };
-          if (protocolCase === "undefined") {
-            proxyConfig.protocol = undefined;
+          if (protocolCase.name !== "omitted") {
+            proxyConfig.protocol = protocolCase.protocol;
           }
-          var config = {proxy: proxyConfig, timeout: 3000};
+          var config = {
+            proxy: proxyConfig,
+            timeout: 3000,
+            httpAgent: new http.Agent({keepAlive: false}),
+            httpsAgent: new https.Agent({rejectUnauthorized: false, keepAlive: false}),
+          };
           if (transportCase === "native") {
             config.maxRedirects = 0;
           }
 
           axios.get(target, config).then(function (res) {
             assert.equal(res.data, "proxied");
-            var expected = [{url: target, host: "target.example"}];
+            var expected = [{
+              url: target,
+              host: "target.example",
+              encrypted: protocolCase.secure,
+              authorization: proxyAuthorization,
+            }];
             if (transportCase === "redirect") {
-              expected.push({url: redirectedTarget, host: "redirected.example"});
+              expected.push({
+                url: redirectedTarget,
+                host: "redirected.example",
+                encrypted: protocolCase.secure,
+                authorization: proxyAuthorization,
+              });
             }
             assert.deepStrictEqual(requests, expected);
             done();
@@ -1401,24 +1438,26 @@ describe("supports http with nodejs", function () {
     });
   });
 
-  [null, false, 1234, {}, "", " "].forEach(function (protocol) {
-    it("should preserve the HTTPS target protocol for an unusable proxy protocol " + JSON.stringify(protocol), function () {
-      var capturedOptions;
-      var stopped = new Error("request inspected");
+  [undefined, null, false, 1234, {}, "", " ", "ftp", "ftp:", "http://", "https://", "http::", "https::", "https:invalid"].forEach(function (protocol) {
+    ["http:", "https:"].forEach(function (targetProtocol) {
+      it("should preserve the " + targetProtocol + " target protocol for an unusable proxy protocol " + JSON.stringify(protocol), function () {
+        var capturedOptions;
+        var stopped = new Error("request inspected");
 
-      return axios.get("https://target.example/", {
-        proxy: {host: "127.0.0.1", port: 4000, protocol: protocol},
-        transport: {
-          request: function (options) {
-            capturedOptions = options;
-            throw stopped;
+        return axios.get(targetProtocol + "//target.example/", {
+          proxy: {host: "127.0.0.1", port: 4000, protocol: protocol},
+          transport: {
+            request: function (options) {
+              capturedOptions = options;
+              throw stopped;
+            },
           },
-        },
-      }).then(function () {
-        assert.fail("transport should stop the request");
-      }, function (err) {
-        assert.strictEqual(err, stopped);
-        assert.equal(capturedOptions.protocol, "https:");
+        }).then(function () {
+          assert.fail("transport should stop the request");
+        }, function (err) {
+          assert.strictEqual(err, stopped);
+          assert.equal(capturedOptions.protocol, targetProtocol);
+        });
       });
     });
   });


### PR DESCRIPTION
## Problem

`setProxy` assigned the configured proxy protocol straight to `options.protocol`:

```js
if (proxy.protocol) {
  options.protocol = proxy.protocol;
}
```

Node compares `options.protocol` verbatim against the agent's own `protocol` (`'http:'` / `'https:'`), so the value has to carry the trailing colon. But `AxiosProxyConfig.protocol` is documented in our own README as a bare scheme and typed as a plain `string`:

```js
proxy: {
  protocol: 'https',
  host: '127.0.0.1',
  port: 9000,
  ...
}
```

So the documented form never worked:

| Config | Result before |
| --- | --- |
| `protocol: 'http'`, https target | `ERR_ASSERTION: protocol mismatch` |
| `protocol: 'http'`, http target | `ERR_ASSERTION: protocol mismatch` |
| `protocol: 'http'`, `maxRedirects: 0` | `ERR_INVALID_PROTOCOL: Protocol "http" not supported. Expected "http:"` |

Only `protocol: 'http:'` worked, which is why the existing proxy tests all pass `'https:'`. Proxies resolved from `HTTP_PROXY` / `HTTPS_PROXY` were unaffected, because `url.parse` already yields `'http:'`.

Present since v0.30.0, when `setProxy` was brought over from the v1 line.

## Fix

- Normalize HTTP(S) proxy protocols to Node's `http:` / `https:` form, accepting a bare scheme, an optional trailing colon, casing differences, and surrounding whitespace.
- Preserve the target protocol when the proxy protocol is omitted or `undefined`. Do not default HTTPS proxy connections to plaintext HTTP.
- Reject unsupported or malformed non-empty protocol strings before configuring a proxy connection or adding proxy credentials. Invalid values such as `https://`, `ftp`, and whitespace-only strings must not silently fall back to the target protocol.
- Use `AxiosError.ERR_BAD_OPTION_VALUE` without echoing the invalid value, which could contain credentials. Errors discovered during redirects retain follow-redirects' normal error wrapping.
- Apply the same validation to explicitly configured and environment-selected proxies, including redirected requests.

## Compatibility

The baseline for this comparison is the PR's `v0.x` base (`d29be18`), not an intermediate commit on this PR. With the built-in Node transports:

| Proxy protocol value | Base branch | Current PR |
| --- | --- | --- |
| `http:` / `https:` | Uses the configured transport | Unchanged |
| Bare HTTP(S) scheme, mixed case, or surrounding whitespace | Protocol-mismatch error | Normalizes to `http:` / `https:` |
| Omitted, `undefined`, empty string, or falsy non-string value | Inherits the target protocol | Unchanged |
| Truthy non-string value, such as `1234` | Rejects the invalid protocol | Ignores the value and inherits the target protocol |
| Unsupported non-empty string, including `ftp`, `https://`, or whitespace-only input | Rejects with a low-level protocol error | Rejects before connecting with `ERR_BAD_OPTION_VALUE` |

Thus, behavior changes are not limited to non-string values: supported string forms are normalized, and invalid strings receive a clearer Axios error code. Consumers matching low-level protocol errors should account for `ERR_BAD_OPTION_VALUE`. Validation failures discovered during redirects retain follow-redirects' `ERR_FR_REDIRECTION_FAILURE` wrapping and the original error in the cause chain.

Relative to intermediate commit `53199fc`, rejecting invalid strings is an intentional change: that commit returned `undefined` and inherited the target protocol. Commit `7e72c54` removes that fallback because an HTTP destination with malformed `protocol: 'https://'` could otherwise send proxy credentials in plaintext. The rejected-string behavior must not be reverted to satisfy an outdated compatibility claim.

Missing protocols still retain legacy target-protocol inheritance. A plaintext proxy serving an HTTPS target must explicitly specify `protocol: 'http'`; an automatic HTTP default would downgrade existing HTTPS proxy connections.

## Tests

Regression coverage includes:

- Authenticated HTTP and HTTPS proxies, supported protocol normalization, and omitted/undefined protocols.
- Native requests, follow-redirects, and actual redirects.
- Invalid protocols with both HTTP and HTTPS destinations: rejection before any proxy connection is opened.
- Unsupported environment proxies on initial and redirected requests.
- Error messages that do not expose malformed protocol values containing credentials.

Validation for runtime fix `7e72c54` (runtime unchanged by the documentation follow-up):

- Node 24.18.0: all Node unit tests pass — **277 passing**.
- Node 16.20.2: focused proxy protocol tests pass — **71 passing**.
- All **38 new rejection tests failed before the fix** and pass afterward.
- ESLint for `lib/adapters/http.js` and `git diff --check` pass.
- Documentation follow-up: the focused proxy protocol suite passes again on Node 24 — **71 passing**.

Commands:

```sh
./node_modules/.bin/mocha --timeout 30000 'test/unit/**/*.js' --reporter dot --exit
node ./node_modules/mocha/bin/mocha --timeout 10000 test/unit/adapters/http.js --grep 'proxy protocol' --reporter dot --exit
./node_modules/.bin/eslint lib/adapters/http.js
git diff --check
```

CI runs Node 12, 14, 16, 18, 20, 22, 24, and 26; see the PR checks for the current results.

## Notes

- No public API shape or type changes; `AxiosProxyConfig.protocol` stays an optional `string`.
- No new dependencies, version bump, or generated artifact changes.
- The browser adapter is unchanged.


