### PR TITLE
Fall back to a supported cache mode in the fetch adapter

### DIFF
--- a/lib/adapters/fetch.js
+++ b/lib/adapters/fetch.js
@@ -142,6 +142,14 @@ const factory = (env) => {
     isReadableStreamSupported &&
     test(() => utils.isReadableStream(new Response('').body));
 
+  // Some runtimes (e.g. Cloudflare Workers) only implement a subset of the
+  // Fetch spec's cache modes and throw when constructing a Request with an
+  // unsupported one, even the spec's own default ('default'). Detect that
+  // once up front rather than letting every request crash on construction.
+  const supportsDefaultCacheMode =
+    isRequestSupported &&
+    test(() => new Request(platform.origin, {cache: 'default'}).cache === 'default');
+
   const resolvers = {
     stream: supportsResponseStream && ((res) => res.body),
   };
@@ -465,6 +473,10 @@ const factory = (env) => {
             resolvedOptions[key] = value;
           }
         });
+
+        if (resolvedOptions.cache === 'default' && !supportsDefaultCacheMode) {
+          resolvedOptions.cache = 'no-store';
+        }
 
         if (resolvedOptions.signal === undefined) {
           resolvedOptions.signal = null;

--- a/tests/unit/adapters/fetch.test.js
+++ b/tests/unit/adapters/fetch.test.js
@@ -284,6 +284,35 @@ describe.runIf(typeof fetch === 'function')('supports fetch with nodejs', () => 
     }
   });
 
+  it('should fall back to a supported cache mode on runtimes that reject the spec default', async () => {
+    // Some runtimes (e.g. Cloudflare Workers) only support a subset of the
+    // Fetch spec's cache modes and throw at Request construction for the
+    // rest, even the spec's own default value ('default'). See GH #11192.
+    class RestrictedCacheModeRequest extends Request {
+      constructor(input, init) {
+        if (init && init.cache === 'default') {
+          throw new TypeError('Unsupported cache mode: default');
+        }
+        super(input, init);
+      }
+    }
+
+    let captured;
+    const response = await fetchAxios.get('/cache-fallback', {
+      env: {
+        Request: RestrictedCacheModeRequest,
+        fetch(input) {
+          captured = input;
+          return Promise.resolve(new Response('ok'));
+        },
+      },
+    });
+
+    assert.strictEqual(response.data, 'ok');
+    assert.ok(captured instanceof RestrictedCacheModeRequest);
+    assert.strictEqual(captured.cache, 'no-store');
+  });
+
   it('should expose an unfollowed redirect response in Node when maxRedirects is zero', async () => {
     let finalRequests = 0;
     const server = await startHTTPServer((req, res) => {


### PR DESCRIPTION
## Summary

The fetch adapter always sets `cache: 'default'` on every `Request` it constructs. Cloudflare Workers (workerd) only implement a subset of the Fetch spec's cache modes and throw at `Request` construction for anything outside that subset, including the literal string `'default'`, so every request through the fetch adapter fails on Workers with `TypeError: Unsupported cache mode: default`.

I couldn't just drop the explicit default though: `DEFAULT_REQUEST_OPTIONS` is applied onto a null-prototype options object specifically to keep `Object.prototype` pollution from reaching the constructed `Request` (there's an existing test for this). It turns out that when `cache` is left unset entirely, Node's own `Request` implementation falls back to a default that IS influenced by `Object.prototype`, so simply removing the explicit default reopens that hole.

## Linked issue

Closes #11192

## Changes

- Detect once per adapter instance whether the current `Request` implementation accepts `cache: 'default'`, using the same `test()` capability-detection pattern already used for the stream-support checks in this file.
- On runtimes where it doesn't (Workers), fall back to `'no-store'` instead, which the runtimes referenced in the issue accept. Everywhere else, behavior is unchanged.
- Added a regression test using a `Request` subclass that throws for `cache: 'default'`, mirroring workerd's behavior; confirmed it fails on unmodified code with the exact reported error and passes with the fix.

#### Checklist

- [x] Tests added or updated (or N/A with reason)
- [x] Docs/types updated if public API changed (`index.d.ts` and `index.d.cts`) — N/A, no public API change
- [x] No breaking changes (or called out explicitly above)

---

I used Claude (Sonnet 5) to help investigate and write this fix, and reviewed and verified the diff, the regression test, and the full test run myself before submitting.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
## Description

The fetch adapter always sets `cache: 'default'` on every `Request` it constructs, which makes every request through it fail on Cloudflare Workers — workerd throws `TypeError: Unsupported cache mode: default` at construction. The adapter now detects at runtime whether the current `Request` implementation accepts that mode and falls back to `'no-store'` when it doesn't.

- Summary of changes: uses the existing `test()` capability-detection pattern to check, once per adapter instance, whether the `Request` implementation accepts `cache: 'default'`; on runtimes that reject it, the resolved options fall back to `'no-store'`. Behavior on all other runtimes is unchanged.
- Reasoning: dropping the explicit default isn't safe — `DEFAULT_REQUEST_OPTIONS` is applied onto a null-prototype options object to block `Object.prototype` pollution, and Node's own `Request` falls back to a default that is influenced by `Object.prototype` when `cache` is unset.
- Additional context: closes #11192.

## Docs

No documentation updates needed — there's no public API change (`index.d.ts` and `index.d.cts` are unaffected).

## Testing

Added a regression test that uses a `Request` subclass throwing for `cache: 'default'` to mirror workerd's behavior. The test fails on unmodified code with the exact reported error and passes with the fix.

## Semantic version impact

Patch version change: bug fix with no public API change and no breaking changes.

<sup>Written for commit 1960d79fe20cf852e3349c5b7acc1c79a2e468eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/axios/axios/pull/11211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

