### PR TITLE
perf(core): reduce request configuration merge overhead

### DIFF
--- a/PRE_RELEASE_CHANGELOG.md
+++ b/PRE_RELEASE_CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## Performance Improvements
+
+- **Request configuration:** Reduced config merge overhead by avoiding redundant plain-object prototype walks, indexing case-insensitive header keys, and reusing stateless merge strategies.
+
 ## Features
 
 - **Proxy bypass CIDR ranges:** Added IPv4 and IPv6 CIDR matching to `NO_PROXY`/`no_proxy`, including bracketed IPv6 and IPv4-mapped IPv6 normalization, while malformed ranges fail closed. A `/0` entry bypasses the proxy for its entire address family.

--- a/lib/core/mergeConfig.js
+++ b/lib/core/mergeConfig.js
@@ -103,7 +103,7 @@ const hasOwnPropertyDescriptor = Object.freeze({
 
 // The strategy table and the strategies above are stateless, so they are
 // built once at module load instead of on every call: mergeConfig runs at
-// least twice per request (once from the method alias, once from `_request`).
+// most twice per request (once from a method alias, once from `_request`).
 const mergeMap = {
   url: valueFromConfig2,
   method: valueFromConfig2,

--- a/lib/core/mergeConfig.js
+++ b/lib/core/mergeConfig.js
@@ -16,6 +16,127 @@ const ownEnumerableKeys = (thing) => {
   return Object.keys(thing);
 };
 
+function getMergedValue(target, source, prop, caseless) {
+  if (utils.isPlainObject(target) && utils.isPlainObject(source)) {
+    return utils.merge.call({ caseless }, target, source);
+  } else if (utils.isPlainObject(source)) {
+    return utils.merge({}, source);
+  } else if (utils.isArray(source)) {
+    return source.slice();
+  }
+  return source;
+}
+
+function mergeDeepProperties(a, b, prop, caseless) {
+  if (!utils.isUndefined(b)) {
+    return getMergedValue(a, b, prop, caseless);
+  } else if (!utils.isUndefined(a)) {
+    return getMergedValue(undefined, a, prop, caseless);
+  }
+}
+
+// eslint-disable-next-line consistent-return
+function valueFromConfig2(a, b) {
+  if (!utils.isUndefined(b)) {
+    return getMergedValue(undefined, b);
+  }
+}
+
+// eslint-disable-next-line consistent-return
+function defaultToConfig2(a, b) {
+  if (!utils.isUndefined(b)) {
+    return getMergedValue(undefined, b);
+  } else if (!utils.isUndefined(a)) {
+    return getMergedValue(undefined, a);
+  }
+}
+
+function getMergedTransitionalOption(config1, config2, prop) {
+  const transitional2 = utils.hasOwnProp(config2, 'transitional')
+    ? config2.transitional
+    : undefined;
+
+  if (!utils.isUndefined(transitional2)) {
+    if (utils.isPlainObject(transitional2)) {
+      if (utils.hasOwnProp(transitional2, prop)) {
+        return transitional2[prop];
+      }
+    } else {
+      return undefined;
+    }
+  }
+
+  const transitional1 = utils.hasOwnProp(config1, 'transitional')
+    ? config1.transitional
+    : undefined;
+
+  if (utils.isPlainObject(transitional1) && utils.hasOwnProp(transitional1, prop)) {
+    return transitional1[prop];
+  }
+
+  return undefined;
+}
+
+// eslint-disable-next-line consistent-return
+function mergeDirectKeys(a, b, prop, config1, config2) {
+  if (utils.hasOwnProp(config2, prop)) {
+    return getMergedValue(a, b);
+  } else if (utils.hasOwnProp(config1, prop)) {
+    return getMergedValue(undefined, a);
+  }
+}
+
+function mergeHeaders(a, b, prop) {
+  return mergeDeepProperties(headersToObject(a), headersToObject(b), prop, true);
+}
+
+// Null-proto, frozen descriptor so a polluted Object.prototype.get cannot turn
+// this data descriptor into an accessor descriptor on the way in.
+// defineProperty only reads it, so one shared instance serves every call.
+const hasOwnPropertyDescriptor = Object.freeze({
+  __proto__: null,
+  value: Object.prototype.hasOwnProperty,
+  enumerable: false,
+  writable: true,
+  configurable: true,
+});
+
+// The strategy table and the strategies above are stateless, so they are
+// built once at module load instead of on every call: mergeConfig runs at
+// least twice per request (once from the method alias, once from `_request`).
+const mergeMap = {
+  url: valueFromConfig2,
+  method: valueFromConfig2,
+  data: valueFromConfig2,
+  baseURL: defaultToConfig2,
+  transformRequest: defaultToConfig2,
+  transformResponse: defaultToConfig2,
+  paramsSerializer: defaultToConfig2,
+  timeout: defaultToConfig2,
+  timeoutErrorMessage: defaultToConfig2,
+  withCredentials: defaultToConfig2,
+  withXSRFToken: defaultToConfig2,
+  adapter: defaultToConfig2,
+  responseType: defaultToConfig2,
+  xsrfCookieName: defaultToConfig2,
+  xsrfHeaderName: defaultToConfig2,
+  onUploadProgress: defaultToConfig2,
+  onDownloadProgress: defaultToConfig2,
+  decompress: defaultToConfig2,
+  maxContentLength: defaultToConfig2,
+  maxBodyLength: defaultToConfig2,
+  beforeRedirect: defaultToConfig2,
+  transport: defaultToConfig2,
+  httpAgent: defaultToConfig2,
+  httpsAgent: defaultToConfig2,
+  cancelToken: defaultToConfig2,
+  socketPath: defaultToConfig2,
+  allowedSocketPaths: defaultToConfig2,
+  responseEncoding: defaultToConfig2,
+  validateStatus: mergeDirectKeys,
+  headers: mergeHeaders,
+};
+
 /**
  * Config-specific merge-function which creates a new config-object
  * by merging two configuration objects together.
@@ -35,133 +156,25 @@ export default function mergeConfig(config1, config2) {
   // `hasOwnProperty` is restored as a non-enumerable own slot to preserve
   // ergonomics for user code that relies on it.
   const config = Object.create(null);
-  Object.defineProperty(config, 'hasOwnProperty', {
-    // Null-proto descriptor so a polluted Object.prototype.get cannot turn
-    // this data descriptor into an accessor descriptor on the way in.
-    __proto__: null,
-    value: Object.prototype.hasOwnProperty,
-    enumerable: false,
-    writable: true,
-    configurable: true,
-  });
+  Object.defineProperty(config, 'hasOwnProperty', hasOwnPropertyDescriptor);
 
-  function getMergedValue(target, source, prop, caseless) {
-    if (utils.isPlainObject(target) && utils.isPlainObject(source)) {
-      return utils.merge.call({ caseless }, target, source);
-    } else if (utils.isPlainObject(source)) {
-      return utils.merge({}, source);
-    } else if (utils.isArray(source)) {
-      return source.slice();
-    }
-    return source;
-  }
+  const keys = ownEnumerableKeys({ ...config1, ...config2 });
 
-  function mergeDeepProperties(a, b, prop, caseless) {
-    if (!utils.isUndefined(b)) {
-      return getMergedValue(a, b, prop, caseless);
-    } else if (!utils.isUndefined(a)) {
-      return getMergedValue(undefined, a, prop, caseless);
-    }
-  }
-
-  // eslint-disable-next-line consistent-return
-  function valueFromConfig2(a, b) {
-    if (!utils.isUndefined(b)) {
-      return getMergedValue(undefined, b);
-    }
-  }
-
-  // eslint-disable-next-line consistent-return
-  function defaultToConfig2(a, b) {
-    if (!utils.isUndefined(b)) {
-      return getMergedValue(undefined, b);
-    } else if (!utils.isUndefined(a)) {
-      return getMergedValue(undefined, a);
-    }
-  }
-
-  function getMergedTransitionalOption(prop) {
-    const transitional2 = utils.hasOwnProp(config2, 'transitional')
-      ? config2.transitional
-      : undefined;
-
-    if (!utils.isUndefined(transitional2)) {
-      if (utils.isPlainObject(transitional2)) {
-        if (utils.hasOwnProp(transitional2, prop)) {
-          return transitional2[prop];
-        }
-      } else {
-        return undefined;
-      }
-    }
-
-    const transitional1 = utils.hasOwnProp(config1, 'transitional')
-      ? config1.transitional
-      : undefined;
-
-    if (utils.isPlainObject(transitional1) && utils.hasOwnProp(transitional1, prop)) {
-      return transitional1[prop];
-    }
-
-    return undefined;
-  }
-
-  // eslint-disable-next-line consistent-return
-  function mergeDirectKeys(a, b, prop) {
-    if (utils.hasOwnProp(config2, prop)) {
-      return getMergedValue(a, b);
-    } else if (utils.hasOwnProp(config1, prop)) {
-      return getMergedValue(undefined, a);
-    }
-  }
-
-  const mergeMap = {
-    url: valueFromConfig2,
-    method: valueFromConfig2,
-    data: valueFromConfig2,
-    baseURL: defaultToConfig2,
-    transformRequest: defaultToConfig2,
-    transformResponse: defaultToConfig2,
-    paramsSerializer: defaultToConfig2,
-    timeout: defaultToConfig2,
-    timeoutErrorMessage: defaultToConfig2,
-    withCredentials: defaultToConfig2,
-    withXSRFToken: defaultToConfig2,
-    adapter: defaultToConfig2,
-    responseType: defaultToConfig2,
-    xsrfCookieName: defaultToConfig2,
-    xsrfHeaderName: defaultToConfig2,
-    onUploadProgress: defaultToConfig2,
-    onDownloadProgress: defaultToConfig2,
-    decompress: defaultToConfig2,
-    maxContentLength: defaultToConfig2,
-    maxBodyLength: defaultToConfig2,
-    beforeRedirect: defaultToConfig2,
-    transport: defaultToConfig2,
-    httpAgent: defaultToConfig2,
-    httpsAgent: defaultToConfig2,
-    cancelToken: defaultToConfig2,
-    socketPath: defaultToConfig2,
-    allowedSocketPaths: defaultToConfig2,
-    responseEncoding: defaultToConfig2,
-    validateStatus: mergeDirectKeys,
-    headers: (a, b, prop) =>
-      mergeDeepProperties(headersToObject(a), headersToObject(b), prop, true),
-  };
-
-  utils.forEach(ownEnumerableKeys({ ...config1, ...config2 }), function computeConfigValue(prop) {
-    if (prop === '__proto__' || prop === 'constructor' || prop === 'prototype') return;
+  for (let i = 0, len = keys.length; i < len; i++) {
+    const prop = keys[i];
+    if (prop === '__proto__' || prop === 'constructor' || prop === 'prototype') continue;
     const merge = utils.hasOwnProp(mergeMap, prop) ? mergeMap[prop] : mergeDeepProperties;
     const a = utils.hasOwnProp(config1, prop) ? config1[prop] : undefined;
     const b = utils.hasOwnProp(config2, prop) ? config2[prop] : undefined;
-    const configValue = merge(a, b, prop);
+    const configValue =
+      merge === mergeDirectKeys ? merge(a, b, prop, config1, config2) : merge(a, b, prop);
     (utils.isUndefined(configValue) && merge !== mergeDirectKeys) || (config[prop] = configValue);
-  });
+  }
 
   if (
     utils.hasOwnProp(config2, 'validateStatus') &&
     utils.isUndefined(config2.validateStatus) &&
-    getMergedTransitionalOption('validateStatusUndefinedResolves') === false
+    getMergedTransitionalOption(config1, config2, 'validateStatusUndefinedResolves') === false
   ) {
     if (utils.hasOwnProp(config1, 'validateStatus')) {
       config.validateStatus = getMergedValue(undefined, config1.validateStatus);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -587,15 +587,30 @@ const isContextDefined = (context) => !isUndefined(context) && context !== _glob
 function merge(...objs) {
   const { caseless, skipUndefined } = (isContextDefined(this) && this) || {};
   const result = {};
+  // Caseless lookup only applies to string keys — symbol keys are
+  // identity-matched. Every string key that reaches `result` passes through
+  // this index first, so it can never hold two case variants of one key and a
+  // lowercase -> key map is exactly what findKey(result, key) would rescan
+  // Object.keys(result) for on each assignment.
+  const lowerCaseKeys = caseless ? Object.create(null) : null;
   const assignValue = (val, key) => {
     // Skip dangerous property names to prevent prototype pollution
     if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
       return;
     }
 
-    // findKey lowercases the key, so caseless lookup only applies to strings —
-    // symbol keys are identity-matched.
-    const targetKey = (caseless && typeof key === 'string' && findKey(result, key)) || key;
+    let targetKey = key;
+    if (lowerCaseKeys && typeof key === 'string') {
+      const lowerKey = key.toLowerCase();
+      const knownKey = lowerCaseKeys[lowerKey];
+      // A key recorded but absent from `result` was skipped by skipUndefined;
+      // the later spelling wins then, as it does for findKey.
+      if (knownKey !== undefined && hasOwnProperty(result, knownKey)) {
+        targetKey = knownKey;
+      } else {
+        lowerCaseKeys[lowerKey] = key;
+      }
+    }
     // Read via own-prop only — a bare `result[targetKey]` walks the prototype
     // chain, so a polluted Object.prototype value could surface here and get
     // copied into the merged result.

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -313,11 +313,17 @@ const isPlainObject = (val) => {
   const prototype = getPrototypeOf(val);
   return (
     (prototype === null || prototype === Object.prototype || getPrototypeOf(prototype) === null) &&
-    // Treat safe own/inherited Symbol.toStringTag or Symbol.iterator members as
-    // evidence the value is tagged/iterable, while ignoring members reachable
-    // only through shared or terminal prototype boundaries.
-    !hasOwnInPrototypeChain(val, toStringTag) &&
-    !hasOwnInPrototypeChain(val, iterator)
+    // Treat own Symbol.toStringTag or Symbol.iterator members as evidence the
+    // value is tagged/iterable, ignoring members reachable only through shared
+    // or terminal prototype boundaries. This is exactly what
+    // hasOwnInPrototypeChain(val, prop) computes here: every prototype admitted
+    // above (null, Object.prototype, or a terminal null-prototype template) is
+    // a boundary, so the walk never inspects anything but `val`'s own members,
+    // and stops before even those when `val` is itself the boundary
+    // Object.prototype. Checking that inline avoids allocating the walker's
+    // `seen` list twice per call on the mergeConfig / merge hot path.
+    (isPrototypeBoundary(val, prototype, true) ||
+      (!hasOwnProperty(val, toStringTag) && !hasOwnProperty(val, iterator)))
   );
 };
 

--- a/tests/unit/utils/isX.test.js
+++ b/tests/unit/utils/isX.test.js
@@ -237,4 +237,106 @@ describe('utils::isX', () => {
     expect(utils.isTypedArray(new Uint8Array([1, 2, 3]))).toEqual(true);
     expect(utils.isTypedArray([1, 2, 3])).toEqual(false);
   });
+
+  describe('isPlainObject prototype boundaries', () => {
+    const withPollutedObjectPrototype = (symbol, descriptor, fn) => {
+      const original = Object.getOwnPropertyDescriptor(Object.prototype, symbol);
+
+      try {
+        Object.defineProperty(Object.prototype, symbol, descriptor);
+        fn();
+      } finally {
+        if (original) {
+          Object.defineProperty(Object.prototype, symbol, original);
+        } else {
+          delete Object.prototype[symbol];
+        }
+      }
+    };
+
+    it('should treat Object.prototype itself as a plain object', () => {
+      expect(utils.isPlainObject(Object.prototype)).toEqual(true);
+    });
+
+    it('should keep Object.prototype a fail-closed boundary when it carries an own Symbol.iterator', () => {
+      withPollutedObjectPrototype(
+        Symbol.iterator,
+        { value: undefined, configurable: true, writable: true },
+        () => {
+          expect(utils.isPlainObject(Object.prototype)).toEqual(true);
+          expect(utils.isPlainObject({})).toEqual(true);
+          expect(utils.isPlainObject(Object.create(null))).toEqual(true);
+          expect(utils.isPlainObject({ [Symbol.iterator]: function* () {} })).toEqual(false);
+        }
+      );
+    });
+
+    it('should keep Object.prototype a fail-closed boundary when it carries an own Symbol.toStringTag', () => {
+      withPollutedObjectPrototype(
+        Symbol.toStringTag,
+        { value: 'Custom', configurable: true, writable: true },
+        () => {
+          expect(utils.isPlainObject(Object.prototype)).toEqual(true);
+          expect(utils.isPlainObject({})).toEqual(true);
+          expect(utils.isPlainObject(Object.create(null))).toEqual(true);
+          expect(utils.isPlainObject({ [Symbol.toStringTag]: 'Own' })).toEqual(false);
+        }
+      );
+    });
+
+    it('should not read a polluted Object.prototype iterator accessor', () => {
+      let accessed = false;
+
+      withPollutedObjectPrototype(
+        Symbol.iterator,
+        {
+          configurable: true,
+          get() {
+            accessed = true;
+            throw new Error('polluted iterator accessor');
+          },
+        },
+        () => {
+          expect(utils.isPlainObject({})).toEqual(true);
+          expect(utils.isPlainObject(Object.prototype)).toEqual(true);
+          expect(accessed).toEqual(false);
+        }
+      );
+    });
+
+    it('should reject own symbol members on null-prototype objects', () => {
+      const tagged = Object.create(null);
+      tagged[Symbol.toStringTag] = 'Tagged';
+      const iterable = Object.create(null);
+      iterable[Symbol.iterator] = function* () {};
+
+      expect(utils.isPlainObject(Object.create(null))).toEqual(true);
+      expect(utils.isPlainObject(tagged)).toEqual(false);
+      expect(utils.isPlainObject(iterable)).toEqual(false);
+    });
+
+    it('should ignore symbol members inherited from a terminal null-prototype parent', () => {
+      const parent = Object.create(null);
+      parent[Symbol.toStringTag] = 'Parent';
+      parent[Symbol.iterator] = function* () {};
+      const child = Object.create(parent);
+      const ownIterable = Object.create(parent);
+      ownIterable[Symbol.iterator] = function* () {};
+
+      expect(utils.isPlainObject(child)).toEqual(true);
+      expect(utils.isPlainObject(ownIterable)).toEqual(false);
+    });
+
+    it('should reject class instances, deeper prototype chains and built-ins', () => {
+      class Klass {}
+
+      expect(utils.isPlainObject(new Klass())).toEqual(false);
+      expect(utils.isPlainObject(Object.create(Object.create(null)))).toEqual(true);
+      expect(utils.isPlainObject(Object.create(Object.create({})))).toEqual(false);
+      expect(utils.isPlainObject([])).toEqual(false);
+      expect(utils.isPlainObject(new Map())).toEqual(false);
+      expect(utils.isPlainObject(Buffer.from('x'))).toEqual(false);
+      expect(utils.isPlainObject(Object.freeze({}))).toEqual(true);
+    });
+  });
 });

--- a/tests/unit/utils/merge.test.js
+++ b/tests/unit/utils/merge.test.js
@@ -168,4 +168,56 @@ describe('utils::merge', () => {
 
     expect(merged[key]).toBe('first');
   });
+
+  it('should keep the first spelling of a caseless key across many sources', () => {
+    const merged = merge.call(
+      { caseless: true },
+      { 'Content-Type': 'a', Accept: 'x' },
+      { 'content-type': 'b' },
+      { 'CONTENT-TYPE': 'c', accept: 'y' }
+    );
+
+    expect(merged).toEqual({ 'Content-Type': 'c', Accept: 'y' });
+    expect(Object.keys(merged)).toEqual(['Content-Type', 'Accept']);
+  });
+
+  it('should keep caseless keys distinct from same-cased keys within one source', () => {
+    const merged = merge.call({ caseless: true }, { foo: 1, FOO: 2, bar: 3 });
+
+    expect(merged).toEqual({ foo: 2, bar: 3 });
+  });
+
+  it('should merge nested objects case-sensitively under a caseless top level', () => {
+    const merged = merge.call(
+      { caseless: true },
+      { headers: { Accept: 'a' } },
+      { HEADERS: { accept: 'b' } }
+    );
+
+    expect(merged).toEqual({ headers: { Accept: 'a', accept: 'b' } });
+  });
+
+  it('should let a later spelling win when skipUndefined dropped the earlier caseless key', () => {
+    const merged = merge.call(
+      { caseless: true, skipUndefined: true },
+      { 'X-Token': undefined },
+      { 'x-token': 'set' }
+    );
+
+    expect(merged).toEqual({ 'x-token': 'set' });
+    expect(merged['X-Token']).toBeUndefined();
+  });
+
+  it('should still filter unsafe keys in caseless mode regardless of casing', () => {
+    const merged = merge.call(
+      { caseless: true },
+      JSON.parse('{"__proto__": {"polluted": true}, "Constructor": 1, "PROTOTYPE": 2, "safe": 3}')
+    );
+
+    expect(merged.safe).toBe(3);
+    expect(merged.Constructor).toBe(1);
+    expect(merged.PROTOTYPE).toBe(2);
+    expect(Object.prototype.polluted).toBeUndefined();
+    expect(Object.getPrototypeOf(merged)).toBe(Object.prototype);
+  });
 });

--- a/tests/unit/utils/merge.test.js
+++ b/tests/unit/utils/merge.test.js
@@ -208,7 +208,7 @@ describe('utils::merge', () => {
     expect(merged['X-Token']).toBeUndefined();
   });
 
-  it('should still filter unsafe keys in caseless mode regardless of casing', () => {
+  it('should filter exact unsafe keys and preserve differently cased keys in caseless mode', () => {
     const merged = merge.call(
       { caseless: true },
       JSON.parse('{"__proto__": {"polluted": true}, "Constructor": 1, "PROTOTYPE": 2, "safe": 3}')


### PR DESCRIPTION
## Summary

Reduce the CPU cost of merging request configuration, especially for requests with many headers. `mergeConfig` runs once for `axios(config)` and twice for method aliases.

In saved local measurements, a typical request using a no-I/O adapter decreased from **36.2 to 31.5 microseconds**, and a header-heavy request from **259.6 to 186.3 microseconds**. These measure Axios request processing, excluding network I/O.

## Linked issue

https://github.com/axios/axios/issues/11207

## Changes

- Replace redundant `isPlainObject` prototype walks with own-symbol checks after the existing prototype eligibility check, preserving shared/terminal prototype boundaries, including `Object.prototype` itself.
- Index lowercase string keys during caseless merges instead of repeatedly scanning `Object.keys(result)`. Symbol keys still match by identity; skipped undefined values do not reserve the earlier spelling.
- Reuse stateless merge strategies and the null-prototype property descriptor. Strategies that need the input configs receive them explicitly.
- Add 12 regression cases and an unreleased changelog entry.

The exact unsafe property names remain filtered, and config reads remain guarded by own-property checks. Differently cased names such as `Constructor` retain their previous behavior. Existing transitional `validateStatus` behavior is preserved.

Two internal observable changes deserve review: stateful Proxy traps see fewer prototype lookups, and the `hasOwnProperty` function installed on returned configs is captured at module initialization rather than reread after later monkeypatches. The public API and type declarations are unchanged.

## Validation

Fresh pre-submission checks on the submitted source:

```text
npx vitest run --project unit tests/unit/utils/isX.test.js tests/unit/utils/merge.test.js tests/unit/core/mergeConfig.test.js tests/unit/axiosHeaders.test.js tests/unit/prototypePollution.test.js tests/unit/core/Axios.test.js tests/unit/core/dispatchRequest.test.js tests/unit/utils.test.js
Test Files  8 passed (8)
Tests       287 passed (287)

node node_modules/eslint/bin/eslint.js lib/utils.js lib/core/mergeConfig.js tests/unit/utils/isX.test.js tests/unit/utils/merge.test.js
exit 0
```

Saved checks from the original development/verification runs on the same executable source:

- Full unit suite: baseline 1,062 passed; change 1,074 passed.
- Differential checks: 665 plain-object cases across prototype-pollution states, 30,041 caseless-merge cases, and 5,040 config-merging cases, including reentrant calls.
- The only subsequent edits correct a source comment, clarify one test title, and add the changelog entry. Browser suites were not rerun for this submission.

## Measurements

Node 24.15.0, Windows 11, i5-12600KF; alternating fresh processes, seven samples per variant for the original run. An independent five-process verification run reproduced the typical/header-heavy gains. Both ran under concurrent machine load; the verification A/A noise was within 3.4%. These are observations on one machine, not guarantees across runtimes.

| No-I/O request case | Original baseline -> change (microseconds) | Independent baseline -> change (microseconds) |
| --- | ---: | ---: |
| Typical POST | 36.2 -> 31.5 | 38.0 -> 31.9 |
| 20 default + 20 request headers | 259.6 -> 186.3 | 261.6 -> 192.4 |

The minimal GET result overlapped the measurement noise and is not claimed as an improvement. The original scripts and raw samples remain in the local review packet; the full request benchmark is reproduced below so the workload can be rerun without that packet.

<details>
<summary>Request benchmark</summary>

```javascript
// Macro benchmark: the full axios request pipeline (config merge, interceptors,
// header normalization, transforms, response wrapping) with a no-I/O adapter,
// so the number is axios' own CPU cost per request, independent of the network.
// Usage: AXIOS_ROOT=<path to axios checkout> node pipeline_macro.mjs [case]
// Prints one JSON line per case: {case, us_per_req, reqs, samples_ns:[...]}
import path from 'node:path';
import { pathToFileURL } from 'node:url';

const root = process.env.AXIOS_ROOT;
if (!root) throw new Error('AXIOS_ROOT env var required');
const { default: axios } = await import(pathToFileURL(path.join(root, 'index.js')).href);

const responseHeaders = {
  'content-type': 'application/json; charset=utf-8',
  'content-length': '1234',
  date: 'Sat, 06 Sep 2026 01:00:00 GMT',
  'cache-control': 'no-cache, no-store',
  etag: '"abc123"',
  vary: 'Accept-Encoding',
  'x-request-id': 'f2d3a1b4',
  server: 'nginx',
  'strict-transport-security': 'max-age=31536000',
  'access-control-allow-origin': '*',
  'set-cookie': ['a=1; Path=/', 'b=2; Path=/'],
};
const body = '{"ok":true,"items":[1,2,3]}';
const adapter = (config) =>
  Promise.resolve({ data: body, status: 200, statusText: 'OK', headers: { ...responseHeaders }, config, request: {} });

// typical: instance with a few default headers, POST with params + a per-call header
const typical = axios.create({
  adapter,
  baseURL: 'http://localhost/api',
  headers: { 'X-Api-Key': 'k', Accept: 'application/json', 'X-Client': 'bench' },
});
// headers-heavy: instance + call each carry many headers (API gateways, tracing, auth)
const manyDefaultHeaders = Object.fromEntries(Array.from({ length: 20 }, (_, i) => ['X-Default-' + i, 'd' + i]));
const manyCallHeaders = Object.fromEntries(Array.from({ length: 20 }, (_, i) => ['x-call-' + i, 'c' + i]));
const heavy = axios.create({ adapter, baseURL: 'http://localhost/api', headers: manyDefaultHeaders });
// minimal: bare GET on the default instance with an adapter and nothing else
const minimal = axios.create({ adapter });

const cases = {
  typical: (i) =>
    typical.post('/items', { id: i, name: 'x' }, { params: { q: 'search term', page: i, tags: ['a', 'b'] }, headers: { 'X-Trace': String(i) } }),
  heavy: (i) => heavy.post('/items', { id: i }, { headers: manyCallHeaders }),
  minimal: (i) => minimal.get('/items/' + i),
};

const only = process.argv[2];
const REQS = +process.env.REQS || 15000;
const SAMPLES = +process.env.SAMPLES || 7;
for (const [name, fn] of Object.entries(cases)) {
  if (only && only !== name) continue;
  for (let i = 0; i < REQS; i++) await fn(i); // warmup (discarded)
  const samples = [];
  for (let s = 0; s < SAMPLES; s++) {
    const t0 = process.hrtime.bigint();
    for (let i = 0; i < REQS; i++) await fn(i);
    samples.push(Number(process.hrtime.bigint() - t0));
  }
  const sorted = samples.slice().sort((a, b) => a - b);
  const median = sorted[Math.floor(sorted.length / 2)];
  console.log(JSON.stringify({ case: name, us_per_req: median / REQS / 1000, reqs: REQS, samples_ns: samples }));
}

```

Run this script outside the checkout, setting `AXIOS_ROOT` to the baseline checkout and then to the PR checkout. Install each checkout's dependencies using `npm ci --ignore-scripts`. Alternate baseline/change in fresh Node processes and report the median across processes. On a hybrid CPU, pin both variants to the same logical processor for an additional controlled comparison.

</details>

#### Checklist

- [x] Tests added or updated.
- [x] No public API/type changes; unreleased changelog updated.
- [x] Internal observable changes are called out above.

AI assistance disclosure: implementation and review used Claude and Codex; the account owner authorized publication. This does not claim a separate human code review. :surfer:


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
## Description

Reduces the CPU cost of merging request configuration, most noticeably for requests with many headers. `mergeConfig` previously rebuilt its 30-entry strategy table and closures on every call, `isPlainObject` walked prototype chains twice per check, and caseless header merges rescanned `Object.keys()` for every assigned key. On one machine, measured request processing with a no-I/O adapter dropped from 36.2 µs to 31.5 µs for a typical POST and from 259.6 µs to 186.3 µs for a header-heavy POST.

- Hoists the stateless merge strategies and the null-prototype property descriptor to module scope; `mergeDirectKeys` is the only strategy needing the source configs and now receives them explicitly.
- Replaces `isPlainObject` prototype walks with inline own-symbol checks, preserving the fail-closed boundary behavior, including for `Object.prototype` itself.
- Indexes lowercase string keys during caseless merges instead of repeatedly scanning `Object.keys(result)`; symbol keys still match by identity and skipped undefined values keep their earlier spelling behavior.

Two internal observable changes to review: stateful Proxy traps now see fewer prototype lookups, and the `hasOwnProperty` installed on returned configs is captured at module initialization rather than reread after later monkeypatches. Public API and type declarations are unchanged, and exact unsafe key filtering plus differently cased names like `Constructor` behave as before. Addresses https://github.com/axios/axios/issues/11207.

## Docs

No documentation update needed — this is an internal performance change with no public behavior or type changes.

## Testing

12 regression cases added: prototype-boundary checks in `tests/unit/utils/isX.test.js` and caseless merge behavior in `tests/unit/utils/merge.test.js`. Targeted unit runs pass (287 tests across 8 files), lint passes on the touched files, and the full unit suite passed on the submitted source (1,074 tests). Differential checks covered 665 plain-object cases, 30,041 caseless-merge cases, and 5,040 config-merging cases, including reentrant calls.

## Semantic version impact

Patch change — no public API or type changes; the two internal observable behaviors are noted above.

<sup>Written for commit 6522b68c1e2bba99805381a6379e521f851f6e2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/axios/axios/pull/11208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

