### PR TITLE
docs: correct silentJSONParsing behavior documentation and test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1171,7 +1171,7 @@ These config options are available for requests. Only `url` is required. Request
   // transitional options for backward compatibility that may be removed in the newer versions
   transitional: {
     // silent JSON parsing mode
-    // `true`  - ignore JSON parsing errors and set response.data to null if parsing failed (old behaviour)
+    // `true`  - ignore JSON parsing errors and keep the original response string if parsing failed (old behaviour)
     // `false` - throw SyntaxError if JSON parsing failed
     // Important: this option only takes effect when `responseType` is explicitly set to 'json'.
     // When `responseType` is omitted (defaults to no value), axios uses `forcedJSONParsing`

--- a/docs/es/pages/advanced/request-config.md
+++ b/docs/es/pages/advanced/request-config.md
@@ -419,7 +419,7 @@ Ten en cuenta que la opción `insecureHTTPParser` solo está disponible en Node.
 
 La propiedad `transitional` te permite habilitar o deshabilitar ciertas características de transición. Las siguientes opciones están disponibles:
 
-- `silentJSONParsing`: Si se establece en `true` _(predeterminado)_, axios ignora silenciosamente los errores de parseo de JSON y establece `response.data` en `null` cuando el parseo falla. Establécelo en `false` para que se lance `SyntaxError` en su lugar.
+- `silentJSONParsing`: Si se establece en `true` _(predeterminado)_, axios ignora silenciosamente los errores de parseo de JSON y conserva la cadena de respuesta original en `response.data` cuando el parseo falla. Establécelo en `false` para que se lance `SyntaxError` en su lugar.
 
   ::: tip Importante
   Esta opción solo tiene efecto cuando `responseType` se establece **explícitamente** en `'json'`. Cuando `responseType` se omite, axios usa `forcedJSONParsing` para intentar el parseo de JSON y devuelve silenciosamente la cadena cruda en caso de fallo, sin importar este ajuste. Para hacer que el JSON inválido lance un error, establece ambos:

--- a/docs/fr/pages/advanced/request-config.md
+++ b/docs/fr/pages/advanced/request-config.md
@@ -419,7 +419,7 @@ Notez que l'option `insecureHTTPParser` n'est disponible que dans Node.js 12.10.
 
 La propriété `transitional` vous permet d'activer ou de désactiver certaines fonctionnalités de transition. Les options suivantes sont disponibles :
 
-- `silentJSONParsing` : Si défini à `true` _(par défaut)_, axios ignore silencieusement les erreurs d'analyse JSON et définit `response.data` à `null` lorsque l'analyse échoue. Définissez à `false` pour lever une `SyntaxError` à la place.
+- `silentJSONParsing` : Si défini à `true` _(par défaut)_, axios ignore silencieusement les erreurs d'analyse JSON et conserve la chaîne de réponse d'origine dans `response.data` lorsque l'analyse échoue. Définissez à `false` pour lever une `SyntaxError` à la place.
 
   ::: tip Important
   Cette option ne prend effet que lorsque `responseType` est **explicitement** défini à `'json'`. Lorsque `responseType` est omis, axios utilise `forcedJSONParsing` pour tenter l'analyse JSON et retourne silencieusement la chaîne brute en cas d'échec, indépendamment de ce paramètre. Pour qu'un JSON invalide lève une erreur, définissez les deux :

--- a/docs/pages/advanced/request-config.md
+++ b/docs/pages/advanced/request-config.md
@@ -419,7 +419,7 @@ Please note that the `insecureHTTPParser` option is only available in Node.js 12
 
 The `transitional` property allows you to enable or disable certain transitional features. The following options are available:
 
-- `silentJSONParsing`: If set to `true` _(default)_, axios silently ignores JSON parsing errors and sets `response.data` to `null` when parsing fails. Set to `false` to throw `SyntaxError` instead.
+- `silentJSONParsing`: If set to `true` _(default)_, axios silently ignores JSON parsing errors and keeps the original response string in `response.data` when parsing fails. Set to `false` to throw `SyntaxError` instead.
 
   ::: tip Important
   This option only takes effect when `responseType` is **explicitly** set to `'json'`. When `responseType` is omitted, axios uses `forcedJSONParsing` to attempt JSON parsing and silently returns the raw string on failure regardless of this setting. To make invalid JSON throw, set both:

--- a/tests/unit/transformResponse.test.js
+++ b/tests/unit/transformResponse.test.js
@@ -38,6 +38,20 @@ describe('transformResponse', () => {
   });
 
   describe('malformed JSON with responseType: json', () => {
+    it('keeps the raw string when silentJSONParsing is enabled', () => {
+      const data = '{bad json';
+      const response = { status: 200, headers: {}, data };
+      const config = {
+        responseType: 'json',
+        transitional: { silentJSONParsing: true, forcedJSONParsing: true },
+        response,
+      };
+
+      const result = transformData.call(config, defaults.transformResponse, response);
+
+      assert.strictEqual(result, data);
+    });
+
     it('throws AxiosError with ERR_BAD_RESPONSE code', () => {
       const response = { status: 200, headers: {}, data: '{bad json' };
       const config = {


### PR DESCRIPTION
Fixes an incorrect statement about the `transitional.silentJSONParsing` option in the English, Spanish and French `request-config` docs (and the README config comment). They claimed axios sets `response.data` to `null` when JSON parsing fails.

In `lib/defaults/index.js` (`transformResponse`), when `silentJSONParsing` is `true` (the default), a `JSON.parse` failure is silently swallowed and the **original response string** is kept in `response.data` — it is never set to `null`. The Chinese docs (`docs/zh`) and the existing README paragraph below the comment already describe this correct behavior.

Changes:
- `docs/pages/advanced/request-config.md` (EN), `docs/es/...`, `docs/fr/...`: correct the option description.
- `README.md`: align the `transitional` comment with the actual behavior.
- `tests/unit/transformResponse.test.js`: add a regression test asserting the raw string is returned when `silentJSONParsing` is enabled (the existing malformed-JSON tests only covered `silentJSONParsing: false`).

Verification: `npm run test:vitest:unit` passes (995/995 locally).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
## Description

Corrects the documented behavior of `transitional.silentJSONParsing` in the English, Spanish, and French request-config docs and the README config comment. The docs previously claimed `axios` sets `response.data` to `null` when JSON parsing fails; the actual behavior is that the original response string is kept in `response.data`.

- Summary of changes: corrected the option description in four docs locations and added a regression test.
- Reasoning: the docs contradicted the implementation in `lib/defaults/index.js`; the Chinese docs already described the correct behavior.
- Additional context: no runtime behavior changes.

## Docs

The corrected docs are part of this PR; no further `/docs/` updates are needed.

## Testing

Adds a regression test asserting the raw string is returned when `silentJSONParsing` is enabled. Existing malformed-JSON tests only covered `silentJSONParsing: false`.

## Semantic version impact

Patch change: documentation and test only, no runtime behavior changes.

<sup>Written for commit ab8e138403295cc237b75ada5fae05cfd048e0fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/axios/axios/pull/11190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

