### PR TITLE
docs: fix interceptor test links

### DIFF
--- a/docs/es/pages/advanced/interceptors.md
+++ b/docs/es/pages/advanced/interceptors.md
@@ -183,5 +183,5 @@ Puedes añadir múltiples interceptores a la misma solicitud o respuesta. Lo sig
   - Una vez capturado, el siguiente interceptor de cumplimiento es llamado nuevamente (igual que en una cadena de promises).
 
 ::: tip
-Para obtener una comprensión profunda de cómo funcionan los interceptores, puedes leer los casos de prueba [aquí](https://github.com/axios/axios/blob/v1.x/test/specs/interceptors.spec.js).
+Para obtener una comprensión profunda de cómo funcionan los interceptores, puedes leer los casos de prueba [aquí](https://github.com/axios/axios/blob/v1.x/tests/browser/interceptors.browser.test.js).
 :::

--- a/docs/fr/pages/advanced/interceptors.md
+++ b/docs/fr/pages/advanced/interceptors.md
@@ -183,5 +183,5 @@ Vous pouvez ajouter plusieurs intercepteurs à la même requête ou réponse. Le
   - Une fois capturée, un autre intercepteur de réussite suivant est à nouveau appelé (comme dans une chaîne de promises).
 
 ::: tip
-Pour une compréhension approfondie du fonctionnement des intercepteurs, vous pouvez lire les cas de test disponibles [ici](https://github.com/axios/axios/blob/v1.x/test/specs/interceptors.spec.js).
+Pour une compréhension approfondie du fonctionnement des intercepteurs, vous pouvez lire les cas de test disponibles [ici](https://github.com/axios/axios/blob/v1.x/tests/browser/interceptors.browser.test.js).
 :::

--- a/docs/pages/advanced/interceptors.md
+++ b/docs/pages/advanced/interceptors.md
@@ -185,5 +185,5 @@ You may add multiple interceptors to the same request or response. The following
   - once caught, another following fulfil-interceptor is called again (just like in a promise chain).
 
 ::: tip
-To gain an in-depth understanding of how interceptors work, you can read the test cases over [here](https://github.com/axios/axios/blob/v1.x/test/specs/interceptors.spec.js).
+To gain an in-depth understanding of how interceptors work, you can read the test cases over [here](https://github.com/axios/axios/blob/v1.x/tests/browser/interceptors.browser.test.js).
 :::

--- a/docs/zh/pages/advanced/interceptors.md
+++ b/docs/zh/pages/advanced/interceptors.md
@@ -183,5 +183,5 @@ instance.interceptors.response.use(interceptor("Response Interceptor 3"));
   - 一旦被捕获，后续的成功回调拦截器将再次被调用（与 Promise 链的行为一致）
 
 ::: tip
-要深入了解拦截器的工作原理，可以查阅[这里](https://github.com/axios/axios/blob/v1.x/test/specs/interceptors.spec.js)的测试用例。
+要深入了解拦截器的工作原理，可以查阅[这里](https://github.com/axios/axios/blob/v1.x/tests/browser/interceptors.browser.test.js)的测试用例。
 :::


### PR DESCRIPTION
## Summary

Fix the stale interceptor test link in the English, Spanish, French, and Chinese documentation pages. Each page now points to the maintained browser interceptor test used by the v1.x branch.

## Linked issue

N/A — docs-only broken-link correction.

## Changes

- Replace four links from the removed `test/specs` path with `tests/browser/interceptors.browser.test.js`.

#### Checklist

- [x] Tests added or updated (N/A; documentation-only link correction)
- [x] Docs/types updated if public API changed (docs updated; no API change)
- [x] No breaking changes

:surfer:

AI-assisted; target resolution and the documentation build were verified locally.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
## Description

Fixes the stale interceptor test links in the English, Spanish, French, and Chinese docs pages. The old links pointed to the removed `test/specs/interceptors.spec.js` file and now point to the maintained browser interceptor test at `tests/browser/interceptors.browser.test.js` on the `v1.x` branch.

This is a docs-only correction; no API or runtime behavior changes.

## Docs

The affected docs pages are updated; no other documentation changes are needed.

## Testing

No tests added; docs-only link corrections don't require test updates.

## Semantic version impact

No semantic version impact because no package code changed. If a docs-only release is made, it would be a patch.

<sup>Written for commit 91c048e205b5e97c53c0e42cbf9c77c49b0f9b6c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/axios/axios/pull/11228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

