### PR TITLE
fix(formdata): isolate Buffer fallback into platform-specific module

### DIFF
--- a/lib/helpers/toFormData.js
+++ b/lib/helpers/toFormData.js
@@ -4,6 +4,7 @@ import utils from '../utils.js';
 import AxiosError from '../core/AxiosError.js';
 // temporary hotfix to avoid circular references until AxiosURLSearchParams is refactored
 import PlatformFormData from '../platform/node/classes/FormData.js';
+import toArrayBufferFallback from '../platform/node/classes/Buffer.js';
 
 /**
  * Determines if the given thing is a array or js object.
@@ -129,7 +130,7 @@ function toFormData(obj, formData, options) {
     }
 
     if (utils.isArrayBuffer(value) || utils.isTypedArray(value)) {
-      return useBlob && typeof Blob === 'function' ? new Blob([value]) : Buffer.from(value);
+      return useBlob && typeof Blob === 'function' ? new Blob([value]) : toArrayBufferFallback(value);
     }
 
     return value;

--- a/lib/platform/browser/classes/Buffer.js
+++ b/lib/platform/browser/classes/Buffer.js
@@ -1,0 +1,9 @@
+'use strict';
+
+// Browser counterpart of platform/node/classes/Buffer.js: a working fallback
+// that never needs Node's Buffer global.
+export default function toArrayBufferFallback(value) {
+  return typeof Blob === 'function' ?
+    new Blob([value]) :
+    String.fromCharCode.apply(null, new Uint8Array(value));
+}

--- a/lib/platform/node/classes/Buffer.js
+++ b/lib/platform/node/classes/Buffer.js
@@ -1,0 +1,8 @@
+'use strict';
+
+// Isolated in its own module (like platform/node/classes/FormData.js) so
+// bundlers targeting the browser, which remap this path via package.json's
+// "browser" field, never see a direct reference to the `Buffer` global.
+export default function toArrayBufferFallback(value) {
+  return Buffer.from(value);
+}

--- a/package.json
+++ b/package.json
@@ -163,12 +163,14 @@
   "browser": {
     "./lib/adapters/http.js": "./lib/helpers/null.js",
     "./lib/platform/node/index.js": "./lib/platform/browser/index.js",
-    "./lib/platform/node/classes/FormData.js": "./lib/helpers/null.js"
+    "./lib/platform/node/classes/FormData.js": "./lib/helpers/null.js",
+    "./lib/platform/node/classes/Buffer.js": "./lib/platform/browser/classes/Buffer.js"
   },
   "react-native": {
     "./lib/adapters/http.js": "./lib/helpers/null.js",
     "./lib/platform/node/index.js": "./lib/platform/browser/index.js",
-    "./lib/platform/node/classes/FormData.js": "./lib/helpers/null.js"
+    "./lib/platform/node/classes/FormData.js": "./lib/helpers/null.js",
+    "./lib/platform/node/classes/Buffer.js": "./lib/platform/browser/classes/Buffer.js"
   },
   "jsdelivr": "dist/axios.min.js",
   "unpkg": "dist/axios.min.js",


### PR DESCRIPTION
## Summary

`toFormData`'s ArrayBuffer/TypedArray conversion falls back to `Buffer.from(value)` when a spec-compliant `Blob` isn't available. Bundlers such as Webpack (used by Next.js) statically detect any reference to the global `Buffer` identifier and pull in the full `buffer` polyfill for browser builds — even though this fallback path only ever runs in Node.

This moves the `Buffer.from` call into `lib/platform/node/classes/Buffer.js`, which is swapped for `lib/platform/browser/classes/Buffer.js` via `package.json`'s `browser`/`react-native` field maps (the same mechanism already used for `lib/platform/node/classes/FormData.js`). The browser implementation falls back to `Blob` (or a plain string when `Blob` isn't available) and never references `Buffer`.

Verified with a rollup build: `dist/browser/axios.cjs` and `dist/esm/axios.js` no longer contain a `Buffer.from`/global `Buffer` reference, while `dist/node/axios.cjs` is unaffected.

## Test plan
[x] `npm run test:mocha` (full unit suite) passes
[x] `npx eslint` on changed files passes
[x] Built with `rollup -c -m` and confirmed no `Buffer` global reference in browser/esm bundles, and no new circular-dependency warning

🤖 shipped by [shiploop](https://github.com/anshss/shiploop)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
## Description

Moves `toFormData`'s ArrayBuffer/TypedArray fallback from a direct `Buffer.from` call into a platform-specific module, so browser bundles no longer pull in the `buffer` polyfill. Bundlers like Webpack (used by Next.js) statically detect the global `Buffer` reference and included the polyfill even though the fallback path only runs in Node.

- The node implementation (`lib/platform/node/classes/Buffer.js`) keeps `Buffer.from`; the browser counterpart (`lib/platform/browser/classes/Buffer.js`) falls back to `Blob` or a plain string and never references `Buffer`.
- `package.json`'s `browser` and `react-native` field maps swap the node module for the browser one, the same mechanism already used for `FormData.js`.
- A rollup build confirmed `dist/browser/axios.cjs` and `dist/esm/axios.js` no longer contain a `Buffer.from` reference, while `dist/node/axios.cjs` is unchanged.

## Docs

No documentation updates needed — this is an internal bundling fix with no API or behavior changes.

## Testing

No new tests were added; the full unit suite (`npm run test:mocha`) and `eslint` pass, and the rollup build shows no `Buffer` reference in browser bundles or new circular-dependency warnings.

## Semantic version impact

Patch change — fixes a bundling issue without altering the public API or observable runtime behavior.

<sup>Written for commit bdb046b2ae5edbf56f3ee2858ba1006a7870bd26. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/axios/axios/pull/11201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

