### PR TITLE
fix(v0)!: address error handling, cancellation and header typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## Unreleased — next v0 minor
+
+These changes improve error handling, cancellation context, and request header typing.
+
+### ⚠️ Breaking Changes & Deprecations
+
+* **Header types:** TypeScript now rejects header values that are Promises, functions, or objects with custom `toString()` methods. Resolve promises, call functions, or explicitly convert objects before assigning header values. This narrows previously accepted types and must ship in the next v0 minor release under the pre-1.0 compatibility policy. (__#11209__)
+
+### 🚀 New Features
+
+* **Caller diagnostics:** Opt in with `captureCallerStack: true` on a request or instance to append caller frames to asynchronous errors. The default is off so successful requests avoid the additional stack capture and Promise reaction. (__#11209__)
+* **Cancellation context:** `CanceledError.reason` preserves `AbortSignal.reason`, including object and falsy values. Native and structural signals retain their identity and live getters across config merging. (__#11209__)
+
+### 🐛 Bug Fixes
+
+* **Error inheritance:** Axios loads alongside read-only `Error.prototype.toJSON` properties while preserving supplied own descriptors and setters. (__#11209__)
+* **Request interceptors:** Synchronous interceptor and dispatch failures reach response interceptors. Rejected recovery promises prevent dispatch; fulfilled recovery values are ignored and the last request config is retained. (__#11209__)
+
+[Full Changelog](https://github.com/axios/axios/pull/11209/files)
+
 ## v0.32.0 — May 4, 2026
 
 This release backports a comprehensive set of security and hardening fixes from the v1.x branch into v0.x, covering prototype-pollution protections, default error redaction, stricter proxy/cookie/socket handling, and one breaking change to merged config and header object prototypes.

--- a/README.md
+++ b/README.md
@@ -748,7 +748,17 @@ and when the response was fulfilled
 
 Read [the interceptor tests](./test/specs/interceptors.spec.js) for seeing all this in code.
 
+For synchronous request interceptors, a thrown error is passed to that interceptor's
+rejection handler, when supplied. If the handler is absent, throws, or returns a
+rejected promise, the request is rejected without being sent and response rejection
+interceptors can handle the failure. A promise returned by a recovery handler is
+awaited before dispatch. Successful synchronous interceptors still dispatch immediately.
+
 ## Handling Errors
+
+When an error is created asynchronously, Axios appends the captured request caller
+stack where the runtime supports textual stacks. The original error and its stack
+are preserved; the number of available frames depends on the runtime's stack settings.
 
 ```js
 axios.get('/user/12345')
@@ -807,6 +817,24 @@ axios.get('/foo/bar', {
 });
 // cancel the request
 controller.abort()
+```
+
+On runtimes that expose `AbortSignal.reason`, Axios preserves that value in
+`CanceledError.reason`, including objects and falsy values. Cancellation still uses
+the `canceled` message, `ERR_CANCELED` code, and `axios.isCancel()` detection. Signals
+without a reason continue to work and leave `error.reason` undefined.
+
+```js
+const controller = new AbortController();
+const reason = new Error('Replaced by a newer search');
+
+axios.get('/search', {signal: controller.signal}).catch(function (error) {
+  if (axios.isCancel(error) && error.reason === reason) {
+    // This request was superseded.
+  }
+});
+
+controller.abort(reason);
 ```
 
 ### CancelToken `👎deprecated`
@@ -1186,6 +1214,11 @@ axios depends on a native ES6 Promise implementation to be [supported](https://c
 If your environment doesn't support ES6 Promises, you can [polyfill](https://github.com/jakearchibald/es6-promise).
 
 ## TypeScript
+
+Request header values are strings, string arrays, numbers, or booleans. The
+`common` and method-specific header groups accept maps of these values. Resolve
+asynchronous values in a request interceptor before assigning them to headers;
+Promise and function values are rejected by the TypeScript declarations.
 
 axios includes [TypeScript](https://typescriptlang.org) definitions and a type guard for axios errors.
 

--- a/README.md
+++ b/README.md
@@ -519,6 +519,10 @@ These are the available config options for making requests. Only the `url` is re
   // an alternative way to cancel Axios requests using AbortController
   signal: new AbortController().signal,
 
+  // Capture the request caller for asynchronous error stacks (default: false).
+  // Enable on a request or instance when the extra diagnostics are needed.
+  captureCallerStack: false,
+
   // `decompress` indicates whether or not the response body should be decompressed
   // automatically. If set to `true` will also remove the 'content-encoding' header
   // from the responses objects of all decompressed responses
@@ -752,13 +756,26 @@ For synchronous request interceptors, a thrown error is passed to that intercept
 rejection handler, when supplied. If the handler is absent, throws, or returns a
 rejected promise, the request is rejected without being sent and response rejection
 interceptors can handle the failure. A promise returned by a recovery handler is
-awaited before dispatch. Successful synchronous interceptors still dispatch immediately.
+awaited before dispatch. Recovery return values, including fulfilled promise values,
+do not replace the last request config; that config is used for dispatch.
+Successful synchronous interceptors still dispatch immediately.
 
 ## Handling Errors
 
-When an error is created asynchronously, Axios appends the captured request caller
-stack where the runtime supports textual stacks. The original error and its stack
-are preserved; the number of available frames depends on the runtime's stack settings.
+Set `captureCallerStack: true` on a request or instance to append the original caller
+to errors created asynchronously. Stack capture is disabled by default because it
+adds work to every enabled request, including successful requests. When disabled,
+Axios keeps the error's existing stack without capturing additional caller frames.
+
+```js
+const client = axios.create({captureCallerStack: true});
+client.get('/user/12345');
+// An individual request can override the instance setting.
+client.get('/status', {captureCallerStack: false});
+```
+
+The original error and its existing stack are preserved when caller frames are
+appended. Availability and frame counts depend on the runtime's stack support and settings.
 
 ```js
 axios.get('/user/12345')
@@ -823,6 +840,8 @@ On runtimes that expose `AbortSignal.reason`, Axios preserves that value in
 `CanceledError.reason`, including objects and falsy values. Cancellation still uses
 the `canceled` message, `ERR_CANCELED` code, and `axios.isCancel()` detection. Signals
 without a reason continue to work and leave `error.reason` undefined.
+Native signals and plain objects implementing `GenericAbortSignal` are retained by
+reference when configurations are merged, preserving live getters and reason identity.
 
 ```js
 const controller = new AbortController();
@@ -1219,6 +1238,17 @@ Request header values are strings, string arrays, numbers, or booleans. The
 `common` and method-specific header groups accept maps of these values. Resolve
 asynchronous values in a request interceptor before assigning them to headers;
 Promise and function values are rejected by the TypeScript declarations.
+
+This is a TypeScript compatibility change for the next v0 minor release. Code that
+previously assigned a Promise, function, or object with a custom `toString()` method
+must first resolve the Promise, call the function, or explicitly convert the object
+to a supported header value. For example:
+
+```typescript
+async function requestWithToken(token: Promise<string>) {
+  return axios.get('/user', {headers: {Authorization: 'Bearer ' + await token}});
+}
+```
 
 axios includes [TypeScript](https://typescriptlang.org) definitions and a type guard for axios errors.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 // TypeScript Version: 4.1
 type HeaderValue = string | string[] | number | boolean;
 
-type AxiosHeaders = Record<string, HeaderValue | Record<Method & CommonHeaders, HeaderValue>>;
+type AxiosHeaders = Record<string, HeaderValue | Record<string, HeaderValue>>;
 
 type MethodsHeaders = {
   [Key in Method as Lowercase<Key>]: AxiosHeaders;
@@ -86,6 +86,7 @@ export interface TransitionalOptions {
 
 export interface GenericAbortSignal {
   aborted: boolean;
+  readonly reason?: unknown;
   onabort: ((...args: any) => any) | null;
   addEventListener: (...args: any) => any;
   removeEventListener: (...args: any) => any;
@@ -241,6 +242,7 @@ export class AxiosError<T = unknown, D = any> extends Error {
 }
 
 export class CanceledError<T> extends AxiosError<T> {
+  reason?: unknown;
 }
 
 export type AxiosPromise<T = any> = Promise<AxiosResponse<T>>;
@@ -251,6 +253,7 @@ export interface CancelStatic {
 
 export interface Cancel {
   message: string | undefined;
+  reason?: unknown;
 }
 
 export interface Canceler {

--- a/index.d.ts
+++ b/index.d.ts
@@ -169,6 +169,7 @@ export interface AxiosRequestConfig<D = any> {
   cancelToken?: CancelToken;
   decompress?: boolean;
   transitional?: TransitionalOptions;
+  captureCallerStack?: boolean;
   signal?: GenericAbortSignal;
   insecureHTTPParser?: boolean;
   env?: {

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -15,7 +15,7 @@ var zlib = require('zlib');
 var VERSION = require('./../env/data').version;
 var transitionalDefaults = require('../defaults/transitional');
 var AxiosError = require('../core/AxiosError');
-var CanceledError = require('../cancel/CanceledError');
+var canceledErrorFromSignal = require('../cancel/fromSignal');
 var platform = require('../platform');
 var fromDataURI = require('../helpers/fromDataURI');
 var stream = require('stream');
@@ -750,7 +750,7 @@ module.exports = function httpAdapter(config) {
         req.abort();
         reject(
           !cancel || cancel.type
-            ? new CanceledError(null, config, req)
+            ? canceledErrorFromSignal(config.signal, config, req)
             : cancel
         );
       };

--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -9,7 +9,7 @@ var parseHeaders = require('./../helpers/parseHeaders');
 var isURLSameOrigin = require('./../helpers/isURLSameOrigin');
 var transitionalDefaults = require('../defaults/transitional');
 var AxiosError = require('../core/AxiosError');
-var CanceledError = require('../cancel/CanceledError');
+var canceledErrorFromSignal = require('../cancel/fromSignal');
 var parseProtocol = require('../helpers/parseProtocol');
 var platform = require('../platform');
 
@@ -261,7 +261,7 @@ module.exports = function xhrAdapter(config) {
         }
         reject(
           !cancel || cancel.type
-            ? new CanceledError(null, config, request)
+            ? canceledErrorFromSignal(config.signal, config, request)
             : cancel
         );
         request.abort();

--- a/lib/cancel/fromSignal.js
+++ b/lib/cancel/fromSignal.js
@@ -1,0 +1,20 @@
+'use strict';
+
+var CanceledError = require('./CanceledError');
+
+module.exports = function fromSignal(signal, config, request) {
+  var error = new CanceledError(null, config, request);
+
+  if (signal) {
+    try {
+      var reason = signal.reason;
+      if (reason !== undefined) {
+        error.reason = reason;
+      }
+    } catch (e) {
+      // A custom signal getter must not prevent cancellation.
+    }
+  }
+
+  return error;
+};

--- a/lib/core/Axios.js
+++ b/lib/core/Axios.js
@@ -25,6 +25,10 @@ function captureCallerStack(boundary) {
 }
 
 function attachCallerStack(promise, caller) {
+  if (!caller) {
+    return promise;
+  }
+
   return promise.then(null, function onRequestRejected(error) {
     try {
       if (error instanceof Error || Object.prototype.toString.call(error) === '[object Error]') {
@@ -75,7 +79,6 @@ function Axios(instanceConfig) {
  * @param {?Object} config
  */
 Axios.prototype.request = function request(configOrUrl, config) {
-  var caller = captureCallerStack(request);
   /*eslint no-param-reassign:0*/
   // Allow for axios('example/url'[, config]) a la fetch API
   if (typeof configOrUrl === 'string') {
@@ -86,6 +89,7 @@ Axios.prototype.request = function request(configOrUrl, config) {
   }
 
   config = mergeConfig(this.defaults, config);
+  var caller = config.captureCallerStack === true ? captureCallerStack(request) : null;
 
   // Set config.method. The merged config is null-prototype, but instance
   // defaults may be an ordinary object, so the fallback is read as an own

--- a/lib/core/Axios.js
+++ b/lib/core/Axios.js
@@ -9,6 +9,52 @@ var buildFullPath = require('./buildFullPath');
 var validator = require('../helpers/validator');
 
 var validators = validator.validators;
+
+function captureCallerStack(boundary) {
+  var caller = {};
+  try {
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(caller, boundary);
+    } else {
+      caller = new Error();
+    }
+  } catch (e) {
+    // Stack hooks must not prevent a request from being sent.
+  }
+  return caller;
+}
+
+function attachCallerStack(promise, caller) {
+  return promise.then(null, function onRequestRejected(error) {
+    try {
+      if (error instanceof Error || Object.prototype.toString.call(error) === '[object Error]') {
+        // Capture at dispatch time, but only format the stack on failure.
+        // Capturing in this callback would lose callers using .then/.catch.
+        var stack = caller.stack;
+        if (typeof stack === 'string') {
+          var newline = stack.indexOf('\n');
+          stack = newline === -1 ? '' : stack.slice(newline + 1);
+          var original = error.stack;
+          if (stack && (original === undefined || original === null || original === '')) {
+            error.stack = stack;
+          } else if (stack && typeof original === 'string' && original.indexOf(stack) === -1) {
+            error.stack = original + '\n' + stack;
+          }
+        }
+      }
+    } catch (e) {
+      // Frozen errors and custom stack accessors must retain their rejection.
+    }
+    return Promise.reject(error);
+  });
+}
+
+function dispatchAfterRecovery(config) {
+  return function dispatchRecoveredRequest() {
+    return dispatchRequest(config);
+  };
+}
+
 /**
  * Create a new instance of Axios
  *
@@ -29,6 +75,7 @@ function Axios(instanceConfig) {
  * @param {?Object} config
  */
 Axios.prototype.request = function request(configOrUrl, config) {
+  var caller = captureCallerStack(request);
   /*eslint no-param-reassign:0*/
   // Allow for axios('example/url'[, config]) a la fetch API
   if (typeof configOrUrl === 'string') {
@@ -107,7 +154,7 @@ Axios.prototype.request = function request(configOrUrl, config) {
       promise = promise.then(chain.shift(), chain.shift());
     }
 
-    return promise;
+    return attachCallerStack(promise, caller);
   }
 
 
@@ -116,24 +163,39 @@ Axios.prototype.request = function request(configOrUrl, config) {
     var onFulfilled = requestInterceptorChain.shift();
     var onRejected = requestInterceptorChain.shift();
     try {
-      newConfig = onFulfilled(newConfig);
+      newConfig = onFulfilled ? onFulfilled(newConfig) : newConfig;
     } catch (error) {
-      onRejected(error);
+      if (!onRejected) {
+        promise = Promise.reject(error);
+        break;
+      }
+      try {
+        var recovery = onRejected(error);
+        if (recovery && typeof recovery.then === 'function') {
+          promise = Promise.resolve(recovery).then(dispatchAfterRecovery(newConfig));
+        }
+      } catch (rejectedError) {
+        promise = Promise.reject(rejectedError);
+      }
       break;
     }
   }
 
-  try {
-    promise = dispatchRequest(newConfig);
-  } catch (error) {
-    return Promise.reject(error);
+  if (!promise) {
+    try {
+      promise = dispatchRequest(newConfig);
+    } catch (error) {
+      // Dispatch errors, including pre-aborted signals, still go through the
+      // response interceptors registered below.
+      promise = Promise.reject(error);
+    }
   }
 
   while (responseInterceptorChain.length) {
     promise = promise.then(responseInterceptorChain.shift(), responseInterceptorChain.shift());
   }
 
-  return promise;
+  return attachCallerStack(promise, caller);
 };
 
 Axios.prototype.getUri = function getUri(config) {

--- a/lib/core/dispatchRequest.js
+++ b/lib/core/dispatchRequest.js
@@ -4,7 +4,7 @@ var utils = require('./../utils');
 var transformData = require('./transformData');
 var isCancel = require('../cancel/isCancel');
 var defaults = require('../defaults');
-var CanceledError = require('../cancel/CanceledError');
+var canceledErrorFromSignal = require('../cancel/fromSignal');
 var normalizeHeaderName = require('../helpers/normalizeHeaderName');
 var sanitizeHeaderValue = require('../helpers/sanitizeHeaderValue');
 
@@ -17,7 +17,7 @@ function throwIfCancellationRequested(config) {
   }
 
   if (config.signal && config.signal.aborted) {
-    throw new CanceledError();
+    throw canceledErrorFromSignal(config.signal, config);
   }
 }
 

--- a/lib/core/mergeConfig.js
+++ b/lib/core/mergeConfig.js
@@ -63,6 +63,11 @@ module.exports = function mergeConfig(config1, config2) {
     }
   }
 
+  function defaultToConfig2Reference(prop) {
+    var value = getOwn(config2, prop);
+    return utils.isUndefined(value) ? getOwn(config1, prop) : value;
+  }
+
   // eslint-disable-next-line consistent-return
   function mergeDirectKeys(prop) {
     if (hasOwn(config2, prop)) {
@@ -98,6 +103,8 @@ module.exports = function mergeConfig(config1, config2) {
     'httpAgent': defaultToConfig2,
     'httpsAgent': defaultToConfig2,
     'cancelToken': defaultToConfig2,
+    // Signals are live objects; cloning them snapshots getters and reasons.
+    'signal': defaultToConfig2Reference,
     'socketPath': defaultToConfig2,
     'allowedSocketPaths': defaultToConfig2,
     'responseEncoding': defaultToConfig2,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -414,7 +414,11 @@ function inherits(constructor, superConstructor, props, descriptors) {
     superConstructor.prototype,
     descriptors
   );
-  defineOwnProperty(constructor.prototype, 'constructor', constructor);
+  if (Object.prototype.hasOwnProperty.call(constructor.prototype, 'constructor')) {
+    constructor.prototype.constructor = constructor;
+  } else {
+    defineOwnProperty(constructor.prototype, 'constructor', constructor);
+  }
 
   if (props) {
     var keys = Object.keys(props);
@@ -424,9 +428,14 @@ function inherits(constructor, superConstructor, props, descriptors) {
       }));
     }
     keys.forEach(function(key) {
-      // Assignment would invoke an inherited setter or fail on a read-only
-      // property installed by another library, such as Error.prototype.toJSON.
-      defineOwnProperty(constructor.prototype, key, props[key]);
+      var value = props[key];
+      if (Object.prototype.hasOwnProperty.call(constructor.prototype, key)) {
+        constructor.prototype[key] = value;
+      } else {
+        // Assignment would invoke an inherited setter or fail on a read-only
+        // property installed by another library, such as Error.prototype.toJSON.
+        defineOwnProperty(constructor.prototype, key, value);
+      }
     });
   }
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -393,6 +393,15 @@ function stripBOM(content) {
   return content;
 }
 
+function defineOwnProperty(target, key, value) {
+  var descriptor = Object.create(null);
+  descriptor.value = value;
+  descriptor.writable = true;
+  descriptor.enumerable = true;
+  descriptor.configurable = true;
+  Object.defineProperty(target, key, descriptor);
+}
+
 /**
  * Inherit the prototype methods from one constructor into another
  * @param {function} constructor
@@ -400,14 +409,26 @@ function stripBOM(content) {
  * @param {object} [props]
  * @param {object} [descriptors]
  */
-
 function inherits(constructor, superConstructor, props, descriptors) {
   constructor.prototype = Object.create(
     superConstructor.prototype,
     descriptors
   );
-  constructor.prototype.constructor = constructor;
-  props && Object.assign(constructor.prototype, props);
+  defineOwnProperty(constructor.prototype, 'constructor', constructor);
+
+  if (props) {
+    var keys = Object.keys(props);
+    if (Object.getOwnPropertySymbols) {
+      keys = keys.concat(Object.getOwnPropertySymbols(props).filter(function(key) {
+        return Object.prototype.propertyIsEnumerable.call(props, key);
+      }));
+    }
+    keys.forEach(function(key) {
+      // Assignment would invoke an inherited setter or fail on a read-only
+      // property installed by another library, such as Error.prototype.toJSON.
+      defineOwnProperty(constructor.prototype, key, props[key]);
+    });
+  }
 }
 
 /**

--- a/test/specs/cancel.spec.js
+++ b/test/specs/cancel.spec.js
@@ -115,4 +115,52 @@ describe('cancel', function() {
       }, 0);
     });
   });
+
+  describe('abort reasons', function () {
+    function createController() {
+      return new (window.AbortController || _AbortController)();
+    }
+
+    function abortWithReason(controller, reason) {
+      if (!('reason' in controller.signal)) {
+        Object.defineProperty(controller.signal, 'reason', {value: reason});
+      }
+      controller.abort(reason);
+    }
+
+    function expectCancellation(error, reason) {
+      expect(axios.isCancel(error)).toBe(true);
+      expect(error.code).toBe('ERR_CANCELED');
+      expect(error.message).toBe('canceled');
+      expect(error.reason).toBe(reason);
+    }
+
+    [new Error('timeout'), 'superseded', {operation: 'search'}, null, false, 0, ''].forEach(function (reason, index) {
+      it('retains pre-aborted reason ' + index, function (done) {
+        var controller = createController();
+        abortWithReason(controller, reason);
+        axios.get('/foo', {signal: controller.signal}).then(function () {
+          done.fail('Expected cancellation');
+        }, function (error) {
+          expectCancellation(error, reason);
+          expect(jasmine.Ajax.requests.count()).toBe(0);
+          done();
+        });
+      });
+
+      it('retains in-flight reason ' + index, function (done) {
+        var controller = createController();
+        axios.get('/foo', {signal: controller.signal}).then(function () {
+          done.fail('Expected cancellation');
+        }, function (error) {
+          expectCancellation(error, reason);
+          done();
+        });
+        getAjaxRequest().then(function (request) {
+          abortWithReason(controller, reason);
+          expect(request.statusText).toBe('abort');
+        });
+      });
+    });
+  });
 });

--- a/test/specs/cancel.spec.js
+++ b/test/specs/cancel.spec.js
@@ -150,16 +150,18 @@ describe('cancel', function() {
 
       it('retains in-flight reason ' + index, function (done) {
         var controller = createController();
-        axios.get('/foo', {signal: controller.signal}).then(function () {
-          done.fail('Expected cancellation');
+        var cancellation = axios.get('/foo', {signal: controller.signal}).then(function () {
+          throw new Error('Expected cancellation');
         }, function (error) {
           expectCancellation(error, reason);
-          done();
         });
-        getAjaxRequest().then(function (request) {
+        var requestPromise = getAjaxRequest().then(function (request) {
           abortWithReason(controller, reason);
-          expect(request.statusText).toBe('abort');
+          return request;
         });
+        Promise.all([cancellation, requestPromise]).then(function (results) {
+          expect(results[1].statusText).toBe('abort');
+        }).then(done, done.fail);
       });
     });
   });

--- a/test/specs/cancel.spec.js
+++ b/test/specs/cancel.spec.js
@@ -135,34 +135,65 @@ describe('cancel', function() {
       expect(error.reason).toBe(reason);
     }
 
-    [new Error('timeout'), 'superseded', {operation: 'search'}, null, false, 0, ''].forEach(function (reason, index) {
-      it('retains pre-aborted reason ' + index, function (done) {
-        var controller = createController();
-        abortWithReason(controller, reason);
-        axios.get('/foo', {signal: controller.signal}).then(function () {
-          done.fail('Expected cancellation');
-        }, function (error) {
-          expectCancellation(error, reason);
-          expect(jasmine.Ajax.requests.count()).toBe(0);
-          done();
-        });
-      });
+    function wrapSignal(signal) {
+      return {
+        get aborted() { return signal.aborted; },
+        get reason() { return signal.reason; },
+        onabort: null,
+        addEventListener: function () { return signal.addEventListener.apply(signal, arguments); },
+        removeEventListener: function () { return signal.removeEventListener.apply(signal, arguments); }
+      };
+    }
 
-      it('retains in-flight reason ' + index, function (done) {
-        var controller = createController();
-        var cancellation = axios.get('/foo', {signal: controller.signal}).then(function () {
-          throw new Error('Expected cancellation');
-        }, function (error) {
-          expectCancellation(error, reason);
-        });
-        var requestPromise = getAjaxRequest().then(function (request) {
+    [false, true].forEach(function (structural) {
+      [new Error('timeout'), 'superseded', {operation: 'search'}, null, false, 0, ''].forEach(function (reason, index) {
+        var kind = structural ? 'structural' : 'native';
+        it('retains pre-aborted reason ' + index + ' with a ' + kind + ' signal', function (done) {
+          var controller = createController();
+          var signal = structural ? wrapSignal(controller.signal) : controller.signal;
           abortWithReason(controller, reason);
-          return request;
+          axios.get('/foo', {signal: signal}).then(function () {
+            done.fail('Expected cancellation');
+          }, function (error) {
+            expectCancellation(error, reason);
+            expect(jasmine.Ajax.requests.count()).toBe(0);
+            done();
+          });
         });
-        Promise.all([cancellation, requestPromise]).then(function (results) {
-          expect(results[1].statusText).toBe('abort');
-        }).then(done, done.fail);
+
+        it('retains in-flight reason ' + index + ' with a ' + kind + ' signal', function (done) {
+          var controller = createController();
+          var signal = structural ? wrapSignal(controller.signal) : controller.signal;
+          var cancellation = axios.get('/foo', {signal: signal}).then(function () {
+            throw new Error('Expected cancellation');
+          }, function (error) {
+            expectCancellation(error, reason);
+          });
+          var requestPromise = getAjaxRequest().then(function (request) {
+            abortWithReason(controller, reason);
+            return request;
+          });
+          Promise.all([cancellation, requestPromise]).then(function (results) {
+            expect(results[1].statusText).toBe('abort');
+          }).then(done, done.fail);
+        });
       });
+    });
+
+    it('cancels a structural signal whose reason getter throws', function (done) {
+      var signal = {
+        aborted: true,
+        get reason() { throw new Error('custom reason getter'); },
+        onabort: null,
+        addEventListener: function () {},
+        removeEventListener: function () {}
+      };
+      axios.get('/foo', {signal: signal}).then(function () {
+        throw new Error('Expected cancellation');
+      }, function (error) {
+        expectCancellation(error, undefined);
+        expect(jasmine.Ajax.requests.count()).toBe(0);
+      }).then(done, done.fail);
     });
   });
 });

--- a/test/specs/core/mergeConfig.spec.js
+++ b/test/specs/core/mergeConfig.spec.js
@@ -16,6 +16,32 @@ describe('core::mergeConfig', function() {
     expect(merged.headers).not.toBe(defaults.headers);
   });
 
+  describe('signal references', function () {
+    it('preserves the selected signal instead of cloning or combining it', function () {
+      var original = {aborted: false, reason: {operation: 'original'}};
+      var replacement = {aborted: true, reason: {operation: 'replacement'}};
+      expect(mergeConfig({signal: original}, {}).signal).toBe(original);
+      expect(mergeConfig({signal: original}, {signal: undefined}).signal).toBe(original);
+      expect(mergeConfig({signal: original}, {signal: replacement}).signal).toBe(replacement);
+      expect(mergeConfig({signal: original}, {signal: null}).signal).toBe(null);
+    });
+
+    it('ignores inherited signals on defaults and requests', function () {
+      var original = {aborted: false};
+      var inherited = Object.create({signal: {aborted: true}});
+      expect(mergeConfig(inherited, {}).signal).toBeUndefined();
+      expect(mergeConfig({signal: original}, inherited).signal).toBe(original);
+    });
+
+    it('does not evaluate signal accessors during merging', function () {
+      var signal = {};
+      Object.defineProperty(signal, 'reason', {enumerable: true, get: function () {
+        throw new Error('reason must stay lazy');
+      }});
+      expect(mergeConfig({}, {signal: signal}).signal).toBe(signal);
+    });
+  });
+
   it('should allow setting request options', function() {
     var config = {
       url: '__sample url__',

--- a/test/specs/interceptors.spec.js
+++ b/test/specs/interceptors.spec.js
@@ -167,6 +167,60 @@ describe('interceptors', function () {
     });
   });
 
+  it('passes synchronous request failures to response interceptors without sending XHR', function (done) {
+    var failure = new Error('request interceptor failed');
+    axios.interceptors.request.use(function () { throw failure; }, undefined, {synchronous: true});
+    axios.interceptors.response.use(undefined, function (error) {
+      expect(error).toBe(failure);
+      return {data: 'recovered'};
+    });
+    axios.get('/foo').then(function (response) {
+      expect(response.data).toBe('recovered');
+      expect(jasmine.Ajax.requests.count()).toBe(0);
+      done();
+    }, done.fail);
+  });
+
+  it('does not send XHR when a synchronous rejection handler returns a rejected promise', function (done) {
+    var failure = new Error('request interceptor failed');
+    axios.interceptors.request.use(function () { throw failure; }, function (error) {
+      return Promise.reject(error);
+    }, {synchronous: true});
+    axios.get('/foo').then(function () { done.fail('Expected rejection'); }, function (error) {
+      expect(error).toBe(failure);
+      expect(jasmine.Ajax.requests.count()).toBe(0);
+      done();
+    });
+  });
+
+  it('routes pre-cancellation through response interceptors', function (done) {
+    var source = axios.CancelToken.source();
+    source.cancel('already canceled');
+    axios.interceptors.response.use(undefined, function (error) {
+      expect(error).toBe(source.token.reason);
+      return {data: 'canceled'};
+    });
+    axios.get('/foo', {cancelToken: source.token}).then(function (response) {
+      expect(response.data).toBe('canceled');
+      expect(jasmine.Ajax.requests.count()).toBe(0);
+      done();
+    }, done.fail);
+  });
+
+  it('appends the original caller to asynchronous adapter errors', function (done) {
+    function namedBrowserCaller() {
+      return axios.get('/foo', {adapter: function () {
+        return new Promise(function (resolve, reject) {
+          setTimeout(function () { reject(new Error('adapter failure')); }, 0);
+        });
+      }});
+    }
+    namedBrowserCaller().then(function () { done.fail('Expected rejection'); }, function (error) {
+      expect(error.stack).toContain('namedBrowserCaller');
+      done();
+    });
+  });
+
   it('should add a request interceptor that returns a new config object', function (done) {
     axios.interceptors.request.use(function () {
       return {

--- a/test/specs/interceptors.spec.js
+++ b/test/specs/interceptors.spec.js
@@ -209,7 +209,7 @@ describe('interceptors', function () {
 
   it('appends the original caller to asynchronous adapter errors', function (done) {
     function namedBrowserCaller() {
-      return axios.get('/foo', {adapter: function () {
+      return axios.get('/foo', {captureCallerStack: true, adapter: function () {
         return new Promise(function (resolve, reject) {
           setTimeout(function () { reject(new Error('adapter failure')); }, 0);
         });

--- a/test/typescript/axios.ts
+++ b/test/typescript/axios.ts
@@ -30,6 +30,7 @@ const config: AxiosRequestConfig = {
   },
   data: { foo: 'bar' },
   timeout: 10000,
+  captureCallerStack: true,
   withCredentials: true,
   auth: {
     username: 'janedoe',
@@ -455,6 +456,10 @@ axios.toFormData({x: 1}, new FormData());
 // AbortSignal
 
 axios.get('/user', {signal: new AbortController().signal});
+
+axios.create({captureCallerStack: true}).get('/user', {captureCallerStack: false});
+// $ExpectError
+axios.get('/user', {captureCallerStack: 'true'});
 
 const reasonSignal: GenericAbortSignal = {
   aborted: true,

--- a/test/typescript/axios.ts
+++ b/test/typescript/axios.ts
@@ -1,9 +1,12 @@
 import axios, {
   AxiosRequestConfig,
+  AxiosRequestHeaders,
   AxiosResponse,
   AxiosError,
   AxiosInstance,
   AxiosAdapter,
+  CanceledError,
+  GenericAbortSignal,
   Cancel,
   CancelToken,
   CancelTokenSource,
@@ -287,6 +290,41 @@ instance1.defaults.timeout = 2500;
 
 axios.create({ headers: { foo: 'bar' } });
 axios.create({ headers: { common: { foo: 'bar' } } });
+
+const validHeaders: AxiosRequestHeaders = {
+  string: 'value',
+  strings: ['one', 'two'],
+  number: 42,
+  boolean: false,
+  optional: undefined,
+  common: {Authorization: 'token'},
+  get: {'X-Method': 'get'},
+  post: {'Content-Type': 'application/json'}
+};
+axios.create({headers: validHeaders});
+
+// $ExpectError
+const promiseHeaders: AxiosRequestHeaders = {'X-Invalid': Promise.resolve('value')};
+// $ExpectError
+const functionHeaders: AxiosRequestHeaders = {'X-Invalid': () => 'value'};
+// $ExpectError
+const nestedPromiseHeaders: AxiosRequestHeaders = {common: {'X-Invalid': Promise.resolve('value')}};
+// $ExpectError
+const methodPromiseHeaders: AxiosRequestHeaders = {post: {'X-Invalid': Promise.resolve('value')}};
+
+axios.interceptors.request.use(requestConfig => {
+  if (requestConfig.headers) {
+    // $ExpectError
+    requestConfig.headers.someCustomHeader = Promise.resolve('foo');
+  }
+  return requestConfig;
+});
+
+// $ExpectError
+axios.defaults.headers.common['X-Invalid'] = Promise.resolve('value');
+// $ExpectError
+instance1.defaults.headers.post['X-Invalid'] = () => 'value';
+
 axios.create({
   headers: {
     'Content-Type': 'application/json',
@@ -417,3 +455,20 @@ axios.toFormData({x: 1}, new FormData());
 // AbortSignal
 
 axios.get('/user', {signal: new AbortController().signal});
+
+const reasonSignal: GenericAbortSignal = {
+  aborted: true,
+  reason: {operation: 'search'},
+  onabort: null,
+  addEventListener: () => {},
+  removeEventListener: () => {}
+};
+axios.get('/user', {signal: reasonSignal}).catch((error: unknown) => {
+  if (axios.isCancel(error)) {
+    const reason: unknown = error.reason;
+    console.log(reason);
+  }
+});
+
+const canceledError: CanceledError<unknown> = new CanceledError('canceled');
+const cancellationReason: unknown = canceledError.reason;

--- a/test/unit/cancel/reason.js
+++ b/test/unit/cancel/reason.js
@@ -16,6 +16,16 @@ function abort(controller, reason) {
   controller.abort(reason);
 }
 
+function wrapSignal(signal) {
+  return {
+    get aborted() { return signal.aborted; },
+    get reason() { return signal.reason; },
+    onabort: null,
+    addEventListener: function () { return signal.addEventListener.apply(signal, arguments); },
+    removeEventListener: function () { return signal.removeEventListener.apply(signal, arguments); }
+  };
+}
+
 describe('AbortSignal cancellation reasons', function () {
   var reasons = [new Error('timeout'), 'superseded', {operation: 'search'}, null, false, 0, ''];
 
@@ -63,6 +73,56 @@ describe('AbortSignal cancellation reasons', function () {
     });
   });
 
+  it('preserves a structural signal and circular reason in instance defaults', function () {
+    var reason = {};
+    reason.self = reason;
+    var signal = {
+      aborted: true,
+      reason: reason,
+      onabort: null,
+      addEventListener: function () {},
+      removeEventListener: function () {}
+    };
+    var instance = axios.create({signal: signal});
+    assert.strictEqual(instance.defaults.signal, signal);
+    return rejectionOf(instance.get('/unused')).then(function (error) {
+      assertCancellation(error, reason);
+      assert.strictEqual(error.config.signal, signal);
+    });
+  });
+
+  it('cancels a structural signal with a throwing reason getter through the request API', function () {
+    var signal = {
+      aborted: true,
+      get reason() { throw new Error('custom getter'); },
+      onabort: null,
+      addEventListener: function () {},
+      removeEventListener: function () {}
+    };
+    return rejectionOf(axios.get('/unused', {signal: signal})).then(function (error) {
+      assertCancellation(error, undefined);
+      assert.strictEqual(error.config.signal, signal);
+    });
+  });
+
+  it('does not read a structural signal reason before cancellation', function () {
+    var reads = 0;
+    var signal = {
+      aborted: false,
+      get reason() { reads++; throw new Error('reason must not be read'); },
+      onabort: null,
+      addEventListener: function () {},
+      removeEventListener: function () {}
+    };
+    var instance = axios.create({signal: signal, adapter: function (config) {
+      return Promise.resolve({data: 'ok', status: 200, statusText: 'OK', headers: {}, config: config});
+    }});
+    return instance.get('/unused').then(function (response) {
+      assert.strictEqual(response.config.signal, signal);
+      assert.strictEqual(reads, 0);
+    });
+  });
+
   it('retains the CancelToken error and its message when both cancellation APIs are configured', function () {
     var controller = new AbortController();
     var source = axios.CancelToken.source();
@@ -75,32 +135,35 @@ describe('AbortSignal cancellation reasons', function () {
     });
   });
 
-  it('preserves reasons for in-flight HTTP requests and releases the abort listener', function () {
-    var server;
-    var sockets = [];
-    var controller = new AbortController();
-    var reason = new Error('operation timed out');
-    var removed = 0;
-    var originalRemove = controller.signal.removeEventListener;
-    controller.signal.removeEventListener = function (event, callback) {
-      if (event === 'abort') removed++;
-      return originalRemove.call(this, event, callback);
-    };
-    return new Promise(function (resolve, reject) {
-      server = http.createServer(function () { abort(controller, reason); });
-      server.on('connection', function (socket) { sockets.push(socket); });
-      server.on('error', reject);
-      server.listen(0, '127.0.0.1', function () {
-        rejectionOf(axios.get('http://127.0.0.1:' + server.address().port, {signal: controller.signal, proxy: false})).then(resolve, reject);
+  [false, true].forEach(function (structural) {
+    it('preserves in-flight HTTP reasons and listener cleanup with a ' + (structural ? 'structural' : 'controller') + ' signal', function () {
+      var server;
+      var sockets = [];
+      var controller = new AbortController();
+      var reason = new Error('operation timed out');
+      var removed = 0;
+      var originalRemove = controller.signal.removeEventListener;
+      controller.signal.removeEventListener = function (event, callback) {
+        if (event === 'abort') removed++;
+        return originalRemove.call(this, event, callback);
+      };
+      var signal = structural ? wrapSignal(controller.signal) : controller.signal;
+      return new Promise(function (resolve, reject) {
+        server = http.createServer(function () { abort(controller, reason); });
+        server.on('connection', function (socket) { sockets.push(socket); });
+        server.on('error', reject);
+        server.listen(0, '127.0.0.1', function () {
+          rejectionOf(axios.get('http://127.0.0.1:' + server.address().port, {signal: signal, proxy: false})).then(resolve, reject);
+        });
+      }).then(function (error) {
+        assertCancellation(error, reason);
+        assert.strictEqual(error.config.signal, signal);
+        assert(error.request);
+        assert(removed > 0);
+      }).finally(function () {
+        sockets.forEach(function (socket) { socket.destroy(); });
+        if (server) return new Promise(function (resolve) { server.close(resolve); });
       });
-    }).then(function (error) {
-      assertCancellation(error, reason);
-      assert.strictEqual(error.config.signal, controller.signal);
-      assert(error.request);
-      assert(removed > 0);
-    }).finally(function () {
-      sockets.forEach(function (socket) { socket.destroy(); });
-      if (server) return new Promise(function (resolve) { server.close(resolve); });
     });
   });
 });

--- a/test/unit/cancel/reason.js
+++ b/test/unit/cancel/reason.js
@@ -1,0 +1,106 @@
+'use strict';
+
+var assert = require('assert');
+var http = require('http');
+var axios = require('../../../index');
+var fromSignal = require('../../../lib/cancel/fromSignal');
+var PolyfillAbortController = require('abortcontroller-polyfill/dist/cjs-ponyfill.js').AbortController;
+var AbortController = global.AbortController || PolyfillAbortController;
+
+function abort(controller, reason) {
+  // The pinned ponyfill predates signal.reason. Model that optional property
+  // on Node 12 while using the native implementation on newer runtimes.
+  if (!('reason' in controller.signal)) {
+    Object.defineProperty(controller.signal, 'reason', {value: reason});
+  }
+  controller.abort(reason);
+}
+
+describe('AbortSignal cancellation reasons', function () {
+  var reasons = [new Error('timeout'), 'superseded', {operation: 'search'}, null, false, 0, ''];
+
+  function rejectionOf(promise) {
+    return promise.then(function () { throw new Error('expected cancellation'); }, function (error) { return error; });
+  }
+
+  function assertCancellation(error, reason) {
+    assert(axios.isCancel(error));
+    assert.strictEqual(error.name, 'CanceledError');
+    assert.strictEqual(error.code, 'ERR_CANCELED');
+    assert.strictEqual(error.message, 'canceled');
+    assert.strictEqual(error.reason, reason);
+  }
+
+  reasons.forEach(function (reason, index) {
+    it('preserves pre-aborted reason ' + index + ' by identity', function () {
+      var controller = new AbortController();
+      abort(controller, reason);
+      return rejectionOf(axios.get('/unused', {signal: controller.signal})).then(function (error) {
+        assertCancellation(error, reason);
+        assert.strictEqual(error.config.signal, controller.signal);
+      });
+    });
+  });
+
+  it('keeps cancellation working for legacy signals and throwing reason getters', function () {
+    var legacy = {aborted: true};
+    var throwing = {};
+    Object.defineProperty(throwing, 'reason', {get: function () { throw new Error('custom getter'); }});
+    [legacy, throwing].forEach(function (signal) {
+      var error = fromSignal(signal);
+      assertCancellation(error, undefined);
+      assert.strictEqual(Object.prototype.hasOwnProperty.call(error, 'reason'), false);
+    });
+  });
+
+  it('preserves reason identity with the Node 12-compatible ponyfill', function () {
+    var controller = new PolyfillAbortController();
+    var reason = {operation: 'superseded'};
+    abort(controller, reason);
+    return rejectionOf(axios.get('/unused', {signal: controller.signal})).then(function (error) {
+      assertCancellation(error, reason);
+      assert.strictEqual(error.config.signal, controller.signal);
+    });
+  });
+
+  it('retains the CancelToken error and its message when both cancellation APIs are configured', function () {
+    var controller = new AbortController();
+    var source = axios.CancelToken.source();
+    abort(controller, 'signal reason');
+    source.cancel('token reason');
+    return rejectionOf(axios.get('/unused', {signal: controller.signal, cancelToken: source.token})).then(function (error) {
+      assert.strictEqual(error, source.token.reason);
+      assert.strictEqual(error.message, 'token reason');
+      assert.strictEqual(error.reason, undefined);
+    });
+  });
+
+  it('preserves reasons for in-flight HTTP requests and releases the abort listener', function () {
+    var server;
+    var sockets = [];
+    var controller = new AbortController();
+    var reason = new Error('operation timed out');
+    var removed = 0;
+    var originalRemove = controller.signal.removeEventListener;
+    controller.signal.removeEventListener = function (event, callback) {
+      if (event === 'abort') removed++;
+      return originalRemove.call(this, event, callback);
+    };
+    return new Promise(function (resolve, reject) {
+      server = http.createServer(function () { abort(controller, reason); });
+      server.on('connection', function (socket) { sockets.push(socket); });
+      server.on('error', reject);
+      server.listen(0, '127.0.0.1', function () {
+        rejectionOf(axios.get('http://127.0.0.1:' + server.address().port, {signal: controller.signal, proxy: false})).then(resolve, reject);
+      });
+    }).then(function (error) {
+      assertCancellation(error, reason);
+      assert.strictEqual(error.config.signal, controller.signal);
+      assert(error.request);
+      assert(removed > 0);
+    }).finally(function () {
+      sockets.forEach(function (socket) { socket.destroy(); });
+      if (server) return new Promise(function (resolve) { server.close(resolve); });
+    });
+  });
+});

--- a/test/unit/core/callerStack.js
+++ b/test/unit/core/callerStack.js
@@ -47,8 +47,49 @@ describe('caller stack reconstruction', function () {
     stacks = {};
   });
 
-  it('appends the caller stack to an error created inside an adapter', async function () {
+  it('avoids capture by default and honors instance and request overrides', function () {
+    var instance = axios.create({adapter: function (config) {
+      return Promise.resolve({data: 'ok', status: 200, statusText: 'OK', headers: {}, config: config});
+    }});
+    Object.setPrototypeOf(instance.defaults, {captureCallerStack: true});
+    var capture = Error.captureStackTrace;
+    var calls = 0;
+    var requests;
+    Error.captureStackTrace = function () {
+      calls++;
+      return capture.apply(Error, arguments);
+    };
+    try {
+      requests = [instance.get('/foo'), instance.get('/foo', {captureCallerStack: false})];
+      assert.strictEqual(calls, 0, 'default and inherited settings must not capture stacks');
+      instance.defaults.captureCallerStack = true;
+      requests.push(instance.get('/foo'));
+      assert.strictEqual(calls, 1);
+      requests.push(instance.get('/foo', {captureCallerStack: false}));
+      assert.strictEqual(calls, 1, 'an explicit request override disables capture');
+    } finally {
+      Error.captureStackTrace = capture;
+    }
+    return Promise.all(requests);
+  });
+
+  it('keeps the original error stack by default after asynchronous interceptors', function () {
     var instance = axios.create({adapter: rejectingAdapter});
+    instance.interceptors.request.use(function (config) { return Promise.resolve(config); });
+    return rejectionOf(requestFromNamedCaller(instance)).then(function (error) {
+      assert.strictEqual(error.stack, stacks.original);
+    });
+  });
+
+  it('can enable caller diagnostics for one request', function () {
+    var instance = axios.create({adapter: rejectingAdapter});
+    return rejectionOf(requestFromNamedCaller(instance, {captureCallerStack: true})).then(function (error) {
+      assert.notStrictEqual(error.stack.indexOf('requestFromNamedCaller'), -1);
+    });
+  });
+
+  it('appends the caller stack to an error created inside an adapter', async function () {
+    var instance = axios.create({captureCallerStack: true, adapter: rejectingAdapter});
 
     var error = await rejectionOf(requestFromNamedCaller(instance));
 
@@ -67,7 +108,7 @@ describe('caller stack reconstruction', function () {
   it('appends the caller stack when the reconstructed stack has fewer than three frames', async function () {
     // Regression guard for the sibling defect in the v1 implementation, where a
     // one or two frame caller stack was silently dropped (#11131).
-    var instance = axios.create({adapter: rejectingAdapter});
+    var instance = axios.create({captureCallerStack: true, adapter: rejectingAdapter});
     var originalLimit = Error.stackTraceLimit;
 
     Error.stackTraceLimit = 2;
@@ -86,7 +127,7 @@ describe('caller stack reconstruction', function () {
   });
 
   it('sets the stack when the rejected error has none', async function () {
-    var instance = axios.create({adapter: rejectingAdapter});
+    var instance = axios.create({captureCallerStack: true, adapter: rejectingAdapter});
 
     var error = await rejectionOf(requestFromNamedCaller(instance, {dropStack: true}));
 
@@ -96,7 +137,7 @@ describe('caller stack reconstruction', function () {
   });
 
   it('keeps synchronous failures synchronous', function () {
-    var instance = axios.create({adapter: rejectingAdapter});
+    var instance = axios.create({captureCallerStack: true, adapter: rejectingAdapter});
 
     assert.throws(function () {
       instance.get('/foo', {transitional: {silentJSONParsing: 'not a boolean'}});
@@ -104,7 +145,7 @@ describe('caller stack reconstruction', function () {
   });
 
   it('preserves callers that use promises without async/await, including method aliases', function () {
-    var instance = axios.create({adapter: rejectingAdapter});
+    var instance = axios.create({captureCallerStack: true, adapter: rejectingAdapter});
     function promiseOnlyCaller() {
       return instance.get('/foo');
     }
@@ -114,7 +155,7 @@ describe('caller stack reconstruction', function () {
   });
 
   it('also decorates failures after asynchronous request interceptors', function () {
-    var instance = axios.create({adapter: rejectingAdapter});
+    var instance = axios.create({captureCallerStack: true, adapter: rejectingAdapter});
     instance.interceptors.request.use(function (config) { return Promise.resolve(config); });
     return rejectionOf(requestFromNamedCaller(instance)).then(function (error) {
       assert.notStrictEqual(error.stack.indexOf('requestFromNamedCaller'), -1);
@@ -123,7 +164,7 @@ describe('caller stack reconstruction', function () {
 
   it('does not replace non-Error rejections', function () {
     var reason = {message: 'application rejection'};
-    var instance = axios.create({adapter: function () { return Promise.reject(reason); }});
+    var instance = axios.create({captureCallerStack: true, adapter: function () { return Promise.reject(reason); }});
     return rejectionOf(instance.get('/foo')).then(function (error) {
       assert.strictEqual(error, reason);
       assert.strictEqual(error.stack, undefined);
@@ -135,7 +176,7 @@ describe('caller stack reconstruction', function () {
     var accessor = new Error('accessor error');
     Object.defineProperty(accessor, 'stack', {get: function () { throw new Error('stack hook'); }});
     return Promise.all([frozen, accessor].map(function (reason) {
-      var instance = axios.create({adapter: function () { return Promise.reject(reason); }});
+      var instance = axios.create({captureCallerStack: true, adapter: function () { return Promise.reject(reason); }});
       return rejectionOf(instance.get('/foo')).then(function (error) { assert.strictEqual(error, reason); });
     }));
   });
@@ -143,7 +184,7 @@ describe('caller stack reconstruction', function () {
   it('does not fail requests when stack capture throws', function () {
     var capture = Error.captureStackTrace;
     var failure = new Error('adapter failure');
-    var instance = axios.create({adapter: function () { return Promise.reject(failure); }});
+    var instance = axios.create({captureCallerStack: true, adapter: function () { return Promise.reject(failure); }});
     var promise;
     Error.captureStackTrace = function () { throw new Error('capture hook'); };
     try {
@@ -156,6 +197,7 @@ describe('caller stack reconstruction', function () {
 
   it('leaves a resolved request untouched', function () {
     var instance = axios.create({
+      captureCallerStack: true,
       adapter: function (config) {
         return Promise.resolve({
           data: 'ok',

--- a/test/unit/core/callerStack.js
+++ b/test/unit/core/callerStack.js
@@ -1,0 +1,176 @@
+'use strict';
+
+var assert = require('assert');
+var axios = require('../../../index');
+var AxiosError = require('../../../lib/core/AxiosError');
+
+describe('caller stack reconstruction', function () {
+  var stacks;
+
+  function rejectingAdapter(config) {
+    return new Promise(function (resolve, reject) {
+      // Reject from a later tick so the error is created with an adapter-only
+      // stack, exactly like a real transport error.
+      setTimeout(function () {
+        var error = new AxiosError('boom', AxiosError.ERR_BAD_RESPONSE, config);
+
+        if (config.dropStack) {
+          error.stack = undefined;
+        }
+
+        stacks.original = error.stack;
+        reject(error);
+      }, 0);
+    });
+  }
+
+  // Use request() for the shallow-stack regression: aliases have additional
+  // synchronous wrapper frames that consume the runtime's stackTraceLimit.
+  async function requestFromNamedCaller(instance, config) {
+    return await instance.request(Object.assign({url: '/foo'}, config));
+  }
+
+  async function rejectionOf(promise) {
+    var settled = false;
+
+    try {
+      await promise;
+      settled = true;
+    } catch (error) {
+      return error;
+    }
+
+    assert.strictEqual(settled, false, 'the request should have rejected');
+  }
+
+  beforeEach(function () {
+    stacks = {};
+  });
+
+  it('appends the caller stack to an error created inside an adapter', async function () {
+    var instance = axios.create({adapter: rejectingAdapter});
+
+    var error = await rejectionOf(requestFromNamedCaller(instance));
+
+    assert.strictEqual(
+      error.stack.indexOf(stacks.original),
+      0,
+      'the original stack should be kept as the prefix'
+    );
+    assert.notStrictEqual(
+      error.stack.indexOf('requestFromNamedCaller'),
+      -1,
+      'the caller frame should be appended, got: ' + error.stack
+    );
+  });
+
+  it('appends the caller stack when the reconstructed stack has fewer than three frames', async function () {
+    // Regression guard for the sibling defect in the v1 implementation, where a
+    // one or two frame caller stack was silently dropped (#11131).
+    var instance = axios.create({adapter: rejectingAdapter});
+    var originalLimit = Error.stackTraceLimit;
+
+    Error.stackTraceLimit = 2;
+
+    try {
+      var error = await rejectionOf(requestFromNamedCaller(instance));
+
+      assert.notStrictEqual(
+        error.stack.indexOf('requestFromNamedCaller'),
+        -1,
+        'the caller frame should be appended, got: ' + error.stack
+      );
+    } finally {
+      Error.stackTraceLimit = originalLimit;
+    }
+  });
+
+  it('sets the stack when the rejected error has none', async function () {
+    var instance = axios.create({adapter: rejectingAdapter});
+
+    var error = await rejectionOf(requestFromNamedCaller(instance, {dropStack: true}));
+
+    assert.strictEqual(stacks.original, undefined);
+    assert.strictEqual(typeof error.stack, 'string');
+    assert.notStrictEqual(error.stack.indexOf('requestFromNamedCaller'), -1);
+  });
+
+  it('keeps synchronous failures synchronous', function () {
+    var instance = axios.create({adapter: rejectingAdapter});
+
+    assert.throws(function () {
+      instance.get('/foo', {transitional: {silentJSONParsing: 'not a boolean'}});
+    }, /must be a boolean/);
+  });
+
+  it('preserves callers that use promises without async/await, including method aliases', function () {
+    var instance = axios.create({adapter: rejectingAdapter});
+    function promiseOnlyCaller() {
+      return instance.get('/foo');
+    }
+    return rejectionOf(promiseOnlyCaller()).then(function (error) {
+      assert.notStrictEqual(error.stack.indexOf('promiseOnlyCaller'), -1);
+    });
+  });
+
+  it('also decorates failures after asynchronous request interceptors', function () {
+    var instance = axios.create({adapter: rejectingAdapter});
+    instance.interceptors.request.use(function (config) { return Promise.resolve(config); });
+    return rejectionOf(requestFromNamedCaller(instance)).then(function (error) {
+      assert.notStrictEqual(error.stack.indexOf('requestFromNamedCaller'), -1);
+    });
+  });
+
+  it('does not replace non-Error rejections', function () {
+    var reason = {message: 'application rejection'};
+    var instance = axios.create({adapter: function () { return Promise.reject(reason); }});
+    return rejectionOf(instance.get('/foo')).then(function (error) {
+      assert.strictEqual(error, reason);
+      assert.strictEqual(error.stack, undefined);
+    });
+  });
+
+  it('does not replace errors with frozen stacks or throwing stack accessors', function () {
+    var frozen = Object.freeze(new Error('frozen error'));
+    var accessor = new Error('accessor error');
+    Object.defineProperty(accessor, 'stack', {get: function () { throw new Error('stack hook'); }});
+    return Promise.all([frozen, accessor].map(function (reason) {
+      var instance = axios.create({adapter: function () { return Promise.reject(reason); }});
+      return rejectionOf(instance.get('/foo')).then(function (error) { assert.strictEqual(error, reason); });
+    }));
+  });
+
+  it('does not fail requests when stack capture throws', function () {
+    var capture = Error.captureStackTrace;
+    var failure = new Error('adapter failure');
+    var instance = axios.create({adapter: function () { return Promise.reject(failure); }});
+    var promise;
+    Error.captureStackTrace = function () { throw new Error('capture hook'); };
+    try {
+      promise = instance.get('/foo');
+    } finally {
+      Error.captureStackTrace = capture;
+    }
+    return rejectionOf(promise).then(function (error) { assert.strictEqual(error, failure); });
+  });
+
+  it('leaves a resolved request untouched', function () {
+    var instance = axios.create({
+      adapter: function (config) {
+        return Promise.resolve({
+          data: 'ok',
+          status: 200,
+          statusText: 'OK',
+          headers: {},
+          config: config,
+          request: {}
+        });
+      }
+    });
+
+    return instance.get('/foo').then(function (response) {
+      assert.strictEqual(response.data, 'ok');
+      assert.strictEqual(response.status, 200);
+    });
+  });
+});

--- a/test/unit/core/requestInterceptorChain.js
+++ b/test/unit/core/requestInterceptorChain.js
@@ -149,7 +149,7 @@ describe('synchronous request interceptor chain', function () {
         return new Promise(function (resolve) {
           setTimeout(function () {
             recovered = true;
-            resolve();
+            resolve({url: '/replacement'});
           }, 10);
         });
       },
@@ -159,6 +159,7 @@ describe('synchronous request interceptor chain', function () {
     return instance.get('/foo').then(function (response) {
       assert.strictEqual(response.status, 200);
       assert.strictEqual(recovered, true, 'the request should wait for the recovery');
+      assert.strictEqual(response.config.url, '/foo', 'recovery values do not replace the last config');
       assert.strictEqual(store.calls, 1);
     });
   });

--- a/test/unit/core/requestInterceptorChain.js
+++ b/test/unit/core/requestInterceptorChain.js
@@ -1,0 +1,241 @@
+'use strict';
+
+var assert = require('assert');
+var axios = require('../../../index');
+var AxiosError = require('../../../lib/core/AxiosError');
+
+describe('synchronous request interceptor chain', function () {
+  function stubAdapter(store) {
+    return function adapter(config) {
+      store.calls++;
+
+      return Promise.resolve({
+        data: '',
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: config,
+        request: {}
+      });
+    };
+  }
+
+  it('runs the response interceptors when dispatch fails synchronously', function () {
+    var store = {calls: 0};
+    var source = axios.CancelToken.source();
+    var instance = axios.create({adapter: stubAdapter(store)});
+    var rejectedRan = false;
+    var fulfilledRan = false;
+
+    source.cancel('canceled before the request');
+
+    instance.interceptors.response.use(
+      function (response) {
+        fulfilledRan = true;
+        return response;
+      },
+      function (error) {
+        rejectedRan = true;
+        return Promise.reject(error);
+      }
+    );
+
+    return instance.get('/foo', {cancelToken: source.token}).then(
+      function () {
+        throw new Error('should have rejected');
+      },
+      function (error) {
+        assert.strictEqual(error.code, AxiosError.ERR_CANCELED);
+        assert.strictEqual(rejectedRan, true, 'the rejection interceptor should run');
+        assert.strictEqual(fulfilledRan, false);
+        assert.strictEqual(store.calls, 0, 'the request should not be dispatched');
+      }
+    );
+  });
+
+  it('runs the response interceptors when the signal is already aborted', function () {
+    if (typeof AbortController === 'undefined') {
+      this.skip();
+      return;
+    }
+
+    var store = {calls: 0};
+    var controller = new AbortController();
+    var instance = axios.create({adapter: stubAdapter(store)});
+    var rejectedRan = false;
+
+    controller.abort();
+
+    instance.interceptors.response.use(undefined, function (error) {
+      rejectedRan = true;
+      return Promise.reject(error);
+    });
+
+    return instance.get('/foo', {signal: controller.signal}).then(
+      function () {
+        throw new Error('should have rejected');
+      },
+      function (error) {
+        assert.strictEqual(error.code, AxiosError.ERR_CANCELED);
+        assert.strictEqual(rejectedRan, true, 'the rejection interceptor should run');
+        assert.strictEqual(store.calls, 0, 'the request should not be dispatched');
+      }
+    );
+  });
+
+  it('rejects instead of throwing when a throwing interceptor has no rejection handler', function () {
+    var store = {calls: 0};
+    var instance = axios.create({adapter: stubAdapter(store)});
+
+    instance.interceptors.request.use(
+      function () {
+        throw new Error('boom');
+      },
+      undefined,
+      {synchronous: true}
+    );
+
+    var promise = instance.get('/foo');
+
+    assert.ok(promise instanceof Promise);
+
+    return promise.then(
+      function () {
+        throw new Error('should have rejected');
+      },
+      function (error) {
+        assert.strictEqual(error.message, 'boom');
+        assert.strictEqual(store.calls, 0, 'the request should not be dispatched');
+      }
+    );
+  });
+
+  it('honours a rejection handler that returns a rejected promise', function () {
+    var store = {calls: 0};
+    var instance = axios.create({adapter: stubAdapter(store)});
+
+    instance.interceptors.request.use(
+      function () {
+        throw new Error('boom');
+      },
+      function (error) {
+        return Promise.reject(error);
+      },
+      {synchronous: true}
+    );
+
+    return instance.get('/foo').then(
+      function () {
+        throw new Error('should have rejected');
+      },
+      function (error) {
+        assert.strictEqual(error.message, 'boom');
+        assert.strictEqual(store.calls, 0, 'the request should not be dispatched');
+      }
+    );
+  });
+
+  it('waits for a rejection handler that recovers asynchronously', function () {
+    var store = {calls: 0};
+    var instance = axios.create({adapter: stubAdapter(store)});
+    var recovered = false;
+
+    instance.interceptors.request.use(
+      function () {
+        throw new Error('boom');
+      },
+      function () {
+        assert.strictEqual(this, undefined, 'rejection handlers retain their unbound context');
+        return new Promise(function (resolve) {
+          setTimeout(function () {
+            recovered = true;
+            resolve();
+          }, 10);
+        });
+      },
+      {synchronous: true}
+    );
+
+    return instance.get('/foo').then(function (response) {
+      assert.strictEqual(response.status, 200);
+      assert.strictEqual(recovered, true, 'the request should wait for the recovery');
+      assert.strictEqual(store.calls, 1);
+    });
+  });
+
+  it('rejects when a rejection handler throws', function () {
+    var store = {calls: 0};
+    var instance = axios.create({adapter: stubAdapter(store)});
+
+    instance.interceptors.request.use(
+      function () {
+        throw new Error('boom');
+      },
+      function () {
+        throw new Error('rethrown');
+      },
+      {synchronous: true}
+    );
+
+    return instance.get('/foo').then(
+      function () {
+        throw new Error('should have rejected');
+      },
+      function (error) {
+        assert.strictEqual(error.message, 'rethrown');
+        assert.strictEqual(store.calls, 0, 'the request should not be dispatched');
+      }
+    );
+  });
+
+  it('keeps dispatching when an interceptor omits its fulfilled handler', function () {
+    var store = {calls: 0};
+    var instance = axios.create({adapter: stubAdapter(store)});
+
+    instance.interceptors.request.use(
+      undefined,
+      function (error) {
+        return Promise.reject(error);
+      },
+      {synchronous: true}
+    );
+
+    return instance.get('/foo').then(function (response) {
+      assert.strictEqual(response.status, 200);
+      assert.strictEqual(store.calls, 1);
+    });
+  });
+
+  it('does not invoke a rejection-only interceptor for a successful config', function () {
+    var store = {calls: 0};
+    var instance = axios.create({adapter: stubAdapter(store)});
+    instance.interceptors.request.use(undefined, function () {
+      throw new Error('rejection handler must not be called');
+    }, {synchronous: true});
+    var request = instance.get('/foo');
+    assert.strictEqual(store.calls, 1, 'successful synchronous requests still dispatch immediately');
+    return request;
+  });
+
+  it('lets response interceptors recover from a synchronous request failure in order', function () {
+    var store = {calls: 0};
+    var instance = axios.create({adapter: stubAdapter(store)});
+    var error = new Error('original failure');
+    var calls = [];
+    instance.interceptors.request.use(function () { throw error; }, undefined, {synchronous: true});
+    instance.interceptors.response.use(undefined, function (reason) {
+      assert.strictEqual(reason, error);
+      calls.push('rejected');
+      return 'recovered';
+    });
+    instance.interceptors.response.use(function (result) {
+      calls.push('fulfilled');
+      return result + '!';
+    });
+    return instance.get('/foo').then(function (result) {
+      assert.strictEqual(result, 'recovered!');
+      assert.deepStrictEqual(calls, ['rejected', 'fulfilled']);
+      assert.strictEqual(store.calls, 0);
+    });
+  });
+});

--- a/test/unit/utils/inherits.js
+++ b/test/unit/utils/inherits.js
@@ -1,0 +1,106 @@
+'use strict';
+
+var assert = require('assert');
+var utils = require('../../../lib/utils');
+var childProcess = require('child_process');
+var path = require('path');
+
+describe('utils.inherits', function () {
+  var originalToJSON;
+  var hadToJSON;
+
+  beforeEach(function () {
+    hadToJSON = Object.prototype.hasOwnProperty.call(Error.prototype, 'toJSON');
+    originalToJSON = hadToJSON
+      ? Object.getOwnPropertyDescriptor(Error.prototype, 'toJSON')
+      : undefined;
+  });
+
+  afterEach(function () {
+    if (hadToJSON) {
+      Object.defineProperty(Error.prototype, 'toJSON', originalToJSON);
+    } else {
+      delete Error.prototype.toJSON;
+    }
+  });
+
+  it('installs props as own writable, enumerable and configurable properties', function () {
+    function Custom() {}
+
+    var toJSON = function () {
+      return {};
+    };
+
+    utils.inherits(Custom, Error, {toJSON: toJSON, flag: true});
+
+    var descriptor = Object.getOwnPropertyDescriptor(Custom.prototype, 'toJSON');
+
+    assert.strictEqual(descriptor.value, toJSON);
+    assert.strictEqual(descriptor.writable, true);
+    assert.strictEqual(descriptor.enumerable, true);
+    assert.strictEqual(descriptor.configurable, true);
+    assert.strictEqual(Custom.prototype.constructor, Custom);
+    assert.strictEqual(Custom.prototype.flag, true);
+    assert.ok(new Custom() instanceof Error);
+  });
+
+  it('works when the super prototype has a non-writable property of the same name', function () {
+    // Libraries that serialize errors sometimes install a read-only
+    // `Error.prototype.toJSON`; assignment would then throw and take axios
+    // down with it at load time (#6690).
+    Object.defineProperty(Error.prototype, 'toJSON', {
+      configurable: true,
+      writable: false,
+      enumerable: false,
+      value: function () {
+        return {inherited: true};
+      }
+    });
+
+    function Custom() {}
+
+    var toJSON = function () {
+      return {own: true};
+    };
+
+    assert.doesNotThrow(function () {
+      utils.inherits(Custom, Error, {toJSON: toJSON});
+    });
+
+    assert.strictEqual(Custom.prototype.toJSON, toJSON);
+    assert.deepStrictEqual(new Custom().toJSON(), {own: true});
+  });
+
+  it('loads axios after another library installs a read-only Error serializer', function () {
+    childProcess.execFileSync(process.execPath, ['-e',
+      "Object.defineProperty(Error.prototype, 'toJSON', {value: function () { return {}; }});" +
+      "var axios = require(" + JSON.stringify(path.resolve(__dirname, '../../..')) + ");" +
+      "var error = new axios.AxiosError('example');" +
+      "require('assert').strictEqual(error.toJSON().message, 'example');"
+    ]);
+  });
+
+  it('shadows inherited constructor and setter properties without invoking the setter', function () {
+    var writes = 0;
+    function Parent() {}
+    function Child() {}
+    Object.defineProperty(Parent.prototype, 'constructor', {value: Parent, writable: false});
+    Object.defineProperty(Parent.prototype, 'value', {set: function () { writes++; }});
+    utils.inherits(Child, Parent, {value: 42});
+    assert.strictEqual(Child.prototype.constructor, Child);
+    assert.strictEqual(Child.prototype.value, 42);
+    assert.strictEqual(writes, 0);
+  });
+
+  it('preserves enumerable symbol properties without copying non-enumerable ones', function () {
+    var visible = Symbol('visible');
+    var hidden = Symbol('hidden');
+    var props = {};
+    function Child() {}
+    props[visible] = 42;
+    Object.defineProperty(props, hidden, {value: 7});
+    utils.inherits(Child, Error, props);
+    assert.strictEqual(Child.prototype[visible], 42);
+    assert.strictEqual(Object.prototype.hasOwnProperty.call(Child.prototype, hidden), false);
+  });
+});

--- a/test/unit/utils/inherits.js
+++ b/test/unit/utils/inherits.js
@@ -103,4 +103,109 @@ describe('utils.inherits', function () {
     assert.strictEqual(Child.prototype[visible], 42);
     assert.strictEqual(Object.prototype.hasOwnProperty.call(Child.prototype, hidden), false);
   });
+
+  it('updates a supplied writable constructor without changing its descriptor flags', function () {
+    function Parent() {}
+    function Child() {}
+
+    utils.inherits(Child, Parent, undefined, {
+      constructor: {value: Parent, writable: true}
+    });
+
+    assert.deepStrictEqual(Object.getOwnPropertyDescriptor(Child.prototype, 'constructor'), {
+      value: Child,
+      writable: true,
+      enumerable: false,
+      configurable: false
+    });
+  });
+
+  it('assigns the constructor through a supplied accessor', function () {
+    function Parent() {}
+    function Child() {}
+    var received;
+    var receiver;
+    var descriptor = {
+      set: function (value) {
+        received = value;
+        receiver = this;
+      },
+      get: undefined,
+      enumerable: false,
+      configurable: true
+    };
+
+    utils.inherits(Child, Parent, undefined, {constructor: descriptor});
+
+    assert.strictEqual(received, Child);
+    assert.strictEqual(receiver, Child.prototype);
+    assert.deepStrictEqual(Object.getOwnPropertyDescriptor(Child.prototype, 'constructor'), descriptor);
+  });
+
+  it('rejects assignment to a supplied read-only constructor', function () {
+    function Parent() {}
+    function Child() {}
+
+    assert.throws(function () {
+      utils.inherits(Child, Parent, undefined, {
+        constructor: {value: Parent, writable: false, configurable: true}
+      });
+    }, TypeError);
+  });
+
+  ['value', Symbol('value')].forEach(function (key) {
+    it('updates a writable own ' + typeof key + ' property without changing its descriptor flags', function () {
+      function Child() {}
+      var descriptors = {};
+      var props = {};
+      descriptors[key] = {value: 7, writable: true};
+      props[key] = 42;
+
+      utils.inherits(Child, Error, props, descriptors);
+
+      assert.deepStrictEqual(Object.getOwnPropertyDescriptor(Child.prototype, key), {
+        value: 42,
+        writable: true,
+        enumerable: false,
+        configurable: false
+      });
+    });
+
+    it('assigns a ' + typeof key + ' property through its own accessor', function () {
+      function Child() {}
+      var received;
+      var receiver;
+      var descriptors = {};
+      var props = {};
+      var descriptor = {
+        set: function (value) {
+          received = value;
+          receiver = this;
+        },
+        get: undefined,
+        enumerable: false,
+        configurable: true
+      };
+      descriptors[key] = descriptor;
+      props[key] = 42;
+
+      utils.inherits(Child, Error, props, descriptors);
+
+      assert.strictEqual(received, 42);
+      assert.strictEqual(receiver, Child.prototype);
+      assert.deepStrictEqual(Object.getOwnPropertyDescriptor(Child.prototype, key), descriptor);
+    });
+
+    it('rejects assignment to a read-only own ' + typeof key + ' property', function () {
+      function Child() {}
+      var descriptors = {};
+      var props = {};
+      descriptors[key] = {value: 7, writable: false, configurable: true};
+      props[key] = 42;
+
+      assert.throws(function () {
+        utils.inherits(Child, Error, props, descriptors);
+      }, TypeError);
+    });
+  });
 });


### PR DESCRIPTION
### Summary

Improve v0 error handling and cancellation while keeping caller-stack diagnostics opt-in:

- Allow Axios to load alongside a read-only `Error.prototype.toJSON`, preserving supplied own descriptors and setters.
- Route synchronous request-interceptor and dispatch failures through response interceptors. Await recovery promises before dispatch, retaining the last request config and ignoring recovery return values.
- Add `captureCallerStack: true` on requests or instances to append the original caller to asynchronous errors. It defaults to off, avoiding stack capture and an additional Promise reaction on ordinary requests.
- Preserve `AbortSignal.reason` as `CanceledError.reason`, including object and falsy values. Config merging retains native and structural signals by reference so live getters and reason identity survive pre-aborted and in-flight HTTP/XHR requests.
- Reject header values that are Promises, functions, or objects with custom `toString()` methods in TypeScript while retaining supported scalar, array, and grouped headers.

Includes regression coverage, README examples, and an unreleased changelog entry.

### Related issue

Refs #6690, #5784, #6670, #7434, and #7487.

The #5784 change covers the related synchronous request path; response-interceptor ordering remains unchanged. Caller diagnostics for #6670 are enabled with `captureCallerStack: true`.

### Release impact

**Target the next v0 minor release, not a patch release.** The header declarations narrow previously accepted types. Resolve promises, call functions, or explicitly convert objects before assigning header values. This follows v0's documented pre-1.0 compatibility policy; the unreleased changelog records the migration requirement.

### Testing

- Installed with `npm ci --ignore-scripts`.
- `npm run build` passed.
- `npm test` on Node v24.18.0 passed: **328 Node tests**, **371 browser specs each in Firefox 153 and Chromium 151**, and declaration tests.
- [GitHub CI](https://github.com/axios/axios/actions/runs/34253775816) passed on **Node 12, 14, 16, 18, 20, 22, 24, and 26** at `59b9976`.
- Signal coverage includes instance/request precedence, inherited config values, live structural wrappers, circular reasons, throwing getters, and HTTP/XHR cancellation.
- Caller-stack coverage includes disabled defaults, explicit request overrides, enabled async/Promise callers, shallow stacks, and frozen/throwing stack hooks.

Successful custom-adapter benchmark on Node v24.18.0, six samples of 20,000 requests after warm-up:

| Configuration | Median µs/request |
| --- | ---: |
| Base `v0.x` (`5268576`) | 7.80 |
| PR, default settings | 7.80 |
| PR, `captureCallerStack: true` | 9.46 |

This measures request CPU overhead rather than network latency. Base and PR request/config-merge implementations were compared with the same dependencies and adapter. The default avoids the previously measured unconditional stack-capture overhead.
