### PR TITLE
fix(helpers): throw error for non-string URL when params are provided

### DIFF
--- a/PRE_RELEASE_CHANGELOG.md
+++ b/PRE_RELEASE_CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ## Bug Fixes
 
+- **Invalid URL handling in buildURL:** Rejected non-string URLs when params are provided with `AxiosError` and `ERR_INVALID_URL`, preventing silent coercion of `undefined` or `null` URLs to empty strings. (**#11202**, closes **#11160**)
+
 - **Method-specific headers:** Added default header buckets for all supported methods and removed those structural buckets during request preparation, so `OPTIONS`, `PURGE`, `LINK`, `UNLINK`, and `QUERY` defaults apply only to matching requests instead of leaking as literal headers. (**#11096**)
 - **Node HTTP adapter option errors:** Invalid custom DNS lookup addresses and invalid or unsupported `httpVersion` values, including non-coercible JavaScript types, now reject with `AxiosError` and `ERR_BAD_OPTION_VALUE` while preserving the request config for diagnostics. (**#11096**)
 - **Runtime configuration hardening:** Prevented values inherited only from shared prototypes, including another JavaScript realm's `Object.prototype` even when its `constructor` is altered, from becoming request behavior after config merging or interceptor replacement. Methods, headers, adapters, transports, FormData hooks, serializer options, and Fetch `Request` options are protected. Already-safe writable merged configs retain their identity through dispatch, while frozen, sealed, accessor-based, otherwise restricted, or unsafe-key-bearing replacements become writable filtered snapshots. Interceptor replacements with non-terminal application-defined prototypes remain supported as normalized null-prototype snapshots, terminal null-prototype ancestors are treated as shared boundaries to fail closed, and own `__proto__`, `constructor`, and `prototype` keys remain excluded from materialized configs.

--- a/lib/helpers/buildURL.js
+++ b/lib/helpers/buildURL.js
@@ -2,6 +2,7 @@
 
 import utils from '../utils.js';
 import AxiosURLSearchParams from './AxiosURLSearchParams.js';
+import AxiosError from '../core/AxiosError.js';
 
 /**
  * It replaces URL-encoded forms of `:`, `$`, `,`, and spaces with
@@ -32,7 +33,12 @@ export default function buildURL(url, params, options) {
   if (!params) {
     return url;
   }
-  url = url || '';
+  if (!utils.isString(url)) {
+    throw new AxiosError(
+      'Invalid URL: url must be a string when params are provided',
+      AxiosError.ERR_INVALID_URL
+    );
+  }
 
   const _options = utils.isFunction(options)
     ? {

--- a/tests/unit/helpers/buildURL.test.js
+++ b/tests/unit/helpers/buildURL.test.js
@@ -16,8 +16,10 @@ describe('helpers::buildURL', () => {
     ).toEqual('/foo?foo=bar');
   });
 
-  it('should support params with undefined url', () => {
-    expect(buildURL(undefined, { foo: 'bar' })).toEqual('?foo=bar');
+  it('should throw an error for non-string URL when params are provided', () => {
+    expect(() => buildURL(undefined, { foo: 'bar' })).toThrowError(/url must be a string/);
+    expect(() => buildURL(null, { foo: 'bar' })).toThrowError(/url must be a string/);
+    expect(() => buildURL(123, { foo: 'bar' })).toThrowError(/url must be a string/);
   });
 
   it('should support sending raw params to custom serializer func', () => {

--- a/tests/unit/helpers/buildURL.test.js
+++ b/tests/unit/helpers/buildURL.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import buildURL, { encode } from '../../../lib/helpers/buildURL.js';
+import AxiosError from '../../../lib/core/AxiosError.js';
 
 describe('helpers::buildURL', () => {
   it('should support null params', () => {
@@ -16,10 +17,18 @@ describe('helpers::buildURL', () => {
     ).toEqual('/foo?foo=bar');
   });
 
-  it('should throw an error for non-string URL when params are provided', () => {
-    expect(() => buildURL(undefined, { foo: 'bar' })).toThrowError(/url must be a string/);
-    expect(() => buildURL(null, { foo: 'bar' })).toThrowError(/url must be a string/);
-    expect(() => buildURL(123, { foo: 'bar' })).toThrowError(/url must be a string/);
+  it('should throw an AxiosError with ERR_INVALID_URL for non-string URL when params are provided', () => {
+    [undefined, null, 123].forEach((url) => {
+      let error;
+      try {
+        buildURL(url, { foo: 'bar' });
+      } catch (err) {
+        error = err;
+      }
+      expect(error).toBeInstanceOf(AxiosError);
+      expect(error.code).toBe(AxiosError.ERR_INVALID_URL);
+      expect(error.message).toMatch(/url must be a string/);
+    });
   });
 
   it('should support sending raw params to custom serializer func', () => {


### PR DESCRIPTION
This fixes an issue introduced in 1.18.1 where `buildURL` silently coerced non-string URLs (like `undefined` or `null`) into empty strings when `params` were provided. In a browser context, returning a relative query string like `?foo=bar` against an empty string URL caused requests to implicitly target the current page instead of failing fast. This change updates `buildURL` to explicitly throw an `AxiosError.ERR_INVALID_URL` when `params` are present but the `url` is not a string, ensuring immediate and predictable failures.

Fixes #11160

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
## Description

Fixes a regression in `buildURL` where non-string URLs (e.g., `undefined`, `null`) were silently coerced to empty strings when `params` were provided, causing requests to implicitly target the current page. Now it throws an `AxiosError` with `ERR_INVALID_URL` instead. Fixes #11160.

- Summary: Replaces silent coercion with explicit error when `params` are given but `url` is not a string.
- Reasoning: The old behavior led to unpredictable requests in browsers; failing fast makes issues easier to diagnose.
- Additional context: No other behavior changes; string URLs continue to work as before.

## Docs

Update the `/docs/` to note that `buildURL` now requires a string URL when `params` are passed, and throws an error otherwise.

## Testing

Tests updated to expect an error for `undefined`, `null`, and numeric URLs. The previous test for `undefined` URL was replaced.

## Semantic version impact

This is a breaking change because it changes the function's contract. Recommend a major version bump.

<sup>Written for commit 7504b17f908885889af62453660d6b216a30d37a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/axios/axios/pull/11202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

