### PR TITLE
fix(xhr): remove progress event listeners on request completion

### DIFF
--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -25,8 +25,38 @@ export default isXHRAdapterSupported &&
       let flushUpload, flushDownload, flushDownloadWithEvent;
 
       function done() {
-        flushUpload && flushUpload(); // flush events
-        flushDownload && flushDownload(); // flush events
+        // A queued final progress delivery can throw (user callback error) or
+        // can synchronously cancel the request (which reenters done() and
+        // nulls `request` before this call unwinds). Neither case may skip
+        // the cleanup below: rethrow listener errors asynchronously, matching
+        // the same convention already used for flushDownloadWithEvent above.
+        try {
+          flushUpload && flushUpload(); // flush events
+        } catch (err) {
+          setTimeout(() => {
+            throw err;
+          });
+        }
+        try {
+          flushDownload && flushDownload(); // flush events
+        } catch (err) {
+          setTimeout(() => {
+            throw err;
+          });
+        }
+
+        // Detach progress listeners so the completed XHR (and the closures
+        // it references via downloadThrottled/uploadThrottled) can be
+        // garbage collected instead of being retained by the browser's
+        // internal listener registry. `request` may already be null here if
+        // one of the flushes above triggered a reentrant cancellation.
+        if (request) {
+          downloadThrottled && request.removeEventListener('progress', downloadThrottled);
+          if (request.upload) {
+            uploadThrottled && request.upload.removeEventListener('progress', uploadThrottled);
+            flushUpload && request.upload.removeEventListener('loadend', flushUpload);
+          }
+        }
 
         _config.cancelToken && _config.cancelToken.unsubscribe(onCanceled);
 

--- a/tests/unit/adapters/xhr.test.js
+++ b/tests/unit/adapters/xhr.test.js
@@ -6,8 +6,40 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 // Firefox 152 navigation-cancel shape (https://bugzilla.mozilla.org/show_bug.cgi?id=1505389)
 // and the shape of a successful file: read in an environment without responseURL.
 
-class StubXMLHttpRequest {
+// Minimal EventTarget-like helper so the stub can model addEventListener/
+// removeEventListener for progress tracking, which the xhr adapter relies on
+// and which the previous stub didn't support at all.
+class StubEventTarget {
   constructor() {
+    this._listeners = {};
+  }
+
+  addEventListener(type, fn) {
+    (this._listeners[type] || (this._listeners[type] = new Set())).add(fn);
+  }
+
+  removeEventListener(type, fn) {
+    this._listeners[type] && this._listeners[type].delete(fn);
+  }
+
+  listenerCount(type) {
+    return this._listeners[type] ? this._listeners[type].size : 0;
+  }
+
+  dispatch(type, event) {
+    const listeners = this._listeners[type];
+    if (!listeners) return;
+    // snapshot: a listener may remove another listener (or itself) mid-dispatch
+    [...listeners].forEach((fn) => fn(event));
+  }
+}
+
+let lastInstance;
+
+class StubXMLHttpRequest extends StubEventTarget {
+  constructor() {
+    super();
+    lastInstance = this;
     this.readyState = 0;
     this.status = 0;
     this.statusText = '';
@@ -19,6 +51,8 @@ class StubXMLHttpRequest {
     this.onerror = null;
     this.ontimeout = null;
     this.onreadystatechange = null;
+    this.upload = new StubEventTarget();
+    this.aborted = false;
   }
 
   open() {}
@@ -29,7 +63,20 @@ class StubXMLHttpRequest {
     return '';
   }
 
-  abort() {}
+  abort() {
+    this.aborted = true;
+  }
+
+  // Test-only helper: fires 'progress' then completes via onloadend,
+  // mirroring a real XHR's event order for a successful response.
+  respondWith({ status = 200, responseText = '' } = {}) {
+    this.readyState = 4;
+    this.status = status;
+    this.responseText = responseText;
+    this.response = responseText;
+    this.onreadystatechange && this.onreadystatechange();
+    this.onloadend && this.onloadend();
+  }
 
   send() {
     setTimeout(() => {
@@ -107,4 +154,111 @@ describe('xhr adapter status 0 handling', () => {
       expect(reason.code).toBe(axios.AxiosError.ECONNABORTED);
     }
   );
+});
+
+describe('xhr adapter progress listener cleanup', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetModules();
+    vi.useRealTimers();
+  });
+
+  it('should remove progress and upload listeners once the request completes', async () => {
+    const axios = await importAxiosForPage('http://localhost/index.html');
+    const responsePromise = axios.get('data.json', {
+      adapter: 'xhr',
+      onDownloadProgress: () => {},
+      onUploadProgress: () => {},
+    });
+    const request = lastInstance;
+
+    // listeners must be attached while the request is in flight
+    expect(request.listenerCount('progress')).toBe(1);
+    expect(request.upload.listenerCount('progress')).toBe(1);
+    expect(request.upload.listenerCount('loadend')).toBe(1);
+
+    request.respondWith({ status: 200, responseText: 'ok' });
+    await responsePromise;
+
+    expect(request.listenerCount('progress')).toBe(0);
+    expect(request.upload.listenerCount('progress')).toBe(0);
+    expect(request.upload.listenerCount('loadend')).toBe(0);
+  });
+
+  // flushDownload() is already invoked earlier inside onloadend's own
+  // try/catch (see the "final progress callback throws" handling above it),
+  // so it can't demonstrate this bug. flushUpload() is only ever called from
+  // inside done() itself, which is the actual path that needed guarding —
+  // these two tests drive upload progress specifically for that reason.
+
+  it('should still remove listeners when a queued final upload progress callback throws', async () => {
+    // fake timers park the intentionally-rethrown listener error so it can't fail the run
+    vi.useFakeTimers();
+    let calls = 0;
+    const axios = await importAxiosForPage('http://localhost/index.html');
+    const responsePromise = axios.post('data.json', 'body', {
+      adapter: 'xhr',
+      onUploadProgress: () => {
+        calls += 1;
+        // second delivery is the one flushed from inside done(); make that one throw
+        if (calls === 2) throw new Error('listener failure');
+      },
+    });
+    const request = lastInstance;
+
+    // first event: throttle has no prior timestamp, invokes immediately (calls -> 1)
+    request.upload.dispatch('progress', { loaded: 10, total: 100, lengthComputable: true });
+    // second event lands inside the throttle window, so it's queued (lastArgs)
+    // rather than invoked immediately — this is what done() will flush
+    request.upload.dispatch('progress', { loaded: 20, total: 100, lengthComputable: true });
+    expect(calls).toBe(1);
+
+    // completion reaches done() via settle()'s _resolve callback, which calls
+    // flushUpload() first — that's where the queued callback above throws
+    request.respondWith({ status: 200, responseText: 'ok' });
+
+    const response = await responsePromise;
+
+    expect(calls).toBe(2);
+    expect(response.status).toBe(200);
+    // cleanup (removeEventListener + signal/cancelToken teardown) must still
+    // have run after the throw, not been skipped by it
+    expect(request.upload.listenerCount('progress')).toBe(0);
+    expect(request.upload.listenerCount('loadend')).toBe(0);
+
+    // drain the asynchronously-rethrown error so it doesn't leak into another test
+    await expect(vi.runAllTimersAsync()).rejects.toThrow('listener failure');
+  });
+
+  it('should not throw when a queued final upload progress callback cancels the request synchronously', async () => {
+    const axios = await importAxiosForPage('http://localhost/index.html');
+    const controller = new AbortController();
+    let calls = 0;
+    const responsePromise = axios.post('data.json', 'body', {
+      adapter: 'xhr',
+      signal: controller.signal,
+      onUploadProgress: () => {
+        calls += 1;
+        // The first delivery invokes immediately (no throttle timestamp yet)
+        // and must NOT abort, or this never reaches the queued/reentrant path
+        // this test exists to cover. Only the second (queued, flushed-by-
+        // done()) delivery aborts.
+        if (calls === 2) controller.abort();
+      },
+    });
+    const request = lastInstance;
+
+    request.upload.dispatch('progress', { loaded: 10, total: 100, lengthComputable: true });
+    request.upload.dispatch('progress', { loaded: 20, total: 100, lengthComputable: true });
+    expect(calls).toBe(1); // confirms the second delivery really is queued, not immediate
+
+    // completion reaches done() via settle()'s _resolve callback, which calls
+    // flushUpload() first. That flush synchronously cancels the request
+    // (nulling the shared `request` variable) *before* done() reaches its own
+    // listener-removal lines — this must not throw a TypeError.
+    expect(() => request.respondWith({ status: 200, responseText: 'ok' })).not.toThrow();
+
+    const reason = await responsePromise.catch((error) => error);
+    expect(reason).toBeInstanceOf(axios.CanceledError);
+  });
 });


### PR DESCRIPTION
## Summary

The XHR adapter's `done()` cleanup function removes the `abort` listener on `_config.signal`, but never removes the three progress-related listeners registered via `addEventListener` (`progress` on the request, and `progress`/`loadend` on `request.upload`). Any request made with `onDownloadProgress` or `onUploadProgress` leaves these attached after completion, which is the root cause behind the long-standing "4 event listeners never cleaned up" reports (#5640, #5641, and related memory-leak issues going back to 2020). The only prior leak fix (#11091) addressed the Node `http.js` adapter's socket listener — this is the browser `xhr.js` counterpart, which has never been patched.

Re-submitting after closing #11224 — this includes the review fixes for the throwing-callback and reentrant-cancellation edge cases that were flagged there.

## Linked issue

Closes #5641

## Changes

- In `lib/adapters/xhr.js`, `done()` now explicitly removes `downloadThrottled` from the request's `progress` listener, and `uploadThrottled`/`flushUpload` from `request.upload`'s `progress`/`loadend` listeners, guarded so it's a no-op when progress callbacks weren't used or `request.upload` doesn't exist.

#### Checklist

- [ ] Tests added or updated — existing `tests/unit/adapters/xhr.test.js` suite passes unchanged (7/7), but I have not added a dedicated regression test or a before/after heap-snapshot repro yet. Will follow up with one before this is ready for review — flagging so maintainers can weigh in on whether that's required before merge.
- [x] Docs/types updated if public API changed — N/A, no public API change.
- [x] No breaking changes

:surfer:

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
## Description

The XHR adapter now removes progress and upload event listeners when a request completes, fixing the long-standing listener leak reported in #5640 and #5641. Previously, any request using `onDownloadProgress` or `onUploadProgress` left three listeners attached after completion, retaining the XHR and its closures in the browser's listener registry. `done()` now detaches them, guarded so it's a no-op when progress callbacks weren't used or `request.upload` doesn't exist.

The cleanup also survives two edge cases: a queued final progress callback that throws (the error is rethrown asynchronously via `setTimeout`) and a callback that synchronously cancels the request (reentrant `done()` nulls `request` before cleanup runs).

- Closes #5641.

## Docs

No documentation update needed — no public API change.

## Testing

Added tests in `tests/unit/adapters/xhr.test.js` covering listener removal after completion, cleanup when a flushed upload callback throws, and cleanup when a flushed callback aborts the request synchronously. The stub `StubXMLHttpRequest` now models `addEventListener`/`removeEventListener` to support listener counting.

## Semantic version impact

Patch — bug fix with no breaking changes and no public API change.

<sup>Written for commit aea209bbaf96a491d15d9667771c171d62c51eb2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/axios/axios/pull/11225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

