### PR TITLE
fix(xhr): remove progress event listeners on request completion

### DIFF
--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -28,6 +28,16 @@ export default isXHRAdapterSupported &&
         flushUpload && flushUpload(); // flush events
         flushDownload && flushDownload(); // flush events
 
+        // Detach progress listeners so the completed XHR (and the closures
+        // it references via downloadThrottled/uploadThrottled) can be
+        // garbage collected instead of being retained by the browser's
+        // internal listener registry.
+        downloadThrottled && request.removeEventListener('progress', downloadThrottled);
+        if (request.upload) {
+          uploadThrottled && request.upload.removeEventListener('progress', uploadThrottled);
+          flushUpload && request.upload.removeEventListener('loadend', flushUpload);
+        }
+
         _config.cancelToken && _config.cancelToken.unsubscribe(onCanceled);
 
         _config.signal && _config.signal.removeEventListener('abort', onCanceled);


### PR DESCRIPTION
## Summary

The XHR adapter's `done()` cleanup function removes the `abort` listener on `_config.signal`, but never removes the three progress-related listeners registered via `addEventListener` (`progress` on the request, and `progress`/`loadend` on `request.upload`). Any request made with `onDownloadProgress` or `onUploadProgress` leaves these attached after completion, which is the root cause behind the long-standing "4 event listeners never cleaned up" reports (#5640, #5641, and related memory-leak issues going back to 2020). The only prior leak fix (#11091) addressed the Node `http.js` adapter's socket listener — this is the browser `xhr.js` counterpart, which has never been patched.

## Linked issue

Closes #5641

## Changes

- In `lib/adapters/xhr.js`, `done()` now explicitly removes `downloadThrottled` from the request's `progress` listener, and `uploadThrottled`/`flushUpload` from `request.upload`'s `progress`/`loadend` listeners, guarded so it's a no-op when progress callbacks weren't used or `request.upload` doesn't exist.

#### Checklist

- [ ] Tests added or updated — existing `tests/unit/adapters/xhr.test.js` suite passes unchanged (7/7), not added any more.
- [x] Docs/types updated if public API changed — no.
- [x] No breaking changes

:surfer:

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
## Description

Fixes the XHR adapter's progress event listener leak. `done()` in `lib/adapters/xhr.js` now explicitly removes `downloadThrottled` from the request's `progress` event and `uploadThrottled`/`flushUpload` from `request.upload`'s `progress`/`loadend` events, so the completed XHR and its closures can be garbage collected. This closes #5641 and addresses the long-standing "4 event listeners never cleaned up" reports. Previously only the `abort` listener was removed; the prior leak fix (#11091) covered only the Node `http.js` adapter's socket listener, never the browser `xhr.js` counterpart.

- Summary of changes: adds guarded `removeEventListener` calls in `done()` that are no-ops when progress callbacks weren't used or `request.upload` is missing.
- Reasoning: attached throttled listeners retained the completed XHR object and its closures in the browser's internal listener registry.
- Additional context: behavior is unchanged for requests without progress callbacks; only memory cleanup is affected.

## Docs

No documentation update needed — internal cleanup fix with no public API change.

## Testing

No tests added or modified. Existing `tests/unit/adapters/xhr.test.js` passes unchanged (7/7); a regression test asserting listener removal after completion could strengthen coverage, but the change is a no-op without progress callbacks.

## Semantic version impact

Patch — bug fix with no public API changes and no breaking behavior.

<sup>Written for commit a705df8e4e8942e894f7f6d780f960b5c1970099. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/axios/axios/pull/11224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

