### PR TITLE
fix: preserve empty FormData field names as empty string keys

### DIFF
--- a/lib/helpers/formDataToJSON.js
+++ b/lib/helpers/formDataToJSON.js
@@ -42,7 +42,7 @@ function parsePropPath(name) {
     path.push(match[0] === '[]' ? '' : match[1] || match[0]);
   }
 
-  return path;
+  return path.length ? path : [''];
 }
 
 /**

--- a/tests/unit/helpers/formDataToJSON.test.js
+++ b/tests/unit/helpers/formDataToJSON.test.js
@@ -54,6 +54,15 @@ describe('formDataToJSON', () => {
     });
   });
 
+  it('should preserve an empty field name as an empty string key', () => {
+    const formData = new FormData();
+
+    formData.append('', 'value');
+    formData.append('', 'second');
+
+    expect(formDataToJSON(formData)).toEqual({ '': ['value', 'second'] });
+  });
+
   it('should convert props with empty brackets to arrays', () => {
     const formData = new FormData();
 


### PR DESCRIPTION
### Bug
When a FormData field is appended with an empty name, formDataToJSON serializes it to a literal undefined key instead of an empty string.

Root cause: parsePropPath('') returns an empty path array, so buildPath falls through to target[undefined].

Fix: treat an empty path as a single '' segment in lib/helpers/formDataToJSON.js, plus a regression test.

Verified: formDataToJSON.test.js 16 passed; full unit suite 58 files/1063 tests passed; eslint clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
## Description

Fixes `formDataToJSON` so FormData fields with an empty name serialize to an empty string key instead of an undefined key.

- The root cause was `parsePropPath('')` returning an empty path array, which made `buildPath` fall through to `target[undefined]`.
- `parsePropPath` now returns `['']` for an empty input, treating the empty name as a single empty-string segment.
- Empty field names are valid in FormData; this makes serialization round-trip correctly and groups repeated empty names into an array, e.g. `{ '': ['value', 'second'] }`.

## Docs

No documentation updates needed; the public API is unchanged.

## Testing

Added a regression test in `tests/unit/helpers/formDataToJSON.test.js` verifying that multiple fields with empty names collect into an array under the `''` key. The full unit suite (1063 tests) and eslint pass.

## Semantic version impact

Patch — non-breaking bug fix.

<sup>Written for commit 17907da42f6c32ec9b0744268c047f72108ae1a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/axios/axios/pull/11191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

