### PR TITLE
fix(http): attach request URL to error when params serialization fails

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -593,11 +593,10 @@ export default isHttpAdapterSupported && function httpAdapter(config) {
         config.paramsSerializer
       ).replace(/^\?/, '');
     } catch (err) {
-      const customErr = new Error(err.message);
-      customErr.config = config;
-      customErr.url = config.url;
-      customErr.exists = true;
-      return reject(customErr);
+      return reject(AxiosError.from(err, AxiosError.ERR_BAD_REQUEST, config, null, null, {
+        url: fullPath,
+        exists: true
+      }));
     }
 
     headers.set(

--- a/test/unit/adapters/http.js
+++ b/test/unit/adapters/http.js
@@ -809,7 +809,9 @@ describe('supports http with nodejs', function () {
           errorParam: new Date(undefined),
         },
       }).catch(function (err) {
-        assert.deepEqual(err.exists, true)
+        assert.deepEqual(err.exists, true);
+        assert.strictEqual(err.code, 'ERR_BAD_REQUEST');
+        assert.strictEqual(err.url, 'http://localhost:4444/');
         done();
       }).catch(done);
     });


### PR DESCRIPTION
## Summary

When a request's `paramsSerializer` (or the default query-string builder) throws while the Node HTTP adapter is building the request URL, the error is currently wrapped as a bare `Error` with no error code, only a `config`, `url`, and `exists` marker attached manually.

This changes the catch block in `lib/adapters/http.js` to wrap the failure as an `AxiosError` (via `AxiosError.from`) carrying `code: 'ERR_BAD_REQUEST'`, while still attaching the resolved target URL (`fullPath`) and the pre-existing `exists` marker via `AxiosError.from`'s `customProps` argument. This lets callers distinguish a serialization failure from other error paths and recover the URL of the request that failed, without breaking the existing `err.exists` contract relied on by the current test suite.

## Test plan

[x] `node bin/ssl_hotfix.js mocha test/unit/adapters/http.js --timeout 30000 --exit` — full adapter suite passes
[x] Extended the existing "should display error while parsing params" test to assert `err.code === 'ERR_BAD_REQUEST'` and `err.url` is the resolved request URL, in addition to the pre-existing `err.exists === true` assertion

🤖 shipped by [shiploop](https://github.com/anshss/shiploop)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
## Description

When params serialization fails in the Node HTTP adapter, the error is now returned as an `AxiosError` with `code: 'ERR_BAD_REQUEST'` instead of a bare, code-less, manually built `Error`. This gives callers a standard error code and the resolved request URL, while preserving the existing `err.exists` marker.

- Summary of changes: The catch block in `lib/adapters/http.js` now uses `AxiosError.from` with `ERR_BAD_REQUEST` and customProps carrying `url: fullPath` and `exists: true`.
- Reasoning: Downstream error handlers previously received a contextless `Error` and could not distinguish a serialization failure from other rejection paths.
- Additional context: The `url` property now holds the fully resolved URL (query string included), whereas before it held the raw `config.url`.

## Docs

No documentation website updates are needed; this is an internal error-handling change with no public API surface change.

## Testing

A test in `test/unit/adapters/http.js` was extended to assert `err.code === 'ERR_BAD_REQUEST'` and `err.url` equals the resolved request URL alongside the existing `err.exists` check. No other tests were added or modified; the full adapter suite passes.

## Semantic version impact

Patch version bump: this is a non-breaking bug fix that only improves error metadata and keeps the `err.exists` contract intact.

<sup>Written for commit 1c986500f1cf7326a8e68480e7c72b017624ad37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/axios/axios/pull/11198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

