### PR TITLE
feat(params): add arrayFormat, including comma-separated values

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -334,6 +334,7 @@ export interface SerializerOptions {
   dots?: boolean;
   metaTokens?: boolean;
   indexes?: boolean | null;
+  arrayFormat?: 'brackets' | 'indices' | 'repeat' | 'comma';
   maxDepth?: number;
   Blob?: { new (...args: any[]): any };
 }

--- a/lib/helpers/toFormData.js
+++ b/lib/helpers/toFormData.js
@@ -10,6 +10,41 @@ import PlatformBuffer from '../platform/node/classes/Buffer.js';
 // the FormData <-> JSON round-trip stays symmetric.
 export const DEFAULT_FORM_DATA_MAX_DEPTH = 100;
 
+const ARRAY_FORMATS = new Set(['brackets', 'indices', 'repeat', 'comma']);
+
+const isScalar = (value) =>
+  utils.isString(value) || utils.isNumber(value) || utils.isBoolean(value);
+
+/**
+ * Resolve the array serialization style.
+ *
+ * `arrayFormat` is the named form; `indexes` is the existing boolean/null
+ * form and stays the fallback, so configs that set it keep their behaviour.
+ *   brackets -> a[]=1&a[]=2   (default, indexes: false)
+ *   indices  -> a[0]=1&a[1]=2 (indexes: true)
+ *   repeat   -> a=1&a=2       (indexes: null)
+ *   comma    -> a=1,2
+ *
+ * @param {?string} arrayFormat - The requested named format, if any.
+ * @param {boolean|null} indexes - The existing option.
+ *
+ * @returns {string} One of ARRAY_FORMATS.
+ */
+function resolveArrayFormat(arrayFormat, indexes) {
+  if (arrayFormat !== undefined) {
+    if (!ARRAY_FORMATS.has(arrayFormat)) {
+      throw new TypeError(
+        `arrayFormat must be one of ${[...ARRAY_FORMATS].join(', ')}, got ${arrayFormat}`
+      );
+    }
+
+    return arrayFormat;
+  }
+
+  // eslint-disable-next-line no-nested-ternary
+  return indexes === true ? 'indices' : indexes === null ? 'repeat' : 'brackets';
+}
+
 /**
  * Determines if the given thing is a array or js object.
  *
@@ -109,6 +144,7 @@ function toFormData(obj, formData, options) {
   const visitor = option('visitor') || defaultVisitor;
   const dots = option('dots', false);
   const indexes = option('indexes', false);
+  const arrayFormat = resolveArrayFormat(option('arrayFormat'), indexes);
   const _Blob = option('Blob') || (typeof Blob !== 'undefined' && Blob);
   const maxDepth = option('maxDepth', DEFAULT_FORM_DATA_MAX_DEPTH);
   const useBlob = _Blob && utils.isSpecCompliantForm(formData);
@@ -212,13 +248,23 @@ function toFormData(obj, formData, options) {
         // eslint-disable-next-line no-param-reassign
         key = removeBrackets(key);
 
+        const defined = arr.filter((el) => !(utils.isUndefined(el) || el === null));
+
+        // Comma form collapses to a single pair, so it only applies when every
+        // element is a scalar. A FileList reaching here still needs one pair
+        // per entry, and joining Blobs would stringify them to [object Blob].
+        if (arrayFormat === 'comma' && defined.every(isScalar)) {
+          defined.length && formData.append(key, defined.map(convertValue).join(','));
+          return false;
+        }
+
         arr.forEach(function each(el, index) {
           !(utils.isUndefined(el) || el === null) &&
             formData.append(
               // eslint-disable-next-line no-nested-ternary
-              indexes === true
+              arrayFormat === 'indices'
                 ? renderKey([key], index, dots)
-                : indexes === null
+                : arrayFormat === 'repeat'
                   ? key
                   : key + '[]',
               convertValue(el)

--- a/tests/unit/helpers/buildURL.test.js
+++ b/tests/unit/helpers/buildURL.test.js
@@ -208,3 +208,54 @@ describe('helpers::encode', () => {
     expect(encode('a:b$c,d e')).toEqual('a:b$c,d+e');
   });
 });
+describe('helpers::buildURL arrayFormat', () => {
+  const params = { id: [1, 2, 3] };
+
+  it('defaults to bracket form, unchanged from before the option existed', () => {
+    expect(buildURL('/x', params)).toEqual('/x?id%5B%5D=1&id%5B%5D=2&id%5B%5D=3');
+  });
+
+  it('serializes each named format', () => {
+    expect(buildURL('/x', params, { arrayFormat: 'brackets' })).toEqual(
+      '/x?id%5B%5D=1&id%5B%5D=2&id%5B%5D=3'
+    );
+    expect(buildURL('/x', params, { arrayFormat: 'indices' })).toEqual(
+      '/x?id%5B0%5D=1&id%5B1%5D=2&id%5B2%5D=3'
+    );
+    expect(buildURL('/x', params, { arrayFormat: 'repeat' })).toEqual('/x?id=1&id=2&id=3');
+    expect(buildURL('/x', params, { arrayFormat: 'comma' })).toEqual('/x?id=1,2,3');
+  });
+
+  it('keeps the legacy indexes option working identically', () => {
+    expect(buildURL('/x', params, { indexes: true })).toEqual(
+      buildURL('/x', params, { arrayFormat: 'indices' })
+    );
+    expect(buildURL('/x', params, { indexes: null })).toEqual(
+      buildURL('/x', params, { arrayFormat: 'repeat' })
+    );
+    expect(buildURL('/x', params, { indexes: false })).toEqual(
+      buildURL('/x', params, { arrayFormat: 'brackets' })
+    );
+  });
+
+  it('lets arrayFormat win over indexes when both are given', () => {
+    expect(buildURL('/x', params, { indexes: true, arrayFormat: 'comma' })).toEqual('/x?id=1,2,3');
+  });
+
+  it('omits an empty array and skips null members in comma form', () => {
+    expect(buildURL('/x', { id: [] }, { arrayFormat: 'comma' })).toEqual('/x');
+    expect(buildURL('/x', { id: [1, null, undefined, 3] }, { arrayFormat: 'comma' })).toEqual(
+      '/x?id=1,3'
+    );
+  });
+
+  it('leaves non-array params alone', () => {
+    expect(buildURL('/x', { a: 'b', id: [1, 2] }, { arrayFormat: 'comma' })).toEqual(
+      '/x?a=b&id=1,2'
+    );
+  });
+
+  it('rejects an unknown format rather than silently defaulting', () => {
+    expect(() => buildURL('/x', params, { arrayFormat: 'nope' })).toThrow(/arrayFormat must be one of/);
+  });
+});


### PR DESCRIPTION
### Summary

Adds an `arrayFormat` serializer option with four named styles:

```js
axios.get('/items', { params: { id: [1, 2, 3] }, paramsSerializer: { arrayFormat: 'comma' } });
// /items?id=1,2,3
```

| `arrayFormat` | Output | Equivalent `indexes` |
|---|---|---|
| `brackets` *(default)* | `id[]=1&id[]=2` | `false` |
| `indices` | `id[0]=1&id[1]=2` | `true` |
| `repeat` | `id=1&id=2` | `null` |
| `comma` | `id=1,2` | — **not currently expressible** |

### Motivation

`indexes` already covers three of these, but as a `boolean | null` tri-state where `null` means "repeat" and `false` means "brackets" — which is hard to read at a call site and undiscoverable from the type. Naming the styles makes the intent explicit.

`comma` is the actual gap: several APIs (and OpenAPI's `style: form, explode: false`) expect `?id=1,2,3`, and there's no way to produce it today short of a full custom `serialize` function. `buildURL`'s existing encoder already leaves `,` unescaped, so the output is clean without further change.

### Compatibility

`indexes` stays the fallback whenever `arrayFormat` is absent, so any existing config produces byte-identical output. There's a test asserting exactly that equivalence for all three legacy values.

An unrecognised `arrayFormat` throws a `TypeError` listing the valid values, rather than silently defaulting — a typo'd format quietly serializing the wrong shape seemed worse than a loud failure. Happy to soften that if you'd prefer lenient behaviour.

### Notes on the comma branch

It applies only when every element is a scalar. A `FileList` can reach that code path, and joining Blobs would stringify them to `[object Blob]`, so anything non-scalar falls through to the per-element append. Empty arrays emit no parameter; `null`/`undefined` members are skipped, matching the existing behaviour.

### Tests

7 tests added to `tests/unit/helpers/buildURL.test.js` covering each format, the legacy-equivalence guarantee, precedence when both options are set, empty/null handling, and the invalid-value throw. `buildURL` and `toFormData` suites pass 58/58.

---

Opened as a draft — glad to rename the option, adjust the strictness, or split `comma` out from the naming change if you'd rather take them separately.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
## Description

Adds an `arrayFormat` serializer option with four named styles: `brackets`, `indices`, `repeat`, and `comma`. The first three name the behaviors the existing `indexes` option already provides; `comma` is new and enables `?id=1,2,3` output that wasn't previously expressible.

- `indexes` remains the fallback whenever `arrayFormat` is absent, so existing configs produce byte-identical output.
- An unrecognised `arrayFormat` throws a `TypeError` listing valid values rather than silently defaulting.
- Comma form only applies when every element is a scalar; empty arrays emit no parameter and `null`/`undefined` members are skipped.

## Docs

Add a suggestion to update the documentation website in the `/docs/` directory to document the new `arrayFormat` option and its interaction with `indexes`.

## Testing

Adds 7 tests covering each named format, legacy-equivalence with `indexes`, precedence when both options are set, empty/null handling, and the invalid-value throw.

## Semantic version impact

This is a minor version change: it adds a new option without altering behavior for existing configurations.

<sup>Written for commit 5ce651f855182e175db8b81c27332eb3fcbd8297. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/axios/axios/pull/11215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

