### PR TITLE
feat(core): expose request duration on the response

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -516,6 +516,8 @@ export interface AxiosResponse<T = any, D = any, H = {}, P = any> {
   data: T;
   status: number;
   statusText: string;
+  /** Milliseconds from dispatch to response. */
+  duration?: number;
   headers: (H & RawAxiosResponseHeaders) | AxiosResponseHeaders;
   config: InternalAxiosRequestConfig<D, P>;
   request?: any;

--- a/lib/core/dispatchRequest.js
+++ b/lib/core/dispatchRequest.js
@@ -26,6 +26,21 @@ function throwIfCancellationRequested(config) {
 }
 
 /**
+ * Milliseconds elapsed since `start`, floored at zero.
+ *
+ * Wall-clock, to match the rest of the codebase (speedometer, throttle,
+ * AxiosTransformStream). A backwards clock adjustment mid-request would
+ * otherwise produce a negative duration, so the result is clamped.
+ *
+ * @param {number} start Timestamp from `Date.now()`
+ *
+ * @returns {number} Non-negative elapsed milliseconds
+ */
+function elapsedSince(start) {
+  return Math.max(0, Date.now() - start);
+}
+
+/**
  * Dispatch a request to the server using the configured adapter.
  *
  * @param {object} config The config that is to be used for the request
@@ -51,9 +66,13 @@ export default function dispatchRequest(_config) {
 
   const adapter = adapters.getAdapter(config.adapter || defaults.adapter, config);
 
+  const start = Date.now();
+
   return adapter(config).then(
     function onAdapterResolution(response) {
       throwIfCancellationRequested(config);
+
+      response.duration = elapsedSince(start);
 
       // Expose the current response on config so that transformResponse can
       // attach it to any AxiosError it throws (e.g. on JSON parse failure).
@@ -75,6 +94,7 @@ export default function dispatchRequest(_config) {
 
         // Transform response data
         if (reason && reason.response) {
+          reason.response.duration = elapsedSince(start);
           config.response = reason.response;
           try {
             reason.response.data = transformData.call(

--- a/tests/unit/core/dispatchRequest.test.js
+++ b/tests/unit/core/dispatchRequest.test.js
@@ -233,3 +233,34 @@ describe('core::dispatchRequest', () => {
     });
   });
 });
+
+describe('core::dispatchRequest response timing', () => {
+  it('reports how long the request took', async () => {
+    const config = baseConfig({
+      adapter: async () => ({ status: 200, statusText: 'OK', headers: {}, data: '{}' }),
+    });
+
+    const response = await dispatchRequest(config);
+
+    assert.strictEqual(typeof response.duration, 'number');
+    assert.ok(response.duration >= 0, 'duration must never be negative');
+  });
+
+  it('reports a duration on an error response too', async () => {
+    const config = baseConfig({
+      adapter: async () => {
+        throw new AxiosError('boom', AxiosError.ERR_BAD_RESPONSE, config, null, {
+          status: 500,
+          statusText: 'Server Error',
+          headers: {},
+          data: '{}',
+        });
+      },
+    });
+
+    const error = await dispatchRequest(config).catch((e) => e);
+
+    assert.strictEqual(typeof error.response.duration, 'number');
+    assert.ok(error.response.duration >= 0);
+  });
+});


### PR DESCRIPTION
### Summary

Adds `response.duration` — milliseconds from dispatch to response, on successful responses and on `error.response` when the server replied.

```js
const res = await axios.get('/users');
console.log(res.duration); // 143

try {
  await axios.get('/boom');
} catch (err) {
  console.log(err.response.duration); // 87
}
```

### Motivation

Timing a request today means registering a request interceptor, a response interceptor, *and* a `Map` keyed by config to correlate the two — then repeating it in every project. It's a common enough need that it seems worth the four lines it actually costs.

### Implementation

One clock read in `dispatchRequest`, which is the single adapter-agnostic choke point: `adapter(config)` is invoked in exactly one place and both outcomes are already handled there. So `http`, `xhr` and `fetch` all get this with no per-adapter code, and no Node/browser split.

`Date.now()` rather than `performance.now()`, to match the existing convention in `speedometer.js`, `throttle.js`, `cookies.js` and `AxiosTransformStream.js` — introducing a global the library hasn't depended on seemed the wrong trade for this. The value is clamped at zero via `Math.max(0, ...)`, so a backwards clock adjustment mid-request can't produce a negative duration.

### Deliberately not included

- **No config flag.** It's one `Date.now()` per request; a toggle would cost more than it saves.
- **No per-phase breakdown** (DNS / TLS / TTFB). That's adapter-specific and Node-only — a much larger, separate feature.
- **No `duration` on errors without a response.** A timeout already tells you its own duration.

### Compatibility

Additive only. `duration` is a new optional field on `AxiosResponse`; nothing existing changes shape or behaviour.

### Tests

Two tests added to `tests/unit/core/dispatchRequest.test.js` covering the success and error-response paths. `tests/unit/core/dispatchRequest.test.js` passes 9/9.

---

Opened as a draft — happy to adjust naming (`duration` vs `elapsed` vs `timing`), scope, or drop the error-response half if you'd rather keep it to successes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
## Description

Adds `response.duration` — milliseconds from dispatch to response — on successful responses and on `error.response` when the server replied.

- Timing a request today requires an interceptor pair plus a Map keyed by config to correlate request and response; this is now built in.
- A single `Date.now()` read in `dispatchRequest` covers the http, xhr, and fetch adapters with no per-adapter code.
- The value is clamped at zero so a backwards clock adjustment mid-request can't produce a negative duration.
- No config flag, no per-phase breakdown, and no duration on errors without a response.

## Docs

The `AxiosResponse` TypeScript type adds an optional `duration` field; the API docs could mention it alongside the other response properties.

## Testing

Two tests added to `tests/unit/core/dispatchRequest.test.js` cover the success and error-response paths.

## Semantic version impact

Minor — additive change introducing a new optional field with no breaking changes.

<sup>Written for commit 8451d51b5fd50be3c68448387dd58b26bd963c94. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/axios/axios/pull/11214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

