### PR TITLE
fix(core): continue the synchronous request interceptor chain after a throw

### DIFF
--- a/lib/core/Axios.js
+++ b/lib/core/Axios.js
@@ -210,38 +210,62 @@ class Axios {
 
     let newConfig = config;
 
+    // Mirrors `.then(onFulfilled, onRejected)` chaining: an error thrown by a
+    // synchronous interceptor is offered to each rejection handler registered
+    // after it, and a handler that returns a value puts the chain back on the
+    // fulfilled path so the interceptors that follow still run. The loop used
+    // to stop at the interceptor that threw, so a rejection handler belonging
+    // to a later interceptor never saw the error at all.
+    let requestError;
+    let requestFailed = false;
+
     while (i < len) {
       const onFulfilled = requestInterceptorChain[i++];
       const onRejected = requestInterceptorChain[i++];
+
+      if (!requestFailed && onFulfilled) {
+        try {
+          newConfig = onFulfilled(newConfig);
+        } catch (error) {
+          requestError = error;
+          requestFailed = true;
+        }
+      }
+
+      if (!requestFailed || !onRejected) {
+        continue;
+      }
+
       try {
-        newConfig = onFulfilled ? onFulfilled(newConfig) : newConfig;
-      } catch (error) {
-        if (!onRejected) {
-          promise = Promise.reject(error);
+        const rejectedResult = onRejected.call(this, requestError);
+
+        if (utils.isThenable(rejectedResult)) {
+          // Asynchronous recovery: dispatch with the last valid config once the
+          // handler settles, and let a rejection propagate instead of sending.
+          promise = Promise.resolve(rejectedResult).then(() =>
+            dispatchRequest.call(this, newConfig)
+          );
           break;
         }
 
-        try {
-          const rejectedResult = onRejected.call(this, error);
-
-          if (utils.isThenable(rejectedResult)) {
-            promise = Promise.resolve(rejectedResult).then(() =>
-              dispatchRequest.call(this, newConfig)
-            );
-          }
-        } catch (rejectedError) {
-          promise = Promise.reject(rejectedError);
-        }
-
-        break;
+        // Recovered synchronously: back on the fulfilled path, so the
+        // interceptors that follow still run.
+        requestFailed = false;
+        requestError = undefined;
+      } catch (rejectedError) {
+        requestError = rejectedError;
       }
     }
 
     if (!promise) {
-      try {
-        promise = dispatchRequest.call(this, newConfig);
-      } catch (error) {
-        promise = Promise.reject(error);
+      if (requestFailed) {
+        promise = Promise.reject(requestError);
+      } else {
+        try {
+          promise = dispatchRequest.call(this, newConfig);
+        } catch (error) {
+          promise = Promise.reject(error);
+        }
       }
     }
 

--- a/tests/unit/core/Axios.test.js
+++ b/tests/unit/core/Axios.test.js
@@ -53,4 +53,194 @@ describe('core::Axios', () => {
       }
     });
   });
+  describe('synchronous request interceptor chain', () => {
+    const SYNC = { synchronous: true };
+    // Registration order, so the chain reads the same way the test does.
+    const ORDERED = { legacyInterceptorReqResOrdering: false };
+
+    const create = (calls) => {
+      const instance = axios.create({
+        transitional: ORDERED,
+        adapter: (config) => {
+          calls.push('dispatch');
+          return Promise.resolve({ data: 'ok', status: 200, headers: {}, config });
+        },
+      });
+      return instance;
+    };
+
+    it('offers the error to a rejection handler registered on a later interceptor', async () => {
+      const calls = [];
+      const instance = create(calls);
+      const error = new Error('boom');
+
+      instance.interceptors.request.use(
+        () => {
+          calls.push('fulfilled0');
+          throw error;
+        },
+        null,
+        SYNC
+      );
+      instance.interceptors.request.use(
+        undefined,
+        (err) => {
+          calls.push('rejected1');
+          return Promise.reject(err);
+        },
+        SYNC
+      );
+
+      await expect(instance.get('/foo')).rejects.toBe(error);
+      expect(calls).toEqual(['fulfilled0', 'rejected1']);
+    });
+
+    it('resumes the chain when a rejection handler recovers synchronously', async () => {
+      const calls = [];
+      const instance = create(calls);
+      let lastConfig;
+
+      instance.interceptors.request.use(
+        (config) => {
+          calls.push('fulfilled0');
+          lastConfig = config;
+          throw new Error('boom');
+        },
+        null,
+        SYNC
+      );
+      instance.interceptors.request.use(
+        undefined,
+        () => {
+          calls.push('rejected1');
+          return lastConfig;
+        },
+        SYNC
+      );
+      instance.interceptors.request.use(
+        (config) => {
+          calls.push('fulfilled2');
+          return config;
+        },
+        null,
+        SYNC
+      );
+
+      await instance.get('/foo');
+      expect(calls).toEqual(['fulfilled0', 'rejected1', 'fulfilled2', 'dispatch']);
+    });
+
+    it('carries an error rethrown by one handler to the next one', async () => {
+      const calls = [];
+      const instance = create(calls);
+      const rethrown = new Error('rethrown');
+
+      instance.interceptors.request.use(
+        () => {
+          throw new Error('original');
+        },
+        () => {
+          calls.push('rejected0');
+          throw rethrown;
+        },
+        SYNC
+      );
+      instance.interceptors.request.use(
+        undefined,
+        (err) => {
+          calls.push(`rejected1:${err.message}`);
+          return Promise.reject(err);
+        },
+        SYNC
+      );
+
+      await expect(instance.get('/foo')).rejects.toBe(rethrown);
+      expect(calls).toEqual(['rejected0', 'rejected1:rethrown']);
+      expect(calls).not.toContain('dispatch');
+    });
+
+    it('still calls the rejection handler on the interceptor that threw', async () => {
+      const calls = [];
+      const instance = create(calls);
+      const error = new Error('boom');
+
+      instance.interceptors.request.use(
+        () => {
+          throw error;
+        },
+        (err) => {
+          calls.push('rejected0');
+          return Promise.reject(err);
+        },
+        SYNC
+      );
+
+      await expect(instance.get('/foo')).rejects.toBe(error);
+      expect(calls).toEqual(['rejected0']);
+    });
+
+    it('rejects with the original error and does not dispatch when nothing handles it', async () => {
+      const calls = [];
+      const instance = create(calls);
+      const error = new Error('deadly');
+
+      instance.interceptors.request.use(
+        () => {
+          throw error;
+        },
+        null,
+        SYNC
+      );
+
+      await expect(instance.get('/foo')).rejects.toBe(error);
+      expect(calls).toEqual([]);
+    });
+
+    it('dispatches with the last valid config when a handler recovers asynchronously', async () => {
+      const calls = [];
+      const instance = create(calls);
+      let dispatchedUrl;
+
+      instance.interceptors.request.use(
+        () => {
+          throw new Error('boom');
+        },
+        () => Promise.resolve({ url: '/bar' }),
+        SYNC
+      );
+      instance.interceptors.response.use((response) => {
+        dispatchedUrl = response.config.url;
+        return response;
+      });
+
+      await instance.get('/foo');
+      expect(dispatchedUrl).toBe('/foo');
+      expect(calls).toEqual(['dispatch']);
+    });
+
+    it('skips interceptors that only supply a fulfilled handler while in the error state', async () => {
+      const calls = [];
+      const instance = create(calls);
+      const error = new Error('boom');
+
+      instance.interceptors.request.use(
+        () => {
+          throw error;
+        },
+        null,
+        SYNC
+      );
+      instance.interceptors.request.use(
+        (config) => {
+          calls.push('fulfilled1');
+          return config;
+        },
+        null,
+        SYNC
+      );
+
+      await expect(instance.get('/foo')).rejects.toBe(error);
+      expect(calls).toEqual([]);
+    });
+  });
 });


### PR DESCRIPTION
Draft. Independent of the other v1 PRs in this set.

## Problem

When every request interceptor is registered with `{ synchronous: true }`, `Axios.prototype.request` walks the chain itself rather than building a promise chain. That loop broke out at the first interceptor whose fulfilled handler threw:

```js
} catch (error) {
  if (!onRejected) {
    promise = Promise.reject(error);
    break;
  }
  ...
  break;
}
```

Two consequences:

1. A rejection handler registered on a **later** interceptor never saw the error. In the fully asynchronous path the same registration works, because `.then(onFulfilled, onRejected)` chaining forwards the rejection down the chain. Sync and async mode disagreed.
2. A rejection handler that recovered **synchronously** returned a value that was then discarded, and the interceptors after it were skipped, so the recovery only half worked.

```js
instance.interceptors.request.use(() => { throw err; }, null, { synchronous: true });
instance.interceptors.request.use(undefined, onRejected,  { synchronous: true });
// onRejected was never called
```

## Fix

The loop now carries an error state across iterations. In the fulfilled state it calls `onFulfilled`; in the error state it calls `onRejected`. A handler that returns a value puts the chain back on the fulfilled path so the interceptors after it still run; one that rethrows passes the new error to the next handler. That is exactly `.then(onFulfilled, onRejected)` semantics, which is what the async path already gives you.

## Deliberately unchanged

The synchronous path has behaviours the browser suite pins down explicitly, and all of them are preserved:

- The throwing interceptor's **own** rejection handler is still tried first. This differs from real `.then` chaining (where a handler does not catch its own sibling's throw) but it is the long-standing axios contract and there is a test for it.
- A rejection handler that returns a **thenable** still dispatches with the **last valid config**, not with the resolved value. There is an explicit test named `should send with the last valid config when a synchronous interceptor onRejected resolves`, so this is a contract, not an accident.
- A rejection still prevents the request from being sent, and terminal request-interceptor errors still reach the response rejection handlers.
- The fully asynchronous path is untouched.

## Verification

Every case was run against unmodified `origin/v1.x` and against this branch. Identical on both: no-handler rejection, same-pair handler returning a rejected promise, async recovery using the last valid config, same-pair handler throwing, terminal error reaching the response chain, async-mode ordering. Changed only where the bug was: the later-handler case and the sync-recovery case.

```
vitest run --project unit                      -> 1061 passed, 8 failed
vitest run --project browser-headless
  tests/browser/interceptors.browser.test.js   ->  105 passed
```

The 8 unit failures (DNS lookup, formDataHeaderPolicy, query parsing) reproduce identically on unmodified `origin/v1.x` here and are unrelated.

## Tests

Seven added to `tests/unit/core/Axios.test.js`, using a stub adapter so they need no network: later-handler dispatch, sync recovery resuming the chain, rethrow carried to the next handler, and the four preserved contracts above asserted directly.

`v2.x` carries a byte-identical `lib/`, so it needs the same change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
## Description

Fixes the synchronous request interceptor chain so an error thrown by one interceptor is offered to rejection handlers on later interceptors, and a handler that recovers synchronously resumes the remaining interceptors. Previously the loop broke at the interceptor that threw, so later rejection handlers never saw the error and a recovered value was discarded.

- Summary of changes: The loop now carries an error state across iterations, mirroring the `.then(onFulfilled, onRejected)` chaining the asynchronous path already uses. A handler that returns a value puts the chain back on the fulfilled path; one that rethrows passes the new error to the next handler.
- Reasoning: Sync and async modes disagreed on error propagation, so the same interceptor registration behaved differently depending on the `synchronous` flag.
- Additional context: The throwing interceptor's own rejection handler is still tried first, async recovery still dispatches with the last valid config, and rejected requests still never reach `dispatchRequest`. The asynchronous path is untouched. `v2.x` carries a byte-identical `lib/` and needs the same change.

## Docs

No documentation update needed — no public API or config surface changed.

## Testing

Added seven tests to `tests/unit/core/Axios.test.js` using a stub adapter (no network): later-handler dispatch, sync recovery resuming the chain, rethrown errors carried to the next handler, and the four preserved contracts asserted directly. Existing suites run unchanged except the 8 unrelated unit failures that already reproduce on unmodified `origin/v1.x`.

## Semantic version impact

Patch — bug fix that restores expected interceptor behavior with no breaking changes or migration steps.

<sup>Written for commit ef6b681f0c96bbe2347da914c03e702e51082e70. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/axios/axios/pull/11185?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

