### PR TITLE
feat(core): allow extending the accepted URL schemes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1168,6 +1168,14 @@ These config options are available for requests. Only `url` is required. Request
   // see also https://nodejs.org/en/blog/vulnerability/february-2020-security-releases/#strict-http-header-parsing-none
   insecureHTTPParser: undefined, // default
 
+  // `additionalProtocols` lists URL schemes to accept on top of the platform defaults
+  // (`http`, `https`, `file`, `data`, plus `blob` and `url` in browsers).
+  // Useful behind native shells such as Capacitor that serve local resources over a
+  // custom scheme. Entries may be written with or without a trailing colon, and the
+  // platform defaults are always kept, so this can widen the accepted set but never
+  // narrow it.
+  additionalProtocols: undefined, // default
+
   // transitional options for backward compatibility that may be removed in the newer versions
   transitional: {
     // silent JSON parsing mode

--- a/index.d.cts
+++ b/index.d.cts
@@ -557,6 +557,14 @@ declare namespace axios {
     transitional?: TransitionalOptions;
     signal?: GenericAbortSignal;
     insecureHTTPParser?: boolean;
+  /**
+   * URL schemes to accept in addition to the platform defaults
+   * (`http`, `https`, `file`, `data`, plus `blob` and `url` in browsers).
+   * Useful behind native shells such as Capacitor that serve local
+   * resources over a custom scheme. Entries may be written with or
+   * without a trailing colon; the platform defaults are always kept.
+   */
+  additionalProtocols?: string[];
     env?: {
       FormData?: new (...args: any[]) => object;
       fetch?: (input: URL | Request | string, init?: RequestInit) => Promise<Response>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -440,6 +440,14 @@ export interface AxiosRequestConfig<D = any, P = any> {
   transitional?: TransitionalOptions;
   signal?: GenericAbortSignal;
   insecureHTTPParser?: boolean;
+  /**
+   * URL schemes to accept in addition to the platform defaults
+   * (`http`, `https`, `file`, `data`, plus `blob` and `url` in browsers).
+   * Useful behind native shells such as Capacitor that serve local
+   * resources over a custom scheme. Entries may be written with or
+   * without a trailing colon; the platform defaults are always kept.
+   */
+  additionalProtocols?: string[];
   env?: {
     FormData?: new (...args: any[]) => object;
     fetch?: (input: URL | Request | string, init?: RequestInit) => Promise<Response>;

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -14,6 +14,7 @@ import zlib from 'zlib';
 import { VERSION } from '../env/data.js';
 import transitionalDefaults from '../defaults/transitional.js';
 import AxiosError from '../core/AxiosError.js';
+import resolveProtocols from '../helpers/resolveProtocols.js';
 import CanceledError from '../cancel/CanceledError.js';
 import platform from '../platform/index.js';
 import fromDataURI from '../helpers/fromDataURI.js';
@@ -780,7 +781,9 @@ export default isHttpAdapterSupported &&
         });
       }
 
-      if (supportedProtocols.indexOf(protocol) === -1) {
+      const allowedProtocols = resolveProtocols(config).map((scheme) => scheme + ':');
+
+      if (allowedProtocols.indexOf(protocol) === -1) {
         return reject(
           new AxiosError('Unsupported protocol ' + protocol, AxiosError.ERR_BAD_REQUEST, config)
         );

--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -5,6 +5,7 @@ import AxiosError from '../core/AxiosError.js';
 import CanceledError from '../cancel/CanceledError.js';
 import normalizeURLForProtocolCheck from '../helpers/normalizeURLForProtocolCheck.js';
 import parseProtocol from '../helpers/parseProtocol.js';
+import resolveProtocols from '../helpers/resolveProtocols.js';
 import platform from '../platform/index.js';
 import AxiosHeaders from '../core/AxiosHeaders.js';
 import { progressEventReducer } from '../helpers/progressEventReducer.js';
@@ -259,7 +260,7 @@ export default isXHRAdapterSupported &&
 
       const protocol = parseProtocol(_config.url);
 
-      if (protocol && !platform.protocols.includes(protocol)) {
+      if (protocol && !resolveProtocols(_config).includes(protocol)) {
         reject(
           new AxiosError(
             'Unsupported protocol ' + protocol + ':',

--- a/lib/helpers/resolveProtocols.js
+++ b/lib/helpers/resolveProtocols.js
@@ -1,0 +1,48 @@
+'use strict';
+
+import platform from '../platform/index.js';
+import utils from '../utils.js';
+
+/**
+ * Build the list of URL schemes a request is allowed to use.
+ *
+ * The platform list is fixed (`http`, `https`, `file`, `data`, plus `blob` and
+ * `url` in browsers), which makes axios unusable behind the custom schemes that
+ * native shells such as Capacitor register for their local resources.
+ *
+ * `config.additionalProtocols` extends that list. It never removes anything, so
+ * a value arriving from a polluted prototype or an untrusted config cannot
+ * narrow the platform defaults or turn protocol validation off; only own
+ * properties are read, and non-string entries are ignored.
+ *
+ * @param {Object} [config] The request config
+ *
+ * @returns {string[]} Accepted schemes, without a trailing colon
+ */
+export default function resolveProtocols(config) {
+  const additional =
+    config && utils.hasOwnProp(config, 'additionalProtocols')
+      ? config.additionalProtocols
+      : undefined;
+
+  if (!utils.isArray(additional) || !additional.length) {
+    return platform.protocols;
+  }
+
+  const protocols = platform.protocols.slice();
+
+  additional.forEach((protocol) => {
+    if (!utils.isString(protocol)) {
+      return;
+    }
+
+    // Accept both `capacitor` and `capacitor:`.
+    const normalized = protocol.trim().toLowerCase().replace(/:$/, '');
+
+    if (normalized && protocols.indexOf(normalized) === -1) {
+      protocols.push(normalized);
+    }
+  });
+
+  return protocols;
+}

--- a/tests/browser/requests.browser.test.js
+++ b/tests/browser/requests.browser.test.js
@@ -558,6 +558,24 @@ describe('requests (vitest browser)', () => {
     });
   });
 
+  it('accepts a scheme listed in additionalProtocols', async () => {
+    const { request, promise } = startRequest('capacitor://localhost/app.js', {
+      method: 'get',
+      additionalProtocols: ['capacitor'],
+    });
+
+    expect(request.url).toBe('capacitor://localhost/app.js');
+    await flushSuccess(request, promise);
+  });
+
+  it('still rejects a scheme that additionalProtocols does not list', async () => {
+    await expect(
+      axios.get('ftp:localhost', { adapter: 'xhr', additionalProtocols: ['capacitor'] })
+    ).rejects.toMatchObject({
+      message: 'Unsupported protocol ftp:',
+    });
+  });
+
   it('should clean up cancellation listeners after unsupported protocol rejection', async () => {
     const source = axios.CancelToken.source();
     const controller = new AbortController();

--- a/tests/unit/adapters/http.test.js
+++ b/tests/unit/adapters/http.test.js
@@ -4074,6 +4074,67 @@ describe('supports http with nodejs', () => {
     });
   });
 
+  describe('additionalProtocols', () => {
+    const reachedTransport = 'reached transport';
+    const transport = {
+      request() {
+        throw new Error(reachedTransport);
+      },
+    };
+
+    it('accepts a scheme listed in additionalProtocols', async () => {
+      await assert.rejects(
+        axios.get('capacitor://localhost/app.js', {
+          additionalProtocols: ['capacitor'],
+          transport,
+        }),
+        (error) => {
+          assert.equal(error.message, reachedTransport);
+          return true;
+        }
+      );
+    });
+
+    it('still rejects a scheme that was not listed', async () => {
+      await assert.rejects(
+        axios.get('capacitor://localhost/app.js', { additionalProtocols: ['other'] }),
+        (error) => {
+          assert.equal(error.message, 'Unsupported protocol capacitor:');
+          return true;
+        }
+      );
+    });
+
+    it('rejects when the option is absent', async () => {
+      await assert.rejects(axios.get('capacitor://localhost/app.js'), (error) => {
+        assert.equal(error.message, 'Unsupported protocol capacitor:');
+        return true;
+      });
+    });
+
+    it('can be set on an instance', async () => {
+      const instance = axios.create({ additionalProtocols: ['capacitor'], transport });
+
+      await assert.rejects(instance.get('capacitor://localhost/app.js'), (error) => {
+        assert.equal(error.message, reachedTransport);
+        return true;
+      });
+    });
+
+    it('does not widen the accepted set from a polluted prototype', async () => {
+      Object.prototype.additionalProtocols = ['capacitor'];
+
+      try {
+        await assert.rejects(axios.get('capacitor://localhost/app.js'), (error) => {
+          assert.equal(error.message, 'Unsupported protocol capacitor:');
+          return true;
+        });
+      } finally {
+        delete Object.prototype.additionalProtocols;
+      }
+    });
+  });
+
   it('rejects malformed HTTP URLs before Node URL normalization and preserves config', async () => {
     for (const url of ['\u0000https:example.com/users', 'h\nttp:example.com/users']) {
       await assert.rejects(

--- a/tests/unit/helpers/resolveProtocols.test.js
+++ b/tests/unit/helpers/resolveProtocols.test.js
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import resolveProtocols from '../../../lib/helpers/resolveProtocols.js';
+import platform from '../../../lib/platform/index.js';
+
+describe('helpers::resolveProtocols', () => {
+  it('returns the platform defaults when nothing is configured', () => {
+    expect(resolveProtocols()).toBe(platform.protocols);
+    expect(resolveProtocols({})).toBe(platform.protocols);
+    expect(resolveProtocols({ additionalProtocols: [] })).toBe(platform.protocols);
+  });
+
+  it('appends configured schemes to the platform defaults', () => {
+    const protocols = resolveProtocols({ additionalProtocols: ['capacitor'] });
+
+    expect(protocols).toContain('capacitor');
+    platform.protocols.forEach((scheme) => expect(protocols).toContain(scheme));
+  });
+
+  it('accepts schemes written with a trailing colon or in mixed case', () => {
+    expect(resolveProtocols({ additionalProtocols: ['Capacitor:'] })).toContain('capacitor');
+  });
+
+  it('never removes a platform default', () => {
+    const protocols = resolveProtocols({ additionalProtocols: ['capacitor'] });
+
+    expect(protocols).toContain('http');
+    expect(protocols).toContain('https');
+  });
+
+  it('ignores a non-array value', () => {
+    expect(resolveProtocols({ additionalProtocols: 'capacitor' })).toBe(platform.protocols);
+  });
+
+  it('ignores non-string entries', () => {
+    expect(resolveProtocols({ additionalProtocols: [1, null, {}, 'ok'] })).toEqual([
+      ...platform.protocols,
+      'ok',
+    ]);
+  });
+
+  it('does not duplicate a scheme that is already supported', () => {
+    const protocols = resolveProtocols({ additionalProtocols: ['http', 'HTTP:'] });
+
+    expect(protocols.filter((scheme) => scheme === 'http')).toHaveLength(1);
+  });
+
+  it('does not read the option from a polluted prototype', () => {
+    Object.prototype.additionalProtocols = ['capacitor'];
+
+    try {
+      expect(resolveProtocols({})).toBe(platform.protocols);
+    } finally {
+      delete Object.prototype.additionalProtocols;
+    }
+  });
+
+  it('does not leak into the platform list', () => {
+    const before = platform.protocols.slice();
+    resolveProtocols({ additionalProtocols: ['capacitor'] });
+
+    expect(platform.protocols).toEqual(before);
+  });
+});


### PR DESCRIPTION
Draft. Independent of the other v1 PRs in this set. This is the one that adds public API, so it is the one most worth pushing back on.

## Problem

The set of URL schemes axios will dispatch is fixed at the platform level:

```js
// lib/platform/browser/index.js
protocols: ['http', 'https', 'file', 'blob', 'url', 'data'],
// lib/platform/node/index.js
protocols: ['http', 'https', 'file', 'data'],
```

Anything else is rejected with `Unsupported protocol <scheme>:`. Native shells such as Capacitor register their own scheme for local resources, so requests through them fail outright, and the workaround has been to pin axios below 0.27 (the release that introduced the fixed list).

## API

```js
axios.get('capacitor://localhost/app.js', {
  additionalProtocols: ['capacitor'],
});

// or on an instance
const api = axios.create({ additionalProtocols: ['capacitor'] });
```

Entries may be written with or without a trailing colon (`'capacitor'` or `'capacitor:'`) and are matched case insensitively. Applies to both the xhr and http adapters.

## Safety properties

The option is deliberately **additive only**:

- It can widen the accepted set, never narrow it. `additionalProtocols: ['capacitor']` still accepts `http` and `https`. There is no way to use this option to turn protocol validation off or to drop a default.
- Only own properties are read (`utils.hasOwnProp`), so a polluted `Object.prototype.additionalProtocols` cannot widen the set for a config that never asked for it. There is a test for this in both the helper and the http adapter suite.
- Non-array values and non-string entries are ignored rather than coerced.
- The resolved list is a copy; `platform.protocols` is never mutated, so one request cannot leak its schemes into another.
- With the option absent, `resolveProtocols` returns the platform array by identity, so the default path allocates nothing.

## The open question: naming and semantics

The issue thread floated `registerProtocols` and a plain `protocols`. I went with `additionalProtocols` because it makes the additive semantics unambiguous at the call site — a plain `protocols` reads like it replaces the list, and a reader cannot tell which without checking the docs.

The tradeoff is that this deliberately does **not** support restricting the accepted set. That is a real use case too (there is a separate thread about trusted-host style config), but "widen" and "narrow" want different safety analysis, and folding them into one option is how you end up with a config key that can silently weaken a security check. Worth deciding if you would rather have a single replacing `protocols` option instead — happy to reshape it.

## Non-breaking

With `additionalProtocols` absent, every scheme resolves exactly as before. Verified against unmodified `origin/v1.x`: an unlisted scheme, a non-array value, non-string entries and a polluted prototype all produce byte-identical `Unsupported protocol capacitor:` errors on both. No existing option or type changes; `AxiosRequestConfig` gains one optional field in `index.d.ts` and `index.d.cts`.

## Tests and docs

- `tests/unit/helpers/resolveProtocols.test.js` (new, 9 cases): defaults by identity, appending, colon/case normalisation, defaults never removed, non-array and non-string rejection, no duplicates, prototype pollution, no mutation of `platform.protocols`.
- `tests/unit/adapters/http.test.js` (5): accepted scheme reaches the transport, unlisted scheme still rejected, absent option still rejects, instance-level config, prototype pollution.
- `tests/browser/requests.browser.test.js` (2): the xhr adapter opens the custom scheme, and still rejects one that is not listed.
- README config table documents the option.

```
vitest run --project unit             -> 1069 passed, 8 failed
vitest run --project browser-headless ->  621 passed
```

The 8 unit failures (DNS lookup, formDataHeaderPolicy, query parsing) reproduce identically on unmodified `origin/v1.x` here and are unrelated.

`v2.x` carries a byte-identical `lib/`, so it needs the same change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
## Description

Lets requests accept URL schemes beyond the platform list so axios works behind native shells like Capacitor that serve local resources over a custom protocol. The fixed defaults (`http`, `https`, `file`, `data`, plus `blob`/`url` in browsers) previously rejected anything else with `Unsupported protocol`; now a request or instance can pass `additionalProtocols: ['capacitor']` to widen the accepted set without changing the default path.

- New optional `additionalProtocols` config field, applied in both the xhr and http adapters via a shared `resolveProtocols` helper; typed in `index.d.ts` and `index.d.cts` and documented in the README.
- The option is additive-only, so it can widen the accepted set but never narrow it or turn protocol validation off.
- Only own properties are read and entries are validated as strings, so a polluted `Object.prototype` or malformed config cannot widen the accepted set.
- Defaults are always kept, entries accept an optional trailing colon and are matched case-insensitively, and `platform.protocols` is never mutated.

## Docs

README config table documents `additionalProtocols`, including the colon/case normalization and that defaults are always kept.

## Testing

Unit tests cover the helper (default identity, appending, normalization, duplicates, non-array and non-string rejection, prototype pollution, no mutation) and the http adapter (accept, still-reject, absent option, instance-level, pollution). Two browser tests cover the xhr adapter. The 8 pre-existing unit failures reproduce on unmodified `v1.x` and are unrelated to this change.

## Semantic version impact

Minor: a non-breaking, additive feature — both type declaration files gain one optional field and no behavior changes when the option is absent.

<sup>Written for commit 16b7333cb726b883d91ff7be2c127e0c5fbff70d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/axios/axios/pull/11187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

