### PR TITLE
fix(cancel): carry the abort reason on CanceledError

### DIFF
--- a/index.d.cts
+++ b/index.d.cts
@@ -174,7 +174,7 @@ declare class AxiosError<T = unknown, D = any, P = any> extends Error {
 }
 
 declare class CanceledError<T, D = any, P = any> extends AxiosError<T, D, P> {
-  constructor(message?: string, config?: axios.InternalAxiosRequestConfig<D, P>, request?: any);
+  constructor(message?: string, config?: axios.InternalAxiosRequestConfig<D, P>, request?: any, cause?: unknown);
   readonly name: 'CanceledError';
   __CANCEL__?: boolean;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -564,7 +564,7 @@ export class AxiosError<T = unknown, D = any, P = any> extends Error {
 }
 
 export class CanceledError<T, D = any, P = any> extends AxiosError<T, D, P> {
-  constructor(message?: string, config?: InternalAxiosRequestConfig<D, P>, request?: any);
+  constructor(message?: string, config?: InternalAxiosRequestConfig<D, P>, request?: any, cause?: unknown);
   readonly name: 'CanceledError';
   __CANCEL__?: boolean;
 }

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -14,6 +14,7 @@ import zlib from 'zlib';
 import { VERSION } from '../env/data.js';
 import transitionalDefaults from '../defaults/transitional.js';
 import AxiosError from '../core/AxiosError.js';
+import abortReason from '../helpers/abortReason.js';
 import CanceledError from '../cancel/CanceledError.js';
 import platform from '../platform/index.js';
 import fromDataURI from '../helpers/fromDataURI.js';
@@ -634,7 +635,9 @@ export default isHttpAdapterSupported &&
         try {
           abortEmitter.emit(
             'abort',
-            !reason || reason.type ? new CanceledError(null, config, req) : reason
+            !reason || reason.type
+              ? new CanceledError(null, config, req, abortReason(config.signal))
+              : reason
           );
         } catch (err) {
           // ignore emit errors

--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -5,6 +5,7 @@ import AxiosError from '../core/AxiosError.js';
 import CanceledError from '../cancel/CanceledError.js';
 import normalizeURLForProtocolCheck from '../helpers/normalizeURLForProtocolCheck.js';
 import parseProtocol from '../helpers/parseProtocol.js';
+import abortReason from '../helpers/abortReason.js';
 import platform from '../platform/index.js';
 import AxiosHeaders from '../core/AxiosHeaders.js';
 import { progressEventReducer } from '../helpers/progressEventReducer.js';
@@ -243,7 +244,11 @@ export default isXHRAdapterSupported &&
           if (!request) {
             return;
           }
-          reject(!cancel || cancel.type ? new CanceledError(null, config, request) : cancel);
+          reject(
+            !cancel || cancel.type
+              ? new CanceledError(null, config, request, abortReason(_config.signal))
+              : cancel
+          );
           request.abort();
           done();
           request = null;

--- a/lib/cancel/CanceledError.js
+++ b/lib/cancel/CanceledError.js
@@ -9,13 +9,27 @@ class CanceledError extends AxiosError {
    * @param {string=} message The message.
    * @param {Object=} config The config.
    * @param {Object=} request The request.
+   * @param {*} [cause] What triggered the cancellation, typically an
+   *   `AbortSignal.reason`. Installed non-enumerable to match native `Error`
+   *   `cause` semantics, so a reason carrying circular internals cannot break
+   *   structured loggers or any own-property walk.
    *
    * @returns {CanceledError} The created error.
    */
-  constructor(message, config, request) {
+  constructor(message, config, request, cause) {
     super(message == null ? 'canceled' : message, AxiosError.ERR_CANCELED, config, request);
     this.name = 'CanceledError';
     this.__CANCEL__ = true;
+
+    if (cause !== undefined) {
+      Object.defineProperty(this, 'cause', {
+        __proto__: null,
+        value: cause,
+        writable: true,
+        enumerable: false,
+        configurable: true,
+      });
+    }
   }
 }
 

--- a/lib/core/dispatchRequest.js
+++ b/lib/core/dispatchRequest.js
@@ -4,6 +4,7 @@ import transformData from './transformData.js';
 import isCancel from '../cancel/isCancel.js';
 import defaults from '../defaults/index.js';
 import CanceledError from '../cancel/CanceledError.js';
+import abortReason from '../helpers/abortReason.js';
 import AxiosHeaders from '../core/AxiosHeaders.js';
 import adapters from '../adapters/adapters.js';
 import utils from '../utils.js';
@@ -21,7 +22,7 @@ function throwIfCancellationRequested(config) {
   }
 
   if (config.signal && config.signal.aborted) {
-    throw new CanceledError(null, config);
+    throw new CanceledError(null, config, undefined, abortReason(config.signal));
   }
 }
 

--- a/lib/helpers/abortReason.js
+++ b/lib/helpers/abortReason.js
@@ -1,0 +1,27 @@
+'use strict';
+
+/**
+ * Read the reason an abort signal was aborted with.
+ *
+ * `AbortSignal.reason` is where `controller.abort(reason)` puts its argument,
+ * and it is the only way to tell one cancellation from another. Adapters
+ * discarded it and reported every cancellation as a bare `canceled` error.
+ *
+ * Reading `reason` off a non-standard or branded signal can throw, so the
+ * access is guarded.
+ *
+ * @param {Object} [signal] The signal the request was watching
+ *
+ * @returns {*} The abort reason, or undefined when there is none
+ */
+export default function abortReason(signal) {
+  if (!signal || !signal.aborted) {
+    return undefined;
+  }
+
+  try {
+    return signal.reason;
+  } catch (err) {
+    return undefined;
+  }
+}

--- a/lib/helpers/composeSignals.js
+++ b/lib/helpers/composeSignals.js
@@ -21,7 +21,7 @@ const composeSignals = (signals, timeout) => {
       controller.abort(
         err instanceof AxiosError
           ? err
-          : new CanceledError(err instanceof Error ? err.message : err)
+          : new CanceledError(err instanceof Error ? err.message : err, undefined, undefined, err)
       );
     }
   };

--- a/tests/unit/adapters/http.test.js
+++ b/tests/unit/adapters/http.test.js
@@ -7245,4 +7245,133 @@ describe('supports http with nodejs', () => {
       );
     });
   });
+  describe('abort reason propagation', () => {
+    let reasonServer;
+    let reasonBase;
+
+    const startServer = () =>
+      new Promise((resolve) => {
+        reasonServer = http.createServer((req, res) => {
+          // Hold the response open so the abort always wins.
+          setTimeout(() => {
+            res.writeHead(200);
+            res.end('ok');
+          }, 500);
+        });
+        reasonServer.listen(0, () => {
+          reasonBase = `http://127.0.0.1:${reasonServer.address().port}/`;
+          resolve();
+        });
+      });
+
+    const stopServer = () =>
+      new Promise((resolve) => {
+        if (!reasonServer) {
+          resolve();
+          return;
+        }
+        reasonServer.close(() => resolve());
+        reasonServer = null;
+      });
+
+    const abortWith = async (reason) => {
+      await startServer();
+      try {
+        const controller = new global.AbortController();
+        const request = axios.get(reasonBase, { signal: controller.signal });
+        controller.abort(reason);
+        return await request.then(
+          () => {
+            throw new Error('request should have been canceled');
+          },
+          (error) => error
+        );
+      } finally {
+        await stopServer();
+      }
+    };
+
+    it('carries a string abort reason as the error cause', async () => {
+      const error = await abortWith('TimeoutError');
+
+      assert.strictEqual(error.cause, 'TimeoutError');
+      // The message and the cancellation contract are unchanged.
+      assert.strictEqual(error.message, 'canceled');
+      assert.strictEqual(error.name, 'CanceledError');
+      assert.strictEqual(axios.isCancel(error), true);
+    });
+
+    it('carries an Error abort reason as the error cause', async () => {
+      const reason = new Error('user navigated away');
+      const error = await abortWith(reason);
+
+      assert.strictEqual(error.cause, reason);
+      assert.strictEqual(error.message, 'canceled');
+    });
+
+    it('carries the default reason for a bare abort', async () => {
+      const error = await abortWith(undefined);
+
+      assert.strictEqual(error.cause.name, 'AbortError');
+      assert.strictEqual(error.message, 'canceled');
+    });
+
+    it('carries the reason when the signal is already aborted before dispatch', async () => {
+      await startServer();
+      try {
+        const controller = new global.AbortController();
+        controller.abort('gone');
+
+        const error = await axios.get(reasonBase, { signal: controller.signal }).then(
+          () => {
+            throw new Error('request should have been canceled');
+          },
+          (err) => err
+        );
+
+        assert.strictEqual(error.cause, 'gone');
+        assert.strictEqual(error.message, 'canceled');
+      } finally {
+        await stopServer();
+      }
+    });
+
+    it('leaves CancelToken cancellations untouched', async () => {
+      await startServer();
+      try {
+        const source = axios.CancelToken.source();
+        const request = axios.get(reasonBase, { cancelToken: source.token });
+        source.cancel('operation cancelled');
+
+        const error = await request.then(
+          () => {
+            throw new Error('request should have been canceled');
+          },
+          (err) => err
+        );
+
+        assert.strictEqual(error.message, 'operation cancelled');
+        assert.strictEqual(error.cause, undefined);
+      } finally {
+        await stopServer();
+      }
+    });
+
+    it('does not attach a cause to a timeout error', async () => {
+      await startServer();
+      try {
+        const error = await axios.get(reasonBase, { timeout: 30 }).then(
+          () => {
+            throw new Error('request should have timed out');
+          },
+          (err) => err
+        );
+
+        assert.strictEqual(error.code, 'ECONNABORTED');
+        assert.strictEqual(axios.isCancel(error), false);
+      } finally {
+        await stopServer();
+      }
+    });
+  });
 });

--- a/tests/unit/cancel/canceledError.test.js
+++ b/tests/unit/cancel/canceledError.test.js
@@ -20,4 +20,23 @@ describe('cancel::CanceledError', () => {
   it('is recognized as a native error by Node util/types', () => {
     expect(isNativeError(new CanceledError('My Canceled Error'))).toBe(true);
   });
+  describe('cause', () => {
+    it('is absent when no cause is supplied', () => {
+      expect(new CanceledError('x')).not.toHaveProperty('cause');
+    });
+
+    it('is installed non-enumerable so it cannot break structured loggers', () => {
+      const reason = { self: null };
+      reason.self = reason;
+      const cancel = new CanceledError(null, undefined, undefined, reason);
+
+      expect(cancel.cause).toBe(reason);
+      expect(Object.keys(cancel)).not.toContain('cause');
+      expect(() => JSON.stringify(cancel.toJSON())).not.toThrow();
+    });
+
+    it('leaves the message alone', () => {
+      expect(new CanceledError(null, undefined, undefined, 'TimeoutError').message).toBe('canceled');
+    });
+  });
 });

--- a/tests/unit/helpers/abortReason.test.js
+++ b/tests/unit/helpers/abortReason.test.js
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import abortReason from '../../../lib/helpers/abortReason.js';
+
+describe('helpers::abortReason', () => {
+  it('returns undefined without a signal', () => {
+    expect(abortReason()).toBeUndefined();
+    expect(abortReason(null)).toBeUndefined();
+  });
+
+  it('returns undefined for a signal that has not aborted', () => {
+    expect(abortReason(new AbortController().signal)).toBeUndefined();
+  });
+
+  it('returns the reason an abort was triggered with', () => {
+    const controller = new AbortController();
+    controller.abort('TimeoutError');
+
+    expect(abortReason(controller.signal)).toBe('TimeoutError');
+  });
+
+  it('returns the default reason for a bare abort', () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    expect(abortReason(controller.signal).name).toBe('AbortError');
+  });
+
+  it('swallows a signal whose reason getter throws', () => {
+    const signal = {
+      aborted: true,
+      get reason() {
+        throw new TypeError('branded getter');
+      },
+    };
+
+    expect(abortReason(signal)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Draft. Independent of the other v1 PRs in this set.

Note: a community PR exists for the same ground, taking the approach of putting the reason into the error **message**. This takes the conservative route instead (see below) — worth picking one before either lands.

## Problem

`controller.abort(reason)` is the only way to tell one cancellation from another, and merging several controllers into one signal is a normal pattern:

```js
// one controller cancels a superseded search, another enforces a timeout
controller.abort('TimeoutError');
```

The xhr and http adapters built their `CanceledError` from the abort **event** and never read `signal.reason`:

```js
reject(!cancel || cancel.type ? new CanceledError(null, config, request) : cancel);
```

So both cancellations produced a byte-identical `CanceledError('canceled')` and the caller had no way to branch on which one fired.

The fetch adapter already reads the reason (via `composeSignals`), so the three adapters disagreed.

## Fix

The reason is attached as `cause` on the resulting `CanceledError`, at all four sites that build one from a signal: the xhr path, the http path, the pre-dispatch already-aborted check in `dispatchRequest`, and the composed signal used by the fetch adapter.

```js
controller.abort('TimeoutError');
// err.cause === 'TimeoutError'
// err.message === 'canceled'   (unchanged)
```

A shared `abortReason` helper reads `signal.reason` behind a try/catch, since a branded or non-standard signal can throw on property access.

## Why `cause` and not the message

Putting the reason into `message` is the more obvious fix and is what the fetch path already effectively does, but it is not safe to generalise:

`controller.abort()` with no argument does not leave `reason` empty. It sets a default `AbortError` DOMException whose message is `This operation was aborted`. Using the reason as the message would therefore rewrite **every** plain cancellation from `canceled` to `This operation was aborted`, including for users who never pass a reason at all. `error.message === 'canceled'` appears in a lot of user code and log matching.

`cause` is the standard JS mechanism for exactly this, `AxiosError.from` already uses it, and it is purely additive.

It is installed non-enumerable, matching `AxiosError.from` and native `Error` semantics, so a reason carrying circular internals cannot break pino/winston or any own-property walk. `toJSON()` continues to omit it.

## Non-breaking

Every case below was run against unmodified `origin/v1.x` and against this branch. Message, name and `isCancel` are byte-identical on both; only `cause` is added:

| case | message | name | isCancel | cause (new) |
| --- | --- | --- | --- | --- |
| `abort('TimeoutError')` | `canceled` | CanceledError | true | `'TimeoutError'` |
| `abort(new Error('...'))` | `canceled` | CanceledError | true | the Error |
| `abort()` | `canceled` | CanceledError | true | `AbortError` |
| pre-aborted signal | `canceled` | CanceledError | true | the reason |
| `CancelToken.cancel('op')` | `op` | CanceledError | true | *(none)* |
| `timeout: 30` | `timeout of 30ms exceeded` | AxiosError | false | *(none)* |
| fetch adapter | `TimeoutError` *(pre-existing)* | CanceledError | true | `'TimeoutError'` |

The `CanceledError` constructor gains an optional fourth parameter; the declaration in `index.d.ts` and `index.d.cts` is widened to match. No existing signature narrows.

The fetch adapter's message behaviour is left exactly as it is. It differs from xhr/http today, and unifying that is a separate decision rather than something to slip into this PR.

## Tests

14 added: `tests/unit/helpers/abortReason.test.js` (new, 5 cases including the throwing-getter guard), `tests/unit/cancel/canceledError.test.js` (3: absent by default, non-enumerable and JSON-safe with a circular reason, message untouched), and `tests/unit/adapters/http.test.js` (6 end-to-end: string reason, Error reason, bare abort, pre-aborted signal, CancelToken untouched, timeout untouched).

```
vitest run --project unit             -> 1069 passed, 8 failed
vitest run --project browser-headless ->  615 passed
```

The 8 unit failures (DNS lookup, formDataHeaderPolicy, query parsing) reproduce identically on unmodified `origin/v1.x` here and are unrelated.

`v2.x` carries a byte-identical `lib/`, so it needs the same change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
## Description

Carries the `controller.abort(reason)` reason onto the resulting `CanceledError` as `cause`, so callers can tell one cancellation from another. Previously every cancellation produced a byte-identical `canceled` error even when multiple controllers were merged into one signal.

- Attaches the reason at all four signal sites: xhr, http, the pre-dispatch already-aborted check, and the composed signal the fetch adapter uses.
- New `abortReason` helper reads `signal.reason` inside a try/catch, since branded or non-standard signals can throw on access.
- Uses `cause` instead of the message because a bare `abort()` sets a default `AbortError` DOMException; rewriting the message would break `error.message === 'canceled'` checks everywhere. A community PR takes that message approach; this PR deliberately avoids it.
- Installed non-enumerable, so circular internals in the reason cannot break structured loggers and `toJSON()` still omits it.
- `CanceledError` gains an optional fourth constructor parameter; `index.d.ts` and `index.d.cts` are widened to match.
- Non-breaking: message, `name`, and `isCancel` are unchanged; `CancelToken` cancellations and timeouts are untouched; the fetch adapter's existing message behavior is left as-is.

## Docs

Suggest documenting that aborting a request with `AbortController` now surfaces the abort reason on `err.cause` for the xhr and http adapters.

## Testing

14 tests added: five for `abortReason` (including the throwing-getter guard), three for `CanceledError` (absent by default, non-enumerable and JSON-safe with a circular reason, message untouched), and six end-to-end http tests (string reason, `Error` reason, bare abort, pre-aborted signal, `CancelToken` untouched, timeout untouched). The eight pre-existing unit failures reproduce on unmodified `origin/v1.x` and are unrelated.

## Semantic version impact

Patch: additive `cause` property and an optional constructor parameter; no existing signature narrows and no behavior breaks.

<sup>Written for commit 43e3a2b3ea3510d227901447429d0a461f20c22e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/axios/axios/pull/11186?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

