### PR TITLE
fix(AxiosURLSearchParams): preserve this binding for custom encoder

### DIFF
--- a/lib/helpers/AxiosURLSearchParams.js
+++ b/lib/helpers/AxiosURLSearchParams.js
@@ -46,9 +46,7 @@ prototype.append = function append(name, value) {
 };
 
 prototype.toString = function toString(encoder) {
-  const _encode = encoder ? function(value) {
-    return encoder.call(this, value, encode);
-  } : encode;
+  const _encode = encoder ? (value) => encoder.call(this, value, encode) : encode;
 
   return this._pairs.map(function each(pair) {
     return _encode(pair[0]) + '=' + _encode(pair[1]);

--- a/test/specs/helpers/AxiosURLSearchParams.spec.js
+++ b/test/specs/helpers/AxiosURLSearchParams.spec.js
@@ -1,0 +1,16 @@
+import AxiosURLSearchParams from '../../../lib/helpers/AxiosURLSearchParams';
+
+describe('helpers::AxiosURLSearchParams', function () {
+  it('should pass the AxiosURLSearchParams instance as `this` to a custom encoder', function () {
+    const params = new AxiosURLSearchParams({foo: 'bar', baz: 'qux'});
+    const capturedThis = [];
+
+    const serialized = params.toString(function customEncoder(value, defaultEncode) {
+      capturedThis.push(this);
+      return defaultEncode(value);
+    });
+
+    expect(serialized).toEqual('foo=bar&baz=qux');
+    expect(capturedThis).toEqual([params, params, params, params]);
+  });
+});

--- a/test/specs/helpers/buildURL.spec.js
+++ b/test/specs/helpers/buildURL.spec.js
@@ -60,6 +60,20 @@ describe('helpers::buildURL', function () {
     })).toEqual('/foo?foo=:$,+');
   });
 
+  it('should pass the params serializer instance as `this` to a custom encode', function () {
+    const capturedThis = [];
+
+    expect(buildURL('/foo', {foo: 'bar', baz: 'qux'}, {
+      encode: function (value, defaultEncode) {
+        capturedThis.push(this);
+        return defaultEncode(value);
+      }
+    })).toEqual('/foo?foo=bar&baz=qux');
+    expect(capturedThis.length).toEqual(4);
+    expect(new Set(capturedThis).size).toEqual(1);
+    expect(capturedThis[0]).not.toBeUndefined();
+  });
+
   it('should support existing params', function () {
     expect(buildURL('/foo?foo=bar', {
       bar: 'baz'


### PR DESCRIPTION
## Summary

`AxiosURLSearchParams.prototype.toString` accepts a custom `encoder` function meant to be invoked with the `AxiosURLSearchParams` instance as `this` (the call site does `encoder.call(this, value, encode)`). The internal wrapper that forwards this call was a plain `function` expression, so when it was later called as a bare function inside `Array.prototype.map`, its own `this` was `undefined` — not the outer `this` from `toString`. Any custom encoder relying on `this` broke silently.

Switching the wrapper to an arrow function makes it inherit `this` lexically from `toString`, so `encoder.call(this, ...)` now forwards the actual `AxiosURLSearchParams` instance.

## Changes

- `lib/helpers/AxiosURLSearchParams.js`: wrap the custom encoder call in an arrow function instead of a plain `function` expression.
- Added a unit test verifying the custom encoder receives the `AxiosURLSearchParams` instance as `this`.
- Added a `buildURL` test verifying the same for `params.encode` passed through `buildURL` options.

## Test plan

- [x] `npx karma start karma.conf.cjs --single-run --browsers ChromeHeadless` — 325/326 passing (new tests pass; the one pre-existing failure is an unrelated `FormData` network test unaffected by this change).

🤖 shipped by [shiploop](https://github.com/anshss/shiploop)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
## Description

Fixes `AxiosURLSearchParams.prototype.toString` so custom encoder functions receive the `AxiosURLSearchParams` instance as `this`. Previously the internal wrapper used a plain `function` expression, which lost the `this` binding when invoked inside `Array.prototype.map`, so custom encoders relying on `this` silently received `undefined`. Switching the wrapper to an arrow function lets it inherit `this` lexically from `toString`. No public API changes; the fix is one line in `lib/helpers/AxiosURLSearchParams.js`.

## Docs

No documentation update needed — the change is internal and doesn't alter the documented public API.

## Testing

Added unit tests in `test/specs/helpers/AxiosURLSearchParams.spec.js` and `test/specs/helpers/buildURL.spec.js` verifying the encoder receives the instance as `this`. The suite passes 325/326 with one pre-existing unrelated `FormData` network test failure.

## Semantic version impact

Patch version bump — this is a bug fix with no breaking changes.

<sup>Written for commit da22ed7ab815193324357c771092ce42d146c715. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/axios/axios/pull/11199?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

