### PR TITLE
perf(form): avoid copying accumulated repeated field values

### DIFF
--- a/PRE_RELEASE_CHANGELOG.md
+++ b/PRE_RELEASE_CHANGELOG.md
@@ -21,6 +21,10 @@
 - **Request error stacks:** Preserved original request failures when custom `Error` stack instrumentation returns non-string data or throws during optional stack decoration. (**#11109**, closes **#11108**)
 - **Interceptor storage:** Removed trailing interceptor tombstones after ejection so repeated register-then-eject cycles no longer grow the handlers array, while preserving its public array shape, interceptor iteration behavior, and interceptor ID identity across registrations. (**#11070**)
 
+## Performance
+
+- **Repeated FormData fields:** Accumulate repeated values in place when converting FormData to JSON, avoiding repeated copies of the growing output array while preserving field order and file values.
+
 ## Documentation
 
 - **Global search:** Added localized, private, in-browser full-text search for the active documentation language, with fuzzy and prefix matching.

--- a/lib/helpers/formDataToJSON.js
+++ b/lib/helpers/formDataToJSON.js
@@ -86,9 +86,11 @@ function formDataToJSON(formData) {
 
     if (isLast) {
       if (utils.hasOwnProp(target, name)) {
-        target[name] = utils.isArray(target[name])
-          ? target[name].concat(value)
-          : [target[name], value];
+        if (utils.isArray(target[name])) {
+          target[name].push(value);
+        } else {
+          target[name] = [target[name], value];
+        }
       } else {
         target[name] = value;
       }

--- a/tests/unit/helpers/formDataToJSON.test.js
+++ b/tests/unit/helpers/formDataToJSON.test.js
@@ -54,6 +54,33 @@ describe('formDataToJSON', () => {
     });
   });
 
+  it('should preserve the order of many repeated nested fields', () => {
+    const formData = new FormData();
+    const values = Array.from({ length: 10000 }, (_, i) => String(i));
+
+    for (const value of values) {
+      formData.append('items[id]', value);
+    }
+
+    expect(formDataToJSON(formData)).toEqual({ items: { id: values } });
+  });
+
+  it('should preserve repeated file values and interleaved fields', () => {
+    const formData = new FormData();
+    const first = new File(['first'], 'first.txt');
+    const second = new File(['second'], 'second.txt');
+    formData.append('files', first);
+    formData.append('label', 'upload');
+    formData.append('files', second);
+    formData.append('files', 'last');
+
+    const result = formDataToJSON(formData);
+    expect(result.label).toBe('upload');
+    expect(result.files).toEqual([first, second, 'last']);
+    expect(result.files[0]).toBe(first);
+    expect(result.files[1]).toBe(second);
+  });
+
   it('should convert props with empty brackets to arrays', () => {
     const formData = new FormData();
 


### PR DESCRIPTION
## Summary

Converting repeated FormData fields to JSON copies the entire accumulated array for every value after the second. A multi-value field therefore takes quadratic copying work. Append to the array created by the converter instead; field order and File identities are preserved.

On macOS arm64 / Node.js 25.8.1, converting native FormData entries named `items[id]` gave these median times (3 warmups, 7 measured conversions; input construction and output assertions outside the timer):

| Repeated entries | Before | After |
| --- | ---: | ---: |
| 1,000 | 1.60 ms | 0.24 ms |
| 5,000 | 47.74 ms | 0.84 ms |
| 10,000 | 143.67 ms | 1.66 ms |

These are local measurements, not timing assertions in CI.

## Linked issue

Related to #10982's interest in FormData-to-JSON conversion cost. This change addresses repeated field values specifically.

## Changes

- Append repeated values in place, avoiding a new array allocation and copy per entry.
- Add coverage for 10,000 nested repeated values and interleaved string/File fields, including File identity.
- Add an unreleased performance note. No public API or documentation change is needed.

## Validation

- `npm run test:vitest:unit -- tests/unit/helpers/formDataToJSON.test.js tests/unit/toFormData.test.js tests/unit/core/transformData.test.js tests/unit/axios.test.js` — 56 tests passed, including existing prototype-pollution and nesting-limit regressions.
- Focused ESLint and Prettier checks passed.

Benchmark reproduction from the repository root:

```js
import assert from 'node:assert/strict';
import { performance } from 'node:perf_hooks';
import formDataToJSON from './lib/helpers/formDataToJSON.js';

for (const count of [1000, 5000, 10000]) {
  const form = new FormData();
  const values = Array.from({ length: count }, (_, i) => String(i));
  for (const value of values) form.append('items[id]', value);
  for (let i = 0; i < 3; i++) formDataToJSON(form);
  const times = [];
  for (let i = 0; i < 7; i++) {
    const start = performance.now();
    const result = formDataToJSON(form);
    times.push(performance.now() - start);
    assert.deepEqual(result, { items: { id: values } });
  }
  times.sort((a, b) => a - b);
  console.log({ count, median_ms: times[3] });
}
```

#### Checklist

- [x] Tests added or updated
- [x] Docs/types updated if public API changed (N/A: unchanged)
- [x] No breaking changes

:surfer: AI assistance: OpenAI Codex assisted with source analysis, implementation, tests, and the local benchmark.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
## **Description**

Converting repeated FormData fields to JSON no longer rebuilds the accumulated array with `concat` for every additional value; it appends in place, turning quadratic copying into linear work. Field order, nested structure, and `File` identity are unchanged.

- A local benchmark converting 10,000 repeated `items[id]` values dropped from ~144 ms to ~1.7 ms per conversion.

## **Docs**

No documentation update is needed; the public API and JSON output shape are unchanged.

## **Testing**

Added tests covering 10,000 repeated nested values and interleaved string/`File` fields, including `File` identity checks. Existing prototype-pollution and nesting-limit regression tests continue to pass.

## **Semantic version impact**

Patch release; the change is a performance improvement with no public API change.

<sup>Written for commit a8501f0ef0b1b25b1690ffb7ad69858947439386. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/axios/axios/pull/11229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

