### PR TITLE
feat(core): include a bounded response snapshot in AxiosError.toJSON

### DIFF
--- a/lib/core/AxiosError.js
+++ b/lib/core/AxiosError.js
@@ -272,6 +272,20 @@ class AxiosError extends Error {
       }
     }
 
+    // A bounded view of the response: enough to diagnose the failure without
+    // `response.request` or `response.config`, which are circular and already
+    // covered by `config` below. Historically omitted wholesale because the
+    // raw response is circular; this shape is not.
+    const response = this.response;
+    const serializedResponse = response
+      ? {
+          status: response.status,
+          statusText: response.statusText,
+          headers: serializeValue(response.headers),
+          data: serializeValue(response.data),
+        }
+      : undefined;
+
     return {
       // Custom properties first, so a collision can never shadow a standard key.
       ...customProps,
@@ -290,6 +304,7 @@ class AxiosError extends Error {
       config: snapshot(withoutOpaqueHandles(config)),
       code: this.code,
       status: this.status,
+      response: serializedResponse,
     };
   }
 }

--- a/tests/unit/core/AxiosError.test.js
+++ b/tests/unit/core/AxiosError.test.js
@@ -24,8 +24,9 @@ describe('core::AxiosError', () => {
   });
 
   it('serializes to JSON safely', () => {
-    // request/response are intentionally omitted from the serialized shape
-    // to avoid circular-reference problems.
+    // `request` is intentionally omitted from the serialized shape to avoid
+    // circular-reference problems; `response` is included as a bounded
+    // snapshot that carries neither `request` nor `config`.
     const request = { path: '/foo' };
     const response = { status: 200, data: { foo: 'bar' } };
     const error = new AxiosError('Boom!', 'ESOMETHING', { foo: 'bar' }, request, response);
@@ -36,7 +37,12 @@ describe('core::AxiosError', () => {
     expect(json.code).toBe('ESOMETHING');
     expect(json.status).toBe(200);
     expect(json.request).toBeUndefined();
-    expect(json.response).toBeUndefined();
+    expect(json.response).toEqual({
+      status: 200,
+      statusText: undefined,
+      headers: undefined,
+      data: { foo: 'bar' },
+    });
   });
 
   it('serializes Set values in config snapshots', () => {
@@ -567,6 +573,62 @@ describe('core::AxiosError', () => {
 
       expect(json.context.token).toBe(REDACTED);
       expect(json.context.id).toBe(7);
+    });
+  });
+  describe('response snapshot in toJSON', () => {
+    it('carries status, statusText, headers and data', async () => {
+      const server = http.createServer((req, res) => {
+        res.writeHead(500, { 'content-type': 'application/json', 'x-request-id': 'abc' });
+        res.end('{"message":"duplicate key error"}');
+      });
+
+      await new Promise((resolve) => server.listen(0, resolve));
+
+      try {
+        await axios.get(`http://127.0.0.1:${server.address().port}/`);
+        throw new Error('should have rejected');
+      } catch (err) {
+        const json = err.toJSON();
+
+        expect(json.response.status).toBe(500);
+        expect(json.response.statusText).toBe('Internal Server Error');
+        expect(json.response.headers['x-request-id']).toBe('abc');
+        expect(json.response.data).toEqual({ message: 'duplicate key error' });
+      } finally {
+        server.close();
+      }
+    });
+
+    it('does not carry the response request or config', () => {
+      const response = { status: 404, data: 'nope', request: {}, config: { url: '/u' } };
+      response.request.self = response.request;
+      const error = new AxiosError('Boom', 'ECODE', { url: '/u' }, {}, response);
+
+      const json = error.toJSON();
+
+      expect(json.response).not.toHaveProperty('request');
+      expect(json.response).not.toHaveProperty('config');
+      expect(() => JSON.stringify(json)).not.toThrow();
+    });
+
+    it('redacts response headers through config.redact', () => {
+      const response = { status: 401, statusText: 'Unauthorized', headers: { authorization: 'Bearer x' }, data: {} };
+      const error = new AxiosError('Boom', 'ECODE', { url: '/u', redact: ['authorization'] }, null, response);
+
+      expect(error.toJSON().response.headers.authorization).toBe(REDACTED);
+    });
+
+    it('snapshots a streamed response body as a marker', () => {
+      const response = { status: 200, data: new stream.Readable() };
+      const error = new AxiosError('Boom', 'ECODE', { url: '/u' }, null, response);
+
+      expect(error.toJSON().response.data).toBe('[Readable]');
+    });
+
+    it('omits response when the error has none', () => {
+      const error = new AxiosError('Boom', 'ECODE', { url: '/u' });
+
+      expect(error.toJSON().response).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
Draft. **Stacked on `fix/v1-error-serialization`** — that PR adds the serializer and marker helpers this one reuses, so review/merge it first. Base is set accordingly; the diff here is just the response snapshot.

## What

`AxiosError.prototype.toJSON()` currently omits the response entirely. Anything that logs a rejected request through pino, winston or Sentry sees the config that produced the failure but never the server's answer to it, and a bare status code rarely explains a 4xx. The usual workaround is a response interceptor that rewraps the error purely to reattach `response.data`.

This adds:

```js
response: {
  status,
  statusText,
  headers,
  data,
}
```

## Why it is safe now when it was not before

The response was left out originally because the raw object is circular: `response.request` and `response.config` point straight back into the request graph, so `JSON.stringify` threw. The snapshot here carries four scalar-ish fields and neither of those, so the original reason no longer applies. There is a test asserting the circular case stays serializable.

`headers` and `data` go through the same serializer as `config`, which means:

- `config.redact` covers response headers and body, so `redact: ['authorization']` masks them.
- A streamed body (`responseType: 'stream'`) is reduced to `'[Readable]'` rather than walked.

## The judgement call

This is the one change in this set that alters existing serialized output rather than only fixing a crash, and there was an explicit test asserting `json.response` is `undefined` — updated here. Two things worth deciding before this lands:

1. **Log volume.** Error response bodies now appear in every logged `AxiosError`. Usually that is the point, but it is a change for anyone logging at scale.
2. **Sensitive payloads.** An error body can contain user data. `config.redact` handles known keys, but it is opt-in.

If either is a concern, the natural alternatives are dropping `data` and keeping only `status`/`statusText`/`headers`, or gating the whole snapshot behind a config flag. Happy to reshape it either way — I have kept it as the straightforward version so the tradeoff is visible rather than pre-decided.

## Tests

Five added to `tests/unit/core/AxiosError.test.js`: full snapshot against a real 500 response, no `request`/`config` leakage with a circular response, redaction of response headers, stream marker for a streamed body, and `undefined` when the error has no response. The existing `serializes to JSON safely` test is updated to assert the new shape.

```
vitest run --project unit  ->  1070 passed, 8 failed
```

Those 8 (DNS lookup, formDataHeaderPolicy, query parsing) reproduce identically on unmodified `origin/v1.x` here and are unrelated.

`v2.x` carries a byte-identical `lib/`, so it needs the same change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
## Description

`AxiosError.toJSON()` now includes a bounded response snapshot (`status`, `statusText`, `headers`, `data`), so logged errors show the server's answer instead of just the request config.

- **Summary of changes**: The serialized shape gains a `response` field; response headers and data go through the same serializer as `config`, so `config.redact` masks them and streamed bodies become `'[Readable]'` instead of being walked.
- **Reasoning**: The raw response is circular (`response.request` and `response.config` point back into the request graph), which is why it was originally omitted; the bounded snapshot avoids those fields, so the historic reason no longer applies. Anything logging a rejected request through pino, winston, or Sentry previously saw only the config, and a bare status code rarely explains a 4xx.
- **Additional context**: This is the one change in this set that alters existing serialized output — `json.response` was previously `undefined` — so error bodies now appear in every logged `AxiosError`. If log volume or sensitive payloads are a concern, drop `data` or gate the snapshot behind a config flag, since `config.redact` is opt-in. This PR depends on `fix/v1-error-serialization` (the serializer and marker helpers), and `v2.x` carries an identical `lib/`, so it needs the same change.

## Docs

Suggest updating the documentation website in the `/docs/` directory to note that `AxiosError.toJSON()` now includes the response snapshot and that `config.redact` applies to response headers and body.

## Testing

Five tests added to `tests/unit/core/AxiosError.test.js`: full snapshot against a real 500 response, no `request`/`config` leakage with a circular response, response-header redaction, stream-body marker, and `undefined` response when the error has none. The existing "serializes to JSON safely" test was updated to assert the new shape. Note that 8 unrelated existing failures (DNS lookup, `formDataHeaderPolicy`, query parsing) reproduce on unmodified `v1.x`.

## Semantic version impact

Minor release (additive feature): `toJSON()` gains a `response` field and no existing fields change, so this should not break consumers; the only risk is code that asserted the field was absent.

<sup>Written for commit 4585fd6f598724462003f4b817473b1bb6cb61d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/axios/axios/pull/11184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

